### PR TITLE
Improve `Activity` API.

### DIFF
--- a/WordPressKit/Activity.swift
+++ b/WordPressKit/Activity.swift
@@ -127,10 +127,6 @@ public class Activity {
         return self.name == ActivityName.fullBackup
     }()
 
-    public lazy var publishedDateUTCWithoutTime: String = {
-        return self.published.longUTCStringWithoutTime()
-    }()
-
     public lazy var isRewindable: Bool = {
         return rewindID != nil && rewindable
     }()

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -128,8 +128,15 @@ private extension ActivityServiceRemote {
     func mapActivitiesResponse(_ response: AnyObject) throws -> ([Activity], Int) {
 
         guard let json = response as? [String: AnyObject],
-            let totalItems = json["totalItems"] as? Int,
-            let current = json["current"] as? [String: AnyObject],
+            let totalItems = json["totalItems"] as? Int else {
+                throw ActivityServiceRemote.ResponseError.decodingFailure
+        }
+
+        guard totalItems > 0 else {
+            return ([], 0)
+        }
+
+        guard let current = json["current"] as? [String: AnyObject],
             let orderedItems = current["orderedItems"] as? [[String: AnyObject]] else {
                 throw ActivityServiceRemote.ResponseError.decodingFailure
         }


### PR DESCRIPTION
This does two things: 
* removes an unused (and very easily misused) property on `Activity`
* improves handling of situations where API returns 0 `Activities` (currently only true for WPCom free sites which we don't show AL for, but probably will change in the future).

