### PR TITLE
ReaderFeed: Parse blog ID if available

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		170589D520C9923500774C6F /* reader-site-search-blog-id-fallback.json in Resources */ = {isa = PBXBuildFile; fileRef = 170589D320C9923500774C6F /* reader-site-search-blog-id-fallback.json */; };
+		170589D620C9923500774C6F /* reader-site-search-no-blog-or-feed-id.json in Resources */ = {isa = PBXBuildFile; fileRef = 170589D420C9923500774C6F /* reader-site-search-no-blog-or-feed-id.json */; };
 		17BF9A6C20C7DC3300BF57D2 /* reader-site-search-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */; };
 		17BF9A7220C7E18200BF57D2 /* reader-site-search-success-hasmore.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A6D20C7E18100BF57D2 /* reader-site-search-success-hasmore.json */; };
 		17BF9A7320C7E18200BF57D2 /* reader-site-search-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A6E20C7E18200BF57D2 /* reader-site-search-failure.json */; };
@@ -408,6 +410,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		170589D320C9923500774C6F /* reader-site-search-blog-id-fallback.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-blog-id-fallback.json"; sourceTree = "<group>"; };
+		170589D420C9923500774C6F /* reader-site-search-no-blog-or-feed-id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-no-blog-or-feed-id.json"; sourceTree = "<group>"; };
 		17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-site-search-success.json"; sourceTree = "<group>"; };
 		17BF9A6D20C7E18100BF57D2 /* reader-site-search-success-hasmore.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-success-hasmore.json"; sourceTree = "<group>"; };
 		17BF9A6E20C7E18200BF57D2 /* reader-site-search-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-failure.json"; sourceTree = "<group>"; };
@@ -1418,6 +1422,8 @@
 				17BF9A6D20C7E18100BF57D2 /* reader-site-search-success-hasmore.json */,
 				17BF9A7120C7E18200BF57D2 /* reader-site-search-success-no-data.json */,
 				17BF9A7020C7E18200BF57D2 /* reader-site-search-success-no-icon.json */,
+				170589D320C9923500774C6F /* reader-site-search-blog-id-fallback.json */,
+				170589D420C9923500774C6F /* reader-site-search-no-blog-or-feed-id.json */,
 			);
 			path = "Mock Data";
 			sourceTree = "<group>";
@@ -1723,6 +1729,7 @@
 				40E4698B2017C2840030DB5F /* plugin-directory-popular.json in Resources */,
 				93AC8ED01ED32FD000900F5A /* stats-v1.1-post-details.json in Resources */,
 				74C473B91EF325F6009918F2 /* site-delete-missing-status-failure.json in Resources */,
+				170589D620C9923500774C6F /* reader-site-search-no-blog-or-feed-id.json in Resources */,
 				7403A2FD1EF06FEB00DED7DC /* me-settings-change-primary-site-success.json in Resources */,
 				93AC8ED41ED32FD000900F5A /* stats-v1.1-summary.json in Resources */,
 				74C473B71EF3229B009918F2 /* site-delete-unexpected-json-failure.json in Resources */,
@@ -1784,6 +1791,7 @@
 				7403A3001EF06FEB00DED7DC /* me-settings-success.json in Resources */,
 				74B335EA1F06F76B0053A184 /* xmlrpc-response-getpost.xml in Resources */,
 				740B23E91F17FB4200067A2A /* xmlrpc-wp-getpost-invalid-id-failure.xml in Resources */,
+				170589D520C9923500774C6F /* reader-site-search-blog-id-fallback.json in Resources */,
 				93AC8EC81ED32FD000900F5A /* stats-v1.1-clicks-month-large.json in Resources */,
 				930999561F16598A00F006A1 /* get-multiple-themes-v1.2.json in Resources */,
 				93AC8EC41ED32FD000900F5A /* emptyarray.json in Resources */,

--- a/WordPressKit/ReaderFeed.swift
+++ b/WordPressKit/ReaderFeed.swift
@@ -8,13 +8,15 @@ public struct ReaderFeed: Decodable {
     public let url: URL
     public let title: String
     public let feedDescription: String?
-    public let feedID: String
+    public let feedID: String?
+    public let blogID: String?
     public let blavatarURL: URL?
 
     private enum CodingKeys: String, CodingKey {
         case url = "URL"
         case title = "title"
         case feedID = "feed_ID"
+        case blogID = "blog_ID"
         case meta = "meta"
     }
 
@@ -40,12 +42,12 @@ public struct ReaderFeed: Decodable {
         // - Some feeds have no `icon` dictionary
         // - Some feeds have no `data` dictionary
         // - We want to decode whatever we can get, and not fail if neither of those exist
-
         let rootContainer = try decoder.container(keyedBy: CodingKeys.self)
 
         url = try rootContainer.decode(URL.self, forKey: .url)
         title = try rootContainer.decode(String.self, forKey: .title)
-        feedID = try rootContainer.decode(String.self, forKey: .feedID)
+        feedID = try? rootContainer.decode(String.self, forKey: .feedID)
+        blogID = try? rootContainer.decode(String.self, forKey: .blogID)
 
         var feedDescription: String? = nil
         var blavatarURL: URL? = nil
@@ -68,6 +70,6 @@ public struct ReaderFeed: Decodable {
 
 extension ReaderFeed: CustomStringConvertible {
     public var description: String {
-        return "<Feed | URL: \(url), title: \(title), feedID: \(feedID)>"
+        return "<Feed | URL: \(url), title: \(title), feedID: \(feedID), blogID: \(blogID)>"
     }
 }

--- a/WordPressKit/ReaderSiteSearchServiceRemote.swift
+++ b/WordPressKit/ReaderSiteSearchServiceRemote.swift
@@ -60,7 +60,10 @@ private extension ReaderSiteSearchServiceRemote {
             let decoder = JSONDecoder()
             let data = try JSONSerialization.data(withJSONObject: response, options: [])
             let envelope = try decoder.decode(ReaderFeedEnvelope.self, from: data)
-            return (envelope.feeds, envelope.total)
+
+            // Filter out any feeds that don't have either a feed ID or a blog ID
+            let feeds = envelope.feeds.filter({ $0.feedID != nil || $0.blogID != nil })
+            return (feeds, envelope.total)
         } catch {
             DDLogError("\(error)")
             DDLogDebug("Full response: \(response)")

--- a/WordPressKitTests/Mock Data/reader-site-search-blog-id-fallback.json
+++ b/WordPressKitTests/Mock Data/reader-site-search-blog-id-fallback.json
@@ -1,0 +1,99 @@
+{
+  "feeds": [
+    {
+      "URL": "https://dailypost.wordpress.com",
+      "subscribe_URL": "http://dailypost.wordpress.com",
+      "blog_ID": "489937",
+      "title": "The Daily Post",
+      "railcar": {
+        "railcar": "*dPbMa8*fdh#",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 489937,
+        "fetch_lang": "en",
+        "fetch_query": "dailypost.wordpress.com"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/27030",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937"
+        },
+        "data": {
+          "site": {
+            "ID": 489937,
+            "name": "The Daily Post",
+            "description": "The Art and Craft of Blogging",
+            "URL": "https://dailypost.wordpress.com",
+            "jetpack": false,
+            "subscribers_count": 36055068,
+            "lang": false,
+            "icon": {
+              "img": "https://secure.gravatar.com/blavatar/7eb290aaccb7d769c6a84369a0a83f3d",
+              "ico": "https://secure.gravatar.com/blavatar/7eb290aaccb7d769c6a84369a0a83f3d"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": null,
+            "is_private": false,
+            "is_following": false,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/489937/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/489937/comments/",
+                "xmlrpc": "https://dailypost.wordpress.com/xmlrpc.php"
+              }
+            },
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 27030,
+            "feed_URL": "http://dailypost.wordpress.com",
+            "header_image": false,
+            "owner": {
+              "ID": 26957695,
+              "login": "a8cuser",
+              "name": "Automattic",
+              "first_name": "Automattic",
+              "last_name": "",
+              "nice_name": "a8cuser",
+              "URL": "",
+              "avatar_URL": "https://1.gravatar.com/avatar/a64c4a50f3f38f02cd27a9bfb3f11b62?s=96&d=identicon&r=G",
+              "profile_URL": "https://en.gravatar.com/a8cuser",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false
+          }
+        }
+      },
+      "subscribers_count": 37418087
+    }
+  ],
+  "total": 1,
+  "algorithm": "reader/manage/search:0",
+  "next_page": "offset=10&algorithm=reader/manage/search:0"
+}

--- a/WordPressKitTests/Mock Data/reader-site-search-no-blog-or-feed-id.json
+++ b/WordPressKitTests/Mock Data/reader-site-search-no-blog-or-feed-id.json
@@ -1,8 +1,8 @@
 {
   "feeds": [
     {
+      "URL": "https://dailypost.wordpress.com",
       "subscribe_URL": "http://dailypost.wordpress.com",
-      "blog_ID": "489937",
       "title": "The Daily Post",
       "railcar": {
         "railcar": "*dPbMa8*fdh#",


### PR DESCRIPTION
Following on from the recent addition of `ReaderSiteSearchServiceRemote`: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/7

It turns out that not all feeds returned by the endpoint have a `feed_ID` value, and we were parsing that as a required property. I've made a few tweaks so that now:

* If feed ID doesn't exist, we can try and use blog ID instead
* If neither exist, we remove the feed from the list of results

I've also updated the unit tests to handle this.

**To test:**

* Build and run the tests, check they pass.
* Check out branch `issue/9433-reader-site-search` of WPiOS.
* Go to Reader > Search, and search for `macos 10.13.5`. You should see an error in the console:

```
2018-06-07 18:18:37:155 WordPress[50072:6170454] Error while performing Reader site search: decodingFailure
```
* Update the Podfile to point to this branch:

```
pod WordPressKit, :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'fix/reader-feed-parsing'
```
* Perform the same search as before. You should see one result in the Sites tab, and no error in the console.

@jleandroperez Sorry, would you mind one more?