### PR TITLE
Removing AFNetworking - Part 1

### DIFF
--- a/WordPressKit/SiteManagementServiceRemote.swift
+++ b/WordPressKit/SiteManagementServiceRemote.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AFNetworking
 
 /// SiteManagementServiceRemote handles REST API calls for managing a WordPress.com site.
 ///

--- a/WordPressKit/UsersServiceRemoteXMLRPC.swift
+++ b/WordPressKit/UsersServiceRemoteXMLRPC.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AFNetworking
 
 public enum UsersServiceRemoteError: Int, Error {
     case UnexpectedResponseData


### PR DESCRIPTION
This PR simple removes some non needed imports and updates the Gravatar Service to use vanilla NSURLSession.

To test:
 - Check the code compile
 - Run some unit tests
 - Try to import this pod version on the main app and see if the Gravatar code works.