### PR TITLE
Updating WordPressShared dependency

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,13 +42,13 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.0.4):
+  - WordPressKit (1.0.5):
     - AFNetworking (= 3.2.1)
     - Alamofire (= 4.7.2)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (= 1.0.3)
+    - WordPressShared (~> 1.0.3)
     - wpxmlrpc (= 0.8.3)
   - WordPressShared (1.0.3):
     - CocoaLumberjack (~> 3.4)
@@ -87,7 +87,7 @@ SPEC CHECKSUMS:
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: ac75c51b09fb78b6bda986b6f1c1841c9b2f910f
+  WordPressKit: 6f78fd4f36b8fc150f732c3fb156560d84b48460
   WordPressShared: b8e910d8133a54e9452ab7bd9d8e27e78dc2f5ba
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.dependency 'AFNetworking', '3.2.1'
   s.dependency 'Alamofire', '4.7.2'
   s.dependency 'CocoaLumberjack', '3.4.2'
-  s.dependency 'WordPressShared', '1.0.3'
+  s.dependency 'WordPressShared', '~> 1.0.3'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.3'
   s.dependency 'UIDeviceIdentifier', '~> 0.4'


### PR DESCRIPTION
Updating `WordPressShared` dependency so `WordPressKit` will work with the latest Shared pod version.