### PR TITLE
ReaderTopicService: Fix version of `read/feed` endpoint

### DIFF
--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -206,7 +206,7 @@ static NSString * const DeliveryMethodNotificationKey = @"notification";
     if (isFeed) {
         NSString *path = [NSString stringWithFormat:@"read/feed/%@", siteID];
         requestUrl = [self pathForEndpoint:path
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     } else {
         NSString *path = [NSString stringWithFormat:@"read/sites/%@", siteID];
         requestUrl = [self pathForEndpoint:path


### PR DESCRIPTION
In [this commit](https://github.com/wordpress-mobile/WordPressKit-iOS/commit/81ae84a25dd36f7f807e46fe2cfe2790aef68a23#diff-95fdd695cd6c24b82abbc507abd85fe3), the version of the `read/feed` endpoint was changed from 1.1 to 1.2. However, version 1.2 doesn't exist, and returns a 404. This PR reverts that change.

**To test:**

The easiest way to trigger this codepath to test is to modify `viewControllerForTopic(_:)` in `ReaderMenuViewController` in WPiOS. Change it to:

```
return ReaderStreamViewController.controllerWithSiteID(20787116, isFeed: true)
```

You'll also need to update your Podfile to point at this branch:

```
pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/reader-site-topic-version'
```

Then run the app, go to the Reader, and tap Discover. It should load the "Daring Fireball" feed and show you a list of posts. Without the change in this PR, the web request will return a 404 and you won't see any posts.