### PR TITLE
Fix Xcode 10 warnings.

### DIFF
--- a/WordPressKit/HTTPAuthenticationAlertController.swift
+++ b/WordPressKit/HTTPAuthenticationAlertController.swift
@@ -9,7 +9,7 @@ open class HTTPAuthenticationAlertController {
 
     fileprivate static var onGoingChallenges = [URLProtectionSpace: [AuthenticationHandler]]()
 
-    static open func controller(for challenge: URLAuthenticationChallenge, handler: @escaping AuthenticationHandler) -> UIAlertController? {
+    static public func controller(for challenge: URLAuthenticationChallenge, handler: @escaping AuthenticationHandler) -> UIAlertController? {
         if var handlers = onGoingChallenges[challenge.protectionSpace] {
             handlers.append(handler)
             onGoingChallenges[challenge.protectionSpace] = handlers

--- a/WordPressKit/RemoteNotificationSettings.swift
+++ b/WordPressKit/RemoteNotificationSettings.swift
@@ -14,11 +14,11 @@ import Foundation
 open class RemoteNotificationSettings {
     /// Represents the Channel to which the current settings are associated.
     ///
-    open let channel: Channel
+    public let channel: Channel
 
     /// Contains an array of the available Notification Streams.
     ///
-    open let streams: [Stream]
+    public let streams: [Stream]
 
 
 
@@ -158,7 +158,7 @@ open class RemoteNotificationSettings {
     ///
     /// - Returns: An array of RemoteNotificationSettings objects
     ///
-    open static func fromDictionary(_ dictionary: NSDictionary?) -> [RemoteNotificationSettings] {
+    public static func fromDictionary(_ dictionary: NSDictionary?) -> [RemoteNotificationSettings] {
         var parsed = [RemoteNotificationSettings]()
 
         if let rawBlogs = dictionary?["blogs"] as? [NSDictionary] {

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -24,21 +24,21 @@ import Alamofire
 }
 
 open class WordPressComRestApi: NSObject {    
-    @objc open static let ErrorKeyErrorCode: String = "WordPressComRestApiErrorCodeKey"
-    @objc open static let ErrorKeyErrorMessage: String = "WordPressComRestApiErrorMessageKey"
-    @objc open static let SessionTaskKey: String = "WordPressComRestAPI.sessionTask"
+    @objc public static let ErrorKeyErrorCode: String = "WordPressComRestApiErrorCodeKey"
+    @objc public static let ErrorKeyErrorMessage: String = "WordPressComRestApiErrorMessageKey"
+    @objc public static let SessionTaskKey: String = "WordPressComRestAPI.sessionTask"
 
     public typealias RequestEnqueuedBlock = (_ taskID : NSNumber) -> Void
     public typealias SuccessResponseBlock = (_ responseObject: AnyObject, _ httpResponse: HTTPURLResponse?) -> ()
     public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> ()
 
-    @objc open static let apiBaseURLString: String = "https://public-api.wordpress.com/"
+    @objc public static let apiBaseURLString: String = "https://public-api.wordpress.com/"
     
-    @objc open static let defaultBackgroundSessionIdentifier = "org.wordpress.wpcomrestapi"
+    @objc public static let defaultBackgroundSessionIdentifier = "org.wordpress.wpcomrestapi"
     
-    @objc open let backgroundSessionIdentifier: String
+    @objc public let backgroundSessionIdentifier: String
 
-    @objc open let sharedContainerIdentifier: String?
+    @objc public let sharedContainerIdentifier: String?
     
     fileprivate let backgroundUploads: Bool
 

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -11,7 +11,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     fileprivate let userAgent: String?
     fileprivate var backgroundUploads: Bool
     fileprivate var backgroundSessionIdentifier: String
-    @objc open static let defaultBackgroundSessionIdentifier = "org.wordpress.wporgxmlrpcapi"
+    @objc public static let defaultBackgroundSessionIdentifier = "org.wordpress.wporgxmlrpcapi"
 
     /// onChallenge's Callback Closure Signature. Host Apps should call this method, whenever a proper AuthChallengeDisposition has been
     /// picked up (optionally with URLCredentials!).
@@ -20,12 +20,12 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
     /// Closure to be executed whenever we receive a URLSession Authentication Challenge.
     ///
-    open static var onChallenge: ((URLAuthenticationChallenge, @escaping AuthenticationHandler) -> Void)?
+    public static var onChallenge: ((URLAuthenticationChallenge, @escaping AuthenticationHandler) -> Void)?
 
 
     /// Minimum WordPress.org Supported Version.
     ///
-    @objc open static let minimumSupportedVersion = "4.0"
+    @objc public static let minimumSupportedVersion = "4.0"
 
 
     fileprivate lazy var sessionManager: Alamofire.SessionManager = {
@@ -288,9 +288,9 @@ open class WordPressOrgXMLRPCApi: NSObject {
         return responseXML as AnyObject
     }
 
-    @objc open static let WordPressOrgXMLRPCApiErrorKeyData: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyData"
-    @objc open static let WordPressOrgXMLRPCApiErrorKeyDataString: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyDataString"
-    @objc open static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
+    @objc public static let WordPressOrgXMLRPCApiErrorKeyData: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyData"
+    @objc public static let WordPressOrgXMLRPCApiErrorKeyDataString: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyDataString"
+    @objc public static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
 
     fileprivate func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
         if let data = data {

--- a/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -38,7 +38,7 @@ import CocoaLumberjack
 /// WordPress XMLRPC sites.
 open class WordPressOrgXMLRPCValidator: NSObject {
 
-    @objc open static let UserInfoHasJetpackKey = "UserInfoHasJetpackKey"
+    @objc public static let UserInfoHasJetpackKey = "UserInfoHasJetpackKey"
 
     // The documentation for NSURLErrorHTTPTooManyRedirects says that 16
     // is the default threshold for allowable redirects.


### PR DESCRIPTION
This gets rid of warnings about conflicting accessiblity specifiers in Xcode 10 ("Static implies final, use public instead").

