### PR TITLE
Add ReaderSiteSearchServiceRemote and tests

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		17BF9A6C20C7DC3300BF57D2 /* reader-site-search-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */; };
+		17BF9A7220C7E18200BF57D2 /* reader-site-search-success-hasmore.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A6D20C7E18100BF57D2 /* reader-site-search-success-hasmore.json */; };
+		17BF9A7320C7E18200BF57D2 /* reader-site-search-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A6E20C7E18200BF57D2 /* reader-site-search-failure.json */; };
+		17BF9A7520C7E18200BF57D2 /* reader-site-search-success-no-icon.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A7020C7E18200BF57D2 /* reader-site-search-success-no-icon.json */; };
+		17BF9A7620C7E18200BF57D2 /* reader-site-search-success-no-data.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A7120C7E18200BF57D2 /* reader-site-search-success-no-data.json */; };
+		17CD0CC320C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CD0CC220C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift */; };
+		17CE77F120C6EB41001DEA5A /* ReaderFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77F020C6EB41001DEA5A /* ReaderFeed.swift */; };
+		17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */; };
 		240315B0A1D6C2B981572B5B /* Pods_WordPressKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED05C8FF3E61D93CE5BA527E /* Pods_WordPressKitTests.framework */; };
 		40AB1ADA200FED25009B533D /* PluginDirectoryFeedPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40AB1AD9200FED25009B533D /* PluginDirectoryFeedPage.swift */; };
 		40E4698B2017C2840030DB5F /* plugin-directory-popular.json in Resources */ = {isa = PBXBuildFile; fileRef = 40E4698A2017C2840030DB5F /* plugin-directory-popular.json */; };
@@ -400,6 +408,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-site-search-success.json"; sourceTree = "<group>"; };
+		17BF9A6D20C7E18100BF57D2 /* reader-site-search-success-hasmore.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-success-hasmore.json"; sourceTree = "<group>"; };
+		17BF9A6E20C7E18200BF57D2 /* reader-site-search-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-failure.json"; sourceTree = "<group>"; };
+		17BF9A7020C7E18200BF57D2 /* reader-site-search-success-no-icon.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-success-no-icon.json"; sourceTree = "<group>"; };
+		17BF9A7120C7E18200BF57D2 /* reader-site-search-success-no-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-success-no-data.json"; sourceTree = "<group>"; };
+		17CD0CC220C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchServiceRemote.swift; sourceTree = "<group>"; };
+		17CE77F020C6EB41001DEA5A /* ReaderFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFeed.swift; sourceTree = "<group>"; };
+		17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchServiceRemoteTests.swift; sourceTree = "<group>"; };
 		264F5C834541BBF2018F4964 /* Pods-WordPressKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		40AB1AD9200FED25009B533D /* PluginDirectoryFeedPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginDirectoryFeedPage.swift; sourceTree = "<group>"; };
 		40E4698A2017C2840030DB5F /* plugin-directory-popular.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "plugin-directory-popular.json"; sourceTree = "<group>"; };
@@ -846,6 +862,7 @@
 				7430C9B91F192C0F0051B8E6 /* ReaderSiteServiceRemoteTests.swift */,
 				7430C9BA1F192C0F0051B8E6 /* ReaderPostServiceRemoteTests.m */,
 				7430C9BB1F192C0F0051B8E6 /* ReaderTopicServiceRemoteTests.m */,
+				17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */,
 			);
 			name = Reader;
 			sourceTree = "<group>";
@@ -1141,6 +1158,7 @@
 				9368C7A11EC62F800092CE8E /* WPStatsServiceRemote.h */,
 				9368C7A21EC62F800092CE8E /* WPStatsServiceRemote.m */,
 				E182BF691FD961810001D850 /* Endpoint.swift */,
+				17CD0CC220C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -1210,6 +1228,7 @@
 				93BD27681EE736A8002BB00B /* RemoteUser.m */,
 				E1D6B555200E46F200325669 /* WPTimeZone.swift */,
 				E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */,
+				17CE77F020C6EB41001DEA5A /* ReaderFeed.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -1394,6 +1413,11 @@
 				740B23DE1F17FB4200067A2A /* xmlrpc-wp-getpost-bad-xml-failure.xml */,
 				740B23DF1F17FB4200067A2A /* xmlrpc-wp-getpost-invalid-id-failure.xml */,
 				740B23E01F17FB4200067A2A /* xmlrpc-wp-getpost-success.xml */,
+				17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */,
+				17BF9A6E20C7E18200BF57D2 /* reader-site-search-failure.json */,
+				17BF9A6D20C7E18100BF57D2 /* reader-site-search-success-hasmore.json */,
+				17BF9A7120C7E18200BF57D2 /* reader-site-search-success-no-data.json */,
+				17BF9A7020C7E18200BF57D2 /* reader-site-search-success-no-icon.json */,
 			);
 			path = "Mock Data";
 			sourceTree = "<group>";
@@ -1694,6 +1718,7 @@
 				74D67F1F1F15C3240010C5ED /* people-send-invitation-success.json in Resources */,
 				93BD27561EE73442002BB00B /* auth-send-login-email-invalid-secret-failure.json in Resources */,
 				93BD275A1EE73442002BB00B /* is-available-email-success.json in Resources */,
+				17BF9A6C20C7DC3300BF57D2 /* reader-site-search-success.json in Resources */,
 				74D67F141F15C2D70010C5ED /* site-roles-bad-json-failure.json in Resources */,
 				40E4698B2017C2840030DB5F /* plugin-directory-popular.json in Resources */,
 				93AC8ED01ED32FD000900F5A /* stats-v1.1-post-details.json in Resources */,
@@ -1732,6 +1757,7 @@
 				829BA4301FACF187003ADEEA /* activity-rewind-status-restore-failure.json in Resources */,
 				74D67F391F15C3740010C5ED /* site-viewers-delete-bad-json.json in Resources */,
 				93BD27631EE73442002BB00B /* me-sites-visibility-bad-json-failure.json in Resources */,
+				17BF9A7220C7E18200BF57D2 /* reader-site-search-success-hasmore.json in Resources */,
 				7433BC131EFC45C7002D9E92 /* site-plans-bad-json-failure.json in Resources */,
 				74B335DE1F06F5A50053A184 /* WordPressComRestApiFailInvalidJSON.json in Resources */,
 				74D67F3B1F15C3740010C5ED /* site-viewers-delete-success.json in Resources */,
@@ -1744,6 +1770,7 @@
 				74D67F151F15C2D70010C5ED /* site-roles-success.json in Resources */,
 				740B23E11F17FB4200067A2A /* xmlrpc-metaweblog-editpost-bad-xml-failure.xml in Resources */,
 				93AC8ED51ED32FD000900F5A /* stats-v1.1-tags-categories-views-day.json in Resources */,
+				17BF9A7520C7E18200BF57D2 /* reader-site-search-success-no-icon.json in Resources */,
 				828A2402201B6B8A004F6859 /* activity-rewind-status-restore-in-progress.json in Resources */,
 				74D67F131F15C2D70010C5ED /* site-roles-auth-failure.json in Resources */,
 				74B040721EF8B366002C6258 /* rest-site-settings.json in Resources */,
@@ -1762,6 +1789,7 @@
 				93AC8EC41ED32FD000900F5A /* emptyarray.json in Resources */,
 				93AC8EDD1ED32FD000900F5A /* stats-v1.1-visits-day.json in Resources */,
 				93AC8EDC1ED32FD000900F5A /* stats-v1.1-visits-day-large.json in Resources */,
+				17BF9A7620C7E18200BF57D2 /* reader-site-search-success-no-data.json in Resources */,
 				74585B9F1F0D6E7500E7E667 /* domain-service-bad-json.json in Resources */,
 				74D67F301F15C3740010C5ED /* site-followers-delete-bad-json-failure.json in Resources */,
 				E1E89C661FD6B291006E7A33 /* plugin-directory-rename-xml-rpc.json in Resources */,
@@ -1796,6 +1824,7 @@
 				74D67F321F15C3740010C5ED /* site-followers-delete-success.json in Resources */,
 				93F50A481F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml in Resources */,
 				93BD27601EE73442002BB00B /* me-sites-bad-json-failure.json in Resources */,
+				17BF9A7320C7E18200BF57D2 /* reader-site-search-failure.json in Resources */,
 				93AC8ECF1ED32FD000900F5A /* stats-v1.1-latest-post.json in Resources */,
 				93BD275D1EE73442002BB00B /* me-auth-failure.json in Resources */,
 				74D67F361F15C3740010C5ED /* site-users-delete-site-owner-failure.json in Resources */,
@@ -1958,6 +1987,7 @@
 				9368C7B81EC630270092CE8E /* StatsStreakItem.m in Sources */,
 				74BA04F61F06DC0A00ED5CD8 /* CommentServiceRemoteXMLRPC.m in Sources */,
 				7430C9A81F1927180051B8E6 /* ReaderTopicServiceRemote.m in Sources */,
+				17CE77F120C6EB41001DEA5A /* ReaderFeed.swift in Sources */,
 				93C674F21EE8351E00BFAF05 /* NSMutableDictionary+Helpers.m in Sources */,
 				74D67F061F1528470010C5ED /* PeopleServiceRemote.swift in Sources */,
 				740B23C31F17EE8000067A2A /* RemotePostCategory.m in Sources */,
@@ -1990,6 +2020,7 @@
 				9FCDD09720A5EF75004F0BF7 /* ReaderTopicServiceError.swift in Sources */,
 				74A44DD11F13C64B006CD8F4 /* RemoteNotificationSettings.swift in Sources */,
 				74DA56331F06EAF000FE9BF4 /* MediaServiceRemoteREST.m in Sources */,
+				17CD0CC320C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift in Sources */,
 				74DA563B1F06EB3000FE9BF4 /* RemoteMedia.m in Sources */,
 				9311A6861F22625A00704AC9 /* RemoteTaxonomyPaging.m in Sources */,
 				93BD27821EE73944002BB00B /* WordPressOrgXMLRPCValidator.swift in Sources */,
@@ -2045,6 +2076,7 @@
 				930999521F1658F800F006A1 /* ThemeServiceRemoteTests.m in Sources */,
 				74B335DA1F06F3D60053A184 /* WordPressComRestApiTests.swift in Sources */,
 				7403A2E61EF06F7000DED7DC /* AccountSettingsRemoteTests.swift in Sources */,
+				17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */,
 				93AC8EE11ED32FD000900F5A /* StatsStringUtilitiesTest.m in Sources */,
 				74C473AF1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift in Sources */,
 				74A44DD51F13C6D8006CD8F4 /* PushAuthenticationServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/ReaderFeed.swift
+++ b/WordPressKit/ReaderFeed.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// ReaderFeed
+/// Encapsulates details of a single feed returned by the Reader feed search API
+/// (read/feed?q=query)
+///
+public struct ReaderFeed: Decodable {
+    public let url: URL
+    public let title: String
+    public let feedDescription: String?
+    public let feedID: String
+    public let blavatarURL: URL?
+
+    private enum CodingKeys: String, CodingKey {
+        case url = "URL"
+        case title = "title"
+        case feedID = "feed_ID"
+        case meta = "meta"
+    }
+
+    private enum MetaKeys: CodingKey {
+        case data
+    }
+
+    private enum DataKeys: CodingKey {
+        case site
+    }
+
+    private enum SiteKeys: CodingKey {
+        case description
+        case icon
+    }
+
+    private enum IconKeys: CodingKey {
+        case img
+    }
+
+    public init(from decoder: Decoder) throws {
+        // We have to manually decode the feed from the JSON, for a couple of reasons:
+        // - Some feeds have no `icon` dictionary
+        // - Some feeds have no `data` dictionary
+        // - We want to decode whatever we can get, and not fail if neither of those exist
+
+        let rootContainer = try decoder.container(keyedBy: CodingKeys.self)
+
+        url = try rootContainer.decode(URL.self, forKey: .url)
+        title = try rootContainer.decode(String.self, forKey: .title)
+        feedID = try rootContainer.decode(String.self, forKey: .feedID)
+
+        var feedDescription: String? = nil
+        var blavatarURL: URL? = nil
+
+        do {
+            let metaContainer = try rootContainer.nestedContainer(keyedBy: MetaKeys.self, forKey: .meta)
+            let dataContainer = try metaContainer.nestedContainer(keyedBy: DataKeys.self, forKey: .data)
+            let siteContainer = try dataContainer.nestedContainer(keyedBy: SiteKeys.self, forKey: .site)
+            feedDescription = try? siteContainer.decode(String.self, forKey: .description)
+
+            let iconContainer = try siteContainer.nestedContainer(keyedBy: IconKeys.self, forKey: .icon)
+            blavatarURL = try? iconContainer.decode(URL.self, forKey: .img)
+        } catch {
+        }
+
+        self.feedDescription = feedDescription
+        self.blavatarURL = blavatarURL
+    }
+}
+
+extension ReaderFeed: CustomStringConvertible {
+    public var description: String {
+        return "<Feed | URL: \(url), title: \(title), feedID: \(feedID)>"
+    }
+}

--- a/WordPressKit/ReaderSiteSearchServiceRemote.swift
+++ b/WordPressKit/ReaderSiteSearchServiceRemote.swift
@@ -19,10 +19,10 @@ public class ReaderSiteSearchServiceRemote: ServiceRemoteWordPressComREST {
     ///     - failure: Closure to be executed on error.
     ///
     public func performSearch(_ query: String,
-                                   offset: Int = 0,
-                                   count: Int,
-                                   success: @escaping (_ results: [ReaderFeed], _ hasMore: Bool, _ feedCount: Int) -> Void,
-                                   failure: @escaping (Error) -> Void) {
+                              offset: Int = 0,
+                              count: Int,
+                              success: @escaping (_ results: [ReaderFeed], _ hasMore: Bool, _ feedCount: Int) -> Void,
+                              failure: @escaping (Error) -> Void) {
         let endpoint = "read/feed"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let locale = WordPressComLanguageDatabase().deviceLanguage.slug

--- a/WordPressKit/ReaderSiteSearchServiceRemote.swift
+++ b/WordPressKit/ReaderSiteSearchServiceRemote.swift
@@ -1,0 +1,84 @@
+import Foundation
+import WordPressShared
+
+public class ReaderSiteSearchServiceRemote: ServiceRemoteWordPressComREST {
+
+    public enum ResponseError: Error {
+        case decodingFailure
+    }
+
+    /// Searches Reader for sites matching the specified query.
+    ///
+    /// - Parameters:
+    ///     - query: A search string to match
+    ///     - offset: The first N results to skip when returning results.
+    ///     - count: Number of objects to retrieve.
+    ///     - success: Closure to be executed on success. Is passed an array of
+    ///                ReaderFeeds, a boolean indicating if there's more results
+    ///                to fetch, and a total feed count.
+    ///     - failure: Closure to be executed on error.
+    ///
+    public func performSearch(_ query: String,
+                                   offset: Int = 0,
+                                   count: Int,
+                                   success: @escaping (_ results: [ReaderFeed], _ hasMore: Bool, _ feedCount: Int) -> Void,
+                                   failure: @escaping (Error) -> Void) {
+        let endpoint = "read/feed"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
+        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
+        let parameters: [String: AnyObject] = [
+            "locale": locale as AnyObject,
+            "number": count as AnyObject,
+            "offset": offset as AnyObject,
+            "exclude_followed": false as AnyObject,
+            "sort": "relevance" as AnyObject,
+            "meta": "site" as AnyObject,
+            "q": query as AnyObject
+        ]
+
+        wordPressComRestApi.GET(path,
+                                parameters: parameters,
+                                success: { response, _ in
+                                    do {
+                                        let (results, total) = try self.mapSearchResponse(response)
+                                        let hasMore = total > (offset + count)
+                                        success(results, hasMore, total)
+                                    } catch {
+                                        failure(error)
+                                    }
+        }, failure: { error, _ in
+            DDLogError("\(error)")
+            failure(error)
+        })
+    }
+}
+
+private extension ReaderSiteSearchServiceRemote {
+
+    func mapSearchResponse(_ response: AnyObject) throws -> ([ReaderFeed], Int) {
+        do {
+            let decoder = JSONDecoder()
+            let data = try JSONSerialization.data(withJSONObject: response, options: [])
+            let envelope = try decoder.decode(ReaderFeedEnvelope.self, from: data)
+            return (envelope.feeds, envelope.total)
+        } catch {
+            DDLogError("\(error)")
+            DDLogDebug("Full response: \(response)")
+            throw ReaderSiteSearchServiceRemote.ResponseError.decodingFailure
+        }
+    }
+}
+
+/// ReaderFeedEnvelope
+/// The Reader feed search endpoint returns feeds in a key named `feeds` key.
+/// This entity allows us to do parse that and the total feed count using JSONDecoder.
+///
+private struct ReaderFeedEnvelope: Decodable {
+    let feeds: [ReaderFeed]
+    let total: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case feeds = "feeds"
+        case total = "total"
+    }
+}

--- a/WordPressKitTests/Mock Data/reader-site-search-failure.json
+++ b/WordPressKitTests/Mock Data/reader-site-search-failure.json
@@ -1,0 +1,193 @@
+{
+  "feeds": [
+    {
+      "URL": "https://dailypost.wordpress.com",
+      "subscribe_URL": "http://dailypost.wordpress.com",
+      "blog_ID": "489937",
+      "title": "The Daily Post",
+      "railcar": {
+        "railcar": "*dPbMa8*fdh#",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 489937,
+        "fetch_lang": "en",
+        "fetch_query": "dailypost.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/27030",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937"
+        },
+        "data": {
+          "site": {
+            "ID": 489937,
+            "name": "The Daily Post",
+            "description": "The Art and Craft of Blogging",
+            "URL": "https://dailypost.wordpress.com",
+            "jetpack": false,
+            "subscribers_count": 36055068,
+            "lang": false,
+            "icon": {
+              "img": "https://secure.gravatar.com/blavatar/7eb290aaccb7d769c6a84369a0a83f3d",
+              "ico": "https://secure.gravatar.com/blavatar/7eb290aaccb7d769c6a84369a0a83f3d"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": null,
+            "is_private": false,
+            "is_following": false,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/489937/comments/",
+                "xmlrpc": "https://dailypost.wordpress.com/xmlrpc.php"
+              }
+            },
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 27030,
+            "feed_URL": "http://dailypost.wordpress.com",
+            "header_image": false,
+            "owner": {
+              "ID": 26957695,
+              "login": "a8cuser",
+              "name": "Automattic",
+              "first_name": "Automattic",
+              "last_name": "",
+              "nice_name": "a8cuser",
+              "URL": "",
+              "avatar_URL": "https://1.gravatar.com/avatar/a64c4a50f3f38f02cd27a9bfb3f11b62?s=96&d=identicon&r=G",
+              "profile_URL": "https://en.gravatar.com/a8cuser",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false
+          }
+        }
+      },
+      "subscribers_count": 37418087
+    },
+    {
+      "URL": "https://discover.wordpress.com",
+      "subscribe_URL": "http://discover.wordpress.com",
+      "blog_ID": "53424024",
+      "title": "Discover",
+      "railcar": {
+        "railcar": "Ulg!Pst)TwI2",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 53424024,
+        "fetch_lang": "en",
+        "fetch_query": "discover.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/41325786",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024"
+        },
+        "data": {
+          "site": {
+            "ID": 53424024,
+            "name": "Discover",
+            "description": "A daily selection of the best content published on WordPress, collected for you by humans who love to read.",
+            "URL": "https://discover.wordpress.com",
+            "jetpack": false,
+            "subscribers_count": 23332327,
+            "lang": false,
+            "icon": {
+              "img": "https://secure.gravatar.com/blavatar/c9e4e04719c81ca4936a63ea2dce6ace",
+              "ico": "https://secure.gravatar.com/blavatar/c9e4e04719c81ca4936a63ea2dce6ace"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": null,
+            "is_private": false,
+            "is_following": false,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/53424024/comments/",
+                "xmlrpc": "https://discover.wordpress.com/xmlrpc.php",
+                "featured": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/featured"
+              }
+            },
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 41325786,
+            "feed_URL": "http://discover.wordpress.com",
+            "header_image": false,
+            "owner": {
+              "ID": 26957695,
+              "login": "a8cuser",
+              "name": "Automattic",
+              "first_name": "Automattic",
+              "last_name": "",
+              "nice_name": "a8cuser",
+              "URL": "",
+              "avatar_URL": "https://1.gravatar.com/avatar/a64c4a50f3f38f02cd27a9bfb3f11b62?s=96&d=identicon&r=G",
+              "profile_URL": "https://en.gravatar.com/a8cuser",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false
+          }
+        }
+      },
+      "feed_ID": "41325786",
+      "subscribers_count": 24623045
+    }
+  ],
+  "total": 2,
+  "algorithm": "reader/manage/search:0",
+  "next_page": "offset=10&algorithm=reader/manage/search:0"
+}

--- a/WordPressKitTests/Mock Data/reader-site-search-success-hasmore.json
+++ b/WordPressKitTests/Mock Data/reader-site-search-success-hasmore.json
@@ -1,0 +1,194 @@
+{
+  "feeds": [
+    {
+      "URL": "https://dailypost.wordpress.com",
+      "subscribe_URL": "http://dailypost.wordpress.com",
+      "blog_ID": "489937",
+      "title": "The Daily Post",
+      "railcar": {
+        "railcar": "*dPbMa8*fdh#",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 489937,
+        "fetch_lang": "en",
+        "fetch_query": "dailypost.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/27030",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937"
+        },
+        "data": {
+          "site": {
+            "ID": 489937,
+            "name": "The Daily Post",
+            "description": "The Art and Craft of Blogging",
+            "URL": "https://dailypost.wordpress.com",
+            "jetpack": false,
+            "subscribers_count": 36055068,
+            "lang": false,
+            "icon": {
+              "img": "https://secure.gravatar.com/blavatar/7eb290aaccb7d769c6a84369a0a83f3d",
+              "ico": "https://secure.gravatar.com/blavatar/7eb290aaccb7d769c6a84369a0a83f3d"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": null,
+            "is_private": false,
+            "is_following": false,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/489937/comments/",
+                "xmlrpc": "https://dailypost.wordpress.com/xmlrpc.php"
+              }
+            },
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 27030,
+            "feed_URL": "http://dailypost.wordpress.com",
+            "header_image": false,
+            "owner": {
+              "ID": 26957695,
+              "login": "a8cuser",
+              "name": "Automattic",
+              "first_name": "Automattic",
+              "last_name": "",
+              "nice_name": "a8cuser",
+              "URL": "",
+              "avatar_URL": "https://1.gravatar.com/avatar/a64c4a50f3f38f02cd27a9bfb3f11b62?s=96&d=identicon&r=G",
+              "profile_URL": "https://en.gravatar.com/a8cuser",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false
+          }
+        }
+      },
+      "feed_ID": "27030",
+      "subscribers_count": 37418087
+    },
+    {
+      "URL": "https://discover.wordpress.com",
+      "subscribe_URL": "http://discover.wordpress.com",
+      "blog_ID": "53424024",
+      "title": "Discover",
+      "railcar": {
+        "railcar": "Ulg!Pst)TwI2",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 53424024,
+        "fetch_lang": "en",
+        "fetch_query": "discover.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/41325786",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024"
+        },
+        "data": {
+          "site": {
+            "ID": 53424024,
+            "name": "Discover",
+            "description": "A daily selection of the best content published on WordPress, collected for you by humans who love to read.",
+            "URL": "https://discover.wordpress.com",
+            "jetpack": false,
+            "subscribers_count": 23332327,
+            "lang": false,
+            "icon": {
+              "img": "https://secure.gravatar.com/blavatar/c9e4e04719c81ca4936a63ea2dce6ace",
+              "ico": "https://secure.gravatar.com/blavatar/c9e4e04719c81ca4936a63ea2dce6ace"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": null,
+            "is_private": false,
+            "is_following": false,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/53424024/comments/",
+                "xmlrpc": "https://discover.wordpress.com/xmlrpc.php",
+                "featured": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/featured"
+              }
+            },
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 41325786,
+            "feed_URL": "http://discover.wordpress.com",
+            "header_image": false,
+            "owner": {
+              "ID": 26957695,
+              "login": "a8cuser",
+              "name": "Automattic",
+              "first_name": "Automattic",
+              "last_name": "",
+              "nice_name": "a8cuser",
+              "URL": "",
+              "avatar_URL": "https://1.gravatar.com/avatar/a64c4a50f3f38f02cd27a9bfb3f11b62?s=96&d=identicon&r=G",
+              "profile_URL": "https://en.gravatar.com/a8cuser",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false
+          }
+        }
+      },
+      "feed_ID": "41325786",
+      "subscribers_count": 24623045
+    }
+  ],
+  "total": 3,
+  "algorithm": "reader/manage/search:0",
+  "next_page": "offset=10&algorithm=reader/manage/search:0"
+}

--- a/WordPressKitTests/Mock Data/reader-site-search-success-no-data.json
+++ b/WordPressKitTests/Mock Data/reader-site-search-success-no-data.json
@@ -1,0 +1,29 @@
+{
+  "feeds": [
+    {
+      "URL": "https://dailypost.wordpress.com",
+      "subscribe_URL": "http://dailypost.wordpress.com",
+      "blog_ID": "489937",
+      "title": "The Daily Post",
+      "railcar": {
+        "railcar": "*dPbMa8*fdh#",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 489937,
+        "fetch_lang": "en",
+        "fetch_query": "dailypost.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/27030",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937"
+        }
+      },
+      "feed_ID": "27030",
+      "subscribers_count": 37418087
+    }
+  ],
+  "total": 1,
+  "algorithm": "reader/manage/search:0",
+  "next_page": "offset=10&algorithm=reader/manage/search:0"
+}

--- a/WordPressKitTests/Mock Data/reader-site-search-success-no-icon.json
+++ b/WordPressKitTests/Mock Data/reader-site-search-success-no-icon.json
@@ -1,0 +1,96 @@
+{
+  "feeds": [
+    {
+      "URL": "https://dailypost.wordpress.com",
+      "subscribe_URL": "http://dailypost.wordpress.com",
+      "blog_ID": "489937",
+      "title": "The Daily Post",
+      "railcar": {
+        "railcar": "*dPbMa8*fdh#",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 489937,
+        "fetch_lang": "en",
+        "fetch_query": "dailypost.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/27030",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937"
+        },
+        "data": {
+          "site": {
+            "ID": 489937,
+            "name": "The Daily Post",
+            "description": "The Art and Craft of Blogging",
+            "URL": "https://dailypost.wordpress.com",
+            "jetpack": false,
+            "subscribers_count": 36055068,
+            "lang": false,
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": null,
+            "is_private": false,
+            "is_following": false,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/489937/comments/",
+                "xmlrpc": "https://dailypost.wordpress.com/xmlrpc.php"
+              }
+            },
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 27030,
+            "feed_URL": "http://dailypost.wordpress.com",
+            "header_image": false,
+            "owner": {
+              "ID": 26957695,
+              "login": "a8cuser",
+              "name": "Automattic",
+              "first_name": "Automattic",
+              "last_name": "",
+              "nice_name": "a8cuser",
+              "URL": "",
+              "avatar_URL": "https://1.gravatar.com/avatar/a64c4a50f3f38f02cd27a9bfb3f11b62?s=96&d=identicon&r=G",
+              "profile_URL": "https://en.gravatar.com/a8cuser",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false
+          }
+        }
+      },
+      "feed_ID": "27030",
+      "subscribers_count": 37418087
+    }
+  ],
+  "total": 1,
+  "algorithm": "reader/manage/search:0",
+  "next_page": "offset=10&algorithm=reader/manage/search:0"
+}

--- a/WordPressKitTests/Mock Data/reader-site-search-success.json
+++ b/WordPressKitTests/Mock Data/reader-site-search-success.json
@@ -1,0 +1,194 @@
+{
+  "feeds": [
+    {
+      "URL": "https://dailypost.wordpress.com",
+      "subscribe_URL": "http://dailypost.wordpress.com",
+      "blog_ID": "489937",
+      "title": "The Daily Post",
+      "railcar": {
+        "railcar": "*dPbMa8*fdh#",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 489937,
+        "fetch_lang": "en",
+        "fetch_query": "dailypost.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/27030",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937"
+        },
+        "data": {
+          "site": {
+            "ID": 489937,
+            "name": "The Daily Post",
+            "description": "The Art and Craft of Blogging",
+            "URL": "https://dailypost.wordpress.com",
+            "jetpack": false,
+            "subscribers_count": 36055068,
+            "lang": false,
+            "icon": {
+              "img": "https://secure.gravatar.com/blavatar/7eb290aaccb7d769c6a84369a0a83f3d",
+              "ico": "https://secure.gravatar.com/blavatar/7eb290aaccb7d769c6a84369a0a83f3d"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": null,
+            "is_private": false,
+            "is_following": false,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/489937/comments/",
+                "xmlrpc": "https://dailypost.wordpress.com/xmlrpc.php"
+              }
+            },
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 27030,
+            "feed_URL": "http://dailypost.wordpress.com",
+            "header_image": false,
+            "owner": {
+              "ID": 26957695,
+              "login": "a8cuser",
+              "name": "Automattic",
+              "first_name": "Automattic",
+              "last_name": "",
+              "nice_name": "a8cuser",
+              "URL": "",
+              "avatar_URL": "https://1.gravatar.com/avatar/a64c4a50f3f38f02cd27a9bfb3f11b62?s=96&d=identicon&r=G",
+              "profile_URL": "https://en.gravatar.com/a8cuser",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false
+          }
+        }
+      },
+      "feed_ID": "27030",
+      "subscribers_count": 37418087
+    },
+    {
+      "URL": "https://discover.wordpress.com",
+      "subscribe_URL": "http://discover.wordpress.com",
+      "blog_ID": "53424024",
+      "title": "Discover",
+      "railcar": {
+        "railcar": "Ulg!Pst)TwI2",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 53424024,
+        "fetch_lang": "en",
+        "fetch_query": "discover.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/41325786",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024"
+        },
+        "data": {
+          "site": {
+            "ID": 53424024,
+            "name": "Discover",
+            "description": "A daily selection of the best content published on WordPress, collected for you by humans who love to read.",
+            "URL": "https://discover.wordpress.com",
+            "jetpack": false,
+            "subscribers_count": 23332327,
+            "lang": false,
+            "icon": {
+              "img": "https://secure.gravatar.com/blavatar/c9e4e04719c81ca4936a63ea2dce6ace",
+              "ico": "https://secure.gravatar.com/blavatar/c9e4e04719c81ca4936a63ea2dce6ace"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": null,
+            "is_private": false,
+            "is_following": false,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/53424024/comments/",
+                "xmlrpc": "https://discover.wordpress.com/xmlrpc.php",
+                "featured": "https://public-api.wordpress.com/rest/v1.1/read/sites/53424024/featured"
+              }
+            },
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 41325786,
+            "feed_URL": "http://discover.wordpress.com",
+            "header_image": false,
+            "owner": {
+              "ID": 26957695,
+              "login": "a8cuser",
+              "name": "Automattic",
+              "first_name": "Automattic",
+              "last_name": "",
+              "nice_name": "a8cuser",
+              "URL": "",
+              "avatar_URL": "https://1.gravatar.com/avatar/a64c4a50f3f38f02cd27a9bfb3f11b62?s=96&d=identicon&r=G",
+              "profile_URL": "https://en.gravatar.com/a8cuser",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false
+          }
+        }
+      },
+      "feed_ID": "41325786",
+      "subscribers_count": 24623045
+    }
+  ],
+  "total": 2,
+  "algorithm": "reader/manage/search:0",
+  "next_page": "offset=10&algorithm=reader/manage/search:0"
+}

--- a/WordPressKitTests/ReaderSiteSearchServiceRemoteTests.swift
+++ b/WordPressKitTests/ReaderSiteSearchServiceRemoteTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import XCTest
+@testable import WordPressKit
+
+class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
+
+    /// MARK: - Constants
+
+    let performSearchSuccessFilename = "reader-site-search-success.json"
+    let performSearchSuccessNoIconFilename = "reader-site-search-success-no-icon.json"
+    let performSearchSuccessNoDataFilename = "reader-site-search-success-no-data.json"
+    let performSearchSuccessHasMoreFilename = "reader-site-search-success-hasmore.json"
+    let performSearchFailureFilename = "reader-site-search-failure.json"
+
+    /// MARK: - Properties
+
+    var performSearchEndpoint: String { return "read/feed" }
+
+    var remote: ReaderSiteSearchServiceRemote!
+
+    /// MARK: - Overridden Methods
+
+    override func setUp() {
+        super.setUp()
+
+        remote = ReaderSiteSearchServiceRemote(wordPressComRestApi: getRestApi())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        remote = nil
+    }
+
+    /// MARK: - Perform Search Tests
+
+    func testPerformSearchSuccessfully() {
+        let expect = expectation(description: "Perform Reader site search successfully")
+
+        stubRemoteResponse(performSearchEndpoint, filename: performSearchSuccessFilename, contentType: .ApplicationJSON)
+        remote.performSearch("discover",
+                             count: 10, success: { (feeds, hasMore, totalFeeds) in
+                                XCTAssertEqual(feeds.count, 2, "The feed count should be 2")
+                                XCTAssertEqual(totalFeeds, 2, "The total feed count should be 2")
+                                XCTAssertFalse(hasMore, "The value of hasMore should be false")
+                                expect.fulfill()
+        }, failure: { error in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testPerformSearchWhenResultsHaveNoIcon() {
+        let expect = expectation(description: "Perform Reader site search when a result has no icon image value")
+
+        stubRemoteResponse(performSearchEndpoint, filename: performSearchSuccessNoIconFilename, contentType: .ApplicationJSON)
+        remote.performSearch("discover",
+                             count: 10, success: { (feeds, hasMore, totalFeeds) in
+                                XCTAssertEqual(feeds.count, 1, "The feed count should be 1")
+                                XCTAssertEqual(totalFeeds, 1, "The total feed count should be 1")
+                                XCTAssertFalse(hasMore, "The value of hasMore should be false")
+
+                                guard let feed = feeds.first else {
+                                    XCTFail("A feed should be parsed from the JSON")
+                                    expect.fulfill()
+                                    return
+                                }
+
+                                XCTAssertEqual(feed.title, "The Daily Post")
+                                XCTAssertEqual(feed.feedID, "27030")
+                                XCTAssertEqual(feed.url, URL(string: "https://dailypost.wordpress.com")!)
+                                XCTAssertEqual(feed.feedDescription, "The Art and Craft of Blogging")
+                                XCTAssertNil(feed.blavatarURL)
+
+                                expect.fulfill()
+        }, failure: { error in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testPerformSearchWhenResultsHaveNoData() {
+        let expect = expectation(description: "Perform Reader site search when a result has no data dictionary")
+
+        stubRemoteResponse(performSearchEndpoint, filename: performSearchSuccessNoDataFilename, contentType: .ApplicationJSON)
+        remote.performSearch("discover",
+                             count: 10, success: { (feeds, hasMore, totalFeeds) in
+                                XCTAssertEqual(feeds.count, 1, "The feed count should be 1")
+                                XCTAssertEqual(totalFeeds, 1, "The total feed count should be 1")
+                                XCTAssertFalse(hasMore, "The value of hasMore should be false")
+
+                                guard let feed = feeds.first else {
+                                    XCTFail("A feed should be parsed from the JSON")
+                                    expect.fulfill()
+                                    return
+                                }
+
+                                XCTAssertEqual(feed.title, "The Daily Post")
+                                XCTAssertEqual(feed.feedID, "27030")
+                                XCTAssertEqual(feed.url, URL(string: "https://dailypost.wordpress.com")!)
+                                XCTAssertNil(feed.blavatarURL)
+                                XCTAssertNil(feed.feedDescription)
+
+                                expect.fulfill()
+
+        }, failure: { error in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testPerformSearchHasMoreResults() {
+        let expect = expectation(description: "Perform Reader site search successfully and reports hasMore correctly")
+
+        stubRemoteResponse(performSearchEndpoint, filename: performSearchSuccessHasMoreFilename, contentType: .ApplicationJSON)
+        remote.performSearch("discover",
+                             count: 2, success: { (feeds, hasMore, totalFeeds) in
+                                XCTAssertEqual(feeds.count, 2, "The feed count should be 2")
+                                XCTAssertEqual(totalFeeds, 3, "The total feed count should be 3")
+                                XCTAssertTrue(hasMore, "The value of hasMore should be true")
+                                expect.fulfill()
+        }, failure: { error in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testPerformSearchHasMoreResultsEqualCount() {
+        let expect = expectation(description: "Perform Reader site search successfully and reports hasMore correctly when the page size equals the feed count")
+
+        stubRemoteResponse(performSearchEndpoint, filename: performSearchSuccessFilename, contentType: .ApplicationJSON)
+        remote.performSearch("discover",
+                             count: 2, success: { (feeds, hasMore, totalFeeds) in
+                                XCTAssertEqual(feeds.count, 2, "The feed count should be 2")
+                                XCTAssertEqual(totalFeeds, 2, "The total feed count should be 2")
+                                XCTAssertFalse(hasMore, "The value of hasMore should be false")
+                                expect.fulfill()
+        }, failure: { error in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testPerformSearchFailure() {
+        let expect = expectation(description: "Perform Reader site search fails if no feed ID is present")
+
+        stubRemoteResponse(performSearchEndpoint, filename: performSearchFailureFilename, contentType: .ApplicationJSON)
+        remote.performSearch("discover",
+                             count: 10, success: { (_, _, _) in
+                                XCTFail("This callback shouldn't get called")
+                                expect.fulfill()
+        }, failure: { error in
+            typealias ResponseError = ReaderSiteSearchServiceRemote.ResponseError
+            guard case ResponseError.decodingFailure? = error as? ResponseError else {
+                XCTFail("Expected a decodingFailure error")
+                expect.fulfill()
+                return
+            }
+
+            expect.fulfill()
+        })
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+}


### PR DESCRIPTION
This PR looks big, but most of it is mock data!

This PR adds a new remote: `ReaderSiteSearchServiceRemote`, which I'll use to fetch a list of possible Reader sites for a user to follow: https://github.com/wordpress-mobile/WordPress-iOS/issues/9433. The remote has a single method to perform a search, and returns the results.

Results should include a feed ID, a title, and a URL. They may also include an optional blavatar URL and description.

Equivalent Android PR: https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/822

**To test:**

* Check the code
* Build and run tests, and check everything passes
* Let me know if you'd like to actually try it out with WPiOS and I can push up a work in progress branch there that uses this remote.