### PR TITLE
Remove AFNetworking part 4: remove AFNetworking from JetpackServiceRemote

### DIFF
--- a/WordPressKit/JetpackServiceRemote.h
+++ b/WordPressKit/JetpackServiceRemote.h
@@ -1,28 +1,7 @@
 #import <Foundation/Foundation.h>
 #import "ServiceRemoteWordPressComREST.h"
 
-/**
- * Error returned as the domain to NSError from JetpackServiceRemote.
- */
-//extern NSString * const JetpackServiceRemoteErrorDomain;
-
-/**
- * Possible NSError codes for BlogJetpackErrorDomain.
- */
-//typedef NS_ENUM(NSInteger, JetpackServiceRemoteErrorCode) {
-//    // The user doesn't have access to that specific blog
-//    JetpackServiceRemoteErrorNoRecordForBlog,
-//    // The provided username/password are invalid
-//    JetpackServiceRemoteErrorInvalidCredentials,
-//};
-
 @interface JetpackServiceRemote : ServiceRemoteWordPressComREST
-
-//- (void)validateJetpackUsername:(NSString *)username
-//                       password:(NSString *)password
-//                      forSiteID:(NSNumber *)siteID
-//                        success:(void (^)(NSArray *blogIDs))success
-//                        failure:(void (^)(NSError *error))failure;
 
 - (void)checkSiteHasJetpack:(NSURL *)siteURL
                     success:(void (^)(BOOL hasJetpack))success

--- a/WordPressKit/JetpackServiceRemote.h
+++ b/WordPressKit/JetpackServiceRemote.h
@@ -4,25 +4,25 @@
 /**
  * Error returned as the domain to NSError from JetpackServiceRemote.
  */
-extern NSString * const JetpackServiceRemoteErrorDomain;
+//extern NSString * const JetpackServiceRemoteErrorDomain;
 
 /**
  * Possible NSError codes for BlogJetpackErrorDomain.
  */
-typedef NS_ENUM(NSInteger, JetpackServiceRemoteErrorCode) {
-    // The user doesn't have access to that specific blog
-    JetpackServiceRemoteErrorNoRecordForBlog,
-    // The provided username/password are invalid
-    JetpackServiceRemoteErrorInvalidCredentials,
-};
+//typedef NS_ENUM(NSInteger, JetpackServiceRemoteErrorCode) {
+//    // The user doesn't have access to that specific blog
+//    JetpackServiceRemoteErrorNoRecordForBlog,
+//    // The provided username/password are invalid
+//    JetpackServiceRemoteErrorInvalidCredentials,
+//};
 
 @interface JetpackServiceRemote : ServiceRemoteWordPressComREST
 
-- (void)validateJetpackUsername:(NSString *)username
-                       password:(NSString *)password
-                      forSiteID:(NSNumber *)siteID
-                        success:(void (^)(NSArray *blogIDs))success
-                        failure:(void (^)(NSError *error))failure;
+//- (void)validateJetpackUsername:(NSString *)username
+//                       password:(NSString *)password
+//                      forSiteID:(NSNumber *)siteID
+//                        success:(void (^)(NSArray *blogIDs))success
+//                        failure:(void (^)(NSError *error))failure;
 
 - (void)checkSiteHasJetpack:(NSURL *)siteURL
                     success:(void (^)(BOOL hasJetpack))success

--- a/WordPressKit/JetpackServiceRemote.m
+++ b/WordPressKit/JetpackServiceRemote.m
@@ -1,6 +1,5 @@
 #import "JetpackServiceRemote.h"
 
-#import <AFNetworking/AFNetworking.h>
 #import <WordPressKit/WordPressKit-Swift.h>
 #import "WPKitLoggingPrivate.h"
 @import CocoaLumberjack;
@@ -11,57 +10,57 @@ static NSString * const GetUsersBlogsApiPath = @"https://public-api.wordpress.co
 
 @implementation JetpackServiceRemote
 
-- (void)validateJetpackUsername:(NSString *)username
-                       password:(NSString *)password
-                      forSiteID:(NSNumber *)siteID
-                        success:(void (^)(NSArray *blogIDs))success
-                        failure:(void (^)(NSError *error))failure
-{
-    AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
-    [manager.requestSerializer setAuthorizationHeaderFieldWithUsername:username password:password];
-    NSDictionary *parameters = @{
-                                 @"f": @"json"
-                                 };
-    
-    [manager GET:GetUsersBlogsApiPath
-      parameters:parameters
-        progress:nil
-         success:^(NSURLSessionDataTask *task, id responseObject) {
-             NSArray *blogs = [responseObject arrayForKeyPath:@"userinfo.blog"];
-             DDLogInfo(@"Available wp.com/jetpack sites for %@: %@", username, blogs);
-             NSArray *foundBlogs = [blogs filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"id = %@", siteID]];
-             if (foundBlogs.count > 0) {
-                 DDLogInfo(@"Found blog: %@", foundBlogs);
-                 NSArray *blogIDs = [blogs valueForKey:@"id"];
-                 if (success) {
-                     success(blogIDs);
-                 }
-             } else {
-                 if (failure) {
-                     NSError *error = [NSError errorWithDomain:JetpackServiceRemoteErrorDomain
-                                                          code:JetpackServiceRemoteErrorNoRecordForBlog
-                                                      userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"This site is not connected to that WordPress.com username", @"")}];
-                     DDLogError(@"Error validating Jetpack user: %@", error);
-                     failure(error);
-                 }
-             }
-         } failure:^(NSURLSessionDataTask *task, NSError *error) {
-             DDLogError(@"Error validating Jetpack user: %@", error);
-             if (failure) {
-                 NSError *jetpackError = error;
-                 NSHTTPURLResponse *httpResponse = nil;
-                 if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {
-                     httpResponse = (NSHTTPURLResponse *)task.response;
-                 }
-                 if (httpResponse && httpResponse.statusCode == 401) {
-                     jetpackError = [NSError errorWithDomain:JetpackServiceRemoteErrorDomain
-                                                        code:JetpackServiceRemoteErrorInvalidCredentials
-                                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid username or password", @""), NSUnderlyingErrorKey: error}];
-                 }
-                 failure(jetpackError);
-             }
-         }];
-}
+//- (void)validateJetpackUsername:(NSString *)username
+//                       password:(NSString *)password
+//                      forSiteID:(NSNumber *)siteID
+//                        success:(void (^)(NSArray *blogIDs))success
+//                        failure:(void (^)(NSError *error))failure
+//{
+//    AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
+//    [manager.requestSerializer setAuthorizationHeaderFieldWithUsername:username password:password];
+//    NSDictionary *parameters = @{
+//                                 @"f": @"json"
+//                                 };
+//    
+//    [manager GET:GetUsersBlogsApiPath
+//      parameters:parameters
+//        progress:nil
+//         success:^(NSURLSessionDataTask *task, id responseObject) {
+//             NSArray *blogs = [responseObject arrayForKeyPath:@"userinfo.blog"];
+//             DDLogInfo(@"Available wp.com/jetpack sites for %@: %@", username, blogs);
+//             NSArray *foundBlogs = [blogs filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"id = %@", siteID]];
+//             if (foundBlogs.count > 0) {
+//                 DDLogInfo(@"Found blog: %@", foundBlogs);
+//                 NSArray *blogIDs = [blogs valueForKey:@"id"];
+//                 if (success) {
+//                     success(blogIDs);
+//                 }
+//             } else {
+//                 if (failure) {
+//                     NSError *error = [NSError errorWithDomain:JetpackServiceRemoteErrorDomain
+//                                                          code:JetpackServiceRemoteErrorNoRecordForBlog
+//                                                      userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"This site is not connected to that WordPress.com username", @"")}];
+//                     DDLogError(@"Error validating Jetpack user: %@", error);
+//                     failure(error);
+//                 }
+//             }
+//         } failure:^(NSURLSessionDataTask *task, NSError *error) {
+//             DDLogError(@"Error validating Jetpack user: %@", error);
+//             if (failure) {
+//                 NSError *jetpackError = error;
+//                 NSHTTPURLResponse *httpResponse = nil;
+//                 if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {
+//                     httpResponse = (NSHTTPURLResponse *)task.response;
+//                 }
+//                 if (httpResponse && httpResponse.statusCode == 401) {
+//                     jetpackError = [NSError errorWithDomain:JetpackServiceRemoteErrorDomain
+//                                                        code:JetpackServiceRemoteErrorInvalidCredentials
+//                                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid username or password", @""), NSUnderlyingErrorKey: error}];
+//                 }
+//                 failure(jetpackError);
+//             }
+//         }];
+//}
 
 /**
     Check if the specified site is a Jetpack site.  The success block

--- a/WordPressKit/JetpackServiceRemote.m
+++ b/WordPressKit/JetpackServiceRemote.m
@@ -5,62 +5,7 @@
 @import CocoaLumberjack;
 @import NSObject_SafeExpectations;
 
-NSString * const JetpackServiceRemoteErrorDomain = @"JetpackServiceRemoteError";
-static NSString * const GetUsersBlogsApiPath = @"https://public-api.wordpress.com/get-user-blogs/1.0";
-
 @implementation JetpackServiceRemote
-
-//- (void)validateJetpackUsername:(NSString *)username
-//                       password:(NSString *)password
-//                      forSiteID:(NSNumber *)siteID
-//                        success:(void (^)(NSArray *blogIDs))success
-//                        failure:(void (^)(NSError *error))failure
-//{
-//    AFHTTPSessionManager *manager = [AFHTTPSessionManager manager];
-//    [manager.requestSerializer setAuthorizationHeaderFieldWithUsername:username password:password];
-//    NSDictionary *parameters = @{
-//                                 @"f": @"json"
-//                                 };
-//    
-//    [manager GET:GetUsersBlogsApiPath
-//      parameters:parameters
-//        progress:nil
-//         success:^(NSURLSessionDataTask *task, id responseObject) {
-//             NSArray *blogs = [responseObject arrayForKeyPath:@"userinfo.blog"];
-//             DDLogInfo(@"Available wp.com/jetpack sites for %@: %@", username, blogs);
-//             NSArray *foundBlogs = [blogs filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"id = %@", siteID]];
-//             if (foundBlogs.count > 0) {
-//                 DDLogInfo(@"Found blog: %@", foundBlogs);
-//                 NSArray *blogIDs = [blogs valueForKey:@"id"];
-//                 if (success) {
-//                     success(blogIDs);
-//                 }
-//             } else {
-//                 if (failure) {
-//                     NSError *error = [NSError errorWithDomain:JetpackServiceRemoteErrorDomain
-//                                                          code:JetpackServiceRemoteErrorNoRecordForBlog
-//                                                      userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"This site is not connected to that WordPress.com username", @"")}];
-//                     DDLogError(@"Error validating Jetpack user: %@", error);
-//                     failure(error);
-//                 }
-//             }
-//         } failure:^(NSURLSessionDataTask *task, NSError *error) {
-//             DDLogError(@"Error validating Jetpack user: %@", error);
-//             if (failure) {
-//                 NSError *jetpackError = error;
-//                 NSHTTPURLResponse *httpResponse = nil;
-//                 if ([task.response isKindOfClass:[NSHTTPURLResponse class]]) {
-//                     httpResponse = (NSHTTPURLResponse *)task.response;
-//                 }
-//                 if (httpResponse && httpResponse.statusCode == 401) {
-//                     jetpackError = [NSError errorWithDomain:JetpackServiceRemoteErrorDomain
-//                                                        code:JetpackServiceRemoteErrorInvalidCredentials
-//                                                    userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Invalid username or password", @""), NSUnderlyingErrorKey: error}];
-//                 }
-//                 failure(jetpackError);
-//             }
-//         }];
-//}
 
 /**
     Check if the specified site is a Jetpack site.  The success block


### PR DESCRIPTION
Refs #4 

On this PR we are simple removing the method that uses AFNetworking because we are no longer using it.

How to test:
 - Make sure unit tests are running
 - Test the compilation on the main app using the branch of this [PR on the main repo](https://github.com/wordpress-mobile/WordPress-iOS/pull/9523).