### PR TITLE
Refactor formattable content range

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		7E3E7A4C20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A4B20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift */; };
 		7E3E7A4F20E446600075D159 /* FormattableContentParent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A4E20E446600075D159 /* FormattableContentParent.swift */; };
 		7E841B4C20E6950600EB2BD1 /* FormattableContentAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E841B4B20E6950600EB2BD1 /* FormattableContentAction.swift */; };
+		7E9A02F920F01CAF0094DC69 /* NotificationContentRangeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E9A02F820F01CAF0094DC69 /* NotificationContentRangeFactory.swift */; };
 		7EFF208120EAC5E0009C4699 /* FormattableTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208020EAC5E0009C4699 /* FormattableTextContent.swift */; };
 		7EFF208320EAC8E0009C4699 /* FormattableContentFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208220EAC8E0009C4699 /* FormattableContentFactory.swift */; };
 		8236EB4D2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8236EB4C2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift */; };
@@ -655,6 +656,7 @@
 		7E3E7A4B20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableParagraphStyle+extensions.swift"; sourceTree = "<group>"; };
 		7E3E7A4E20E446600075D159 /* FormattableContentParent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableContentParent.swift; sourceTree = "<group>"; };
 		7E841B4B20E6950600EB2BD1 /* FormattableContentAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableContentAction.swift; sourceTree = "<group>"; };
+		7E9A02F820F01CAF0094DC69 /* NotificationContentRangeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationContentRangeFactory.swift; sourceTree = "<group>"; };
 		7EFF208020EAC5E0009C4699 /* FormattableTextContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableTextContent.swift; sourceTree = "<group>"; };
 		7EFF208220EAC8E0009C4699 /* FormattableContentFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableContentFactory.swift; sourceTree = "<group>"; };
 		8236EB4C2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBlogJetpackModulesSettings.swift; sourceTree = "<group>"; };
@@ -1009,6 +1011,7 @@
 				7E841B4B20E6950600EB2BD1 /* FormattableContentAction.swift */,
 				7EFF208020EAC5E0009C4699 /* FormattableTextContent.swift */,
 				7EFF208220EAC8E0009C4699 /* FormattableContentFactory.swift */,
+				7E9A02F820F01CAF0094DC69 /* NotificationContentRangeFactory.swift */,
 			);
 			name = FormattableContent;
 			sourceTree = "<group>";
@@ -2130,6 +2133,7 @@
 				7430C9A61F1927180051B8E6 /* ReaderSiteServiceRemote.m in Sources */,
 				7430C9B21F1927C50051B8E6 /* RemoteReaderPost.m in Sources */,
 				93BD27931EE82B30002BB00B /* JetpackServiceRemote.m in Sources */,
+				7E9A02F920F01CAF0094DC69 /* NotificationContentRangeFactory.swift in Sources */,
 				74A44DCD1F13C533006CD8F4 /* PushAuthenticationServiceRemote.swift in Sources */,
 				742362DF1F1025B400BD0A7F /* RemoteMenu.m in Sources */,
 				7E3ADCD220E1505E0008400A /* FormattableMediaContent.swift in Sources */,

--- a/WordPressKit/FormattableContentFormatter.swift
+++ b/WordPressKit/FormattableContentFormatter.swift
@@ -79,8 +79,7 @@ public class FormattableContentFormatter {
         var lengthShift = 0
 
         for range in content.ranges {
-            lengthShift += range.shift
-            range.apply(styles, to: theString, withShift: lengthShift)
+            lengthShift += range.apply(styles, to: theString, withShift: lengthShift)
         }
 
         return theString

--- a/WordPressKit/FormattableContentFormatter.swift
+++ b/WordPressKit/FormattableContentFormatter.swift
@@ -79,24 +79,8 @@ public class FormattableContentFormatter {
         var lengthShift = 0
 
         for range in content.ranges {
-            var shiftedRange        = range.range
-            shiftedRange.location   += lengthShift
-
-            if range.kind == .Noticon {
-                let noticon         = (range.value ?? String()) + " "
-                theString.replaceCharacters(in: shiftedRange, with: noticon)
-                lengthShift         += noticon.count
-                shiftedRange.length += noticon.count
-            }
-
-            if let rangeStyle = styles.rangeStylesMap?[range.kind] {
-                theString.addAttributes(rangeStyle, range: shiftedRange)
-            }
-
-            if let rangeURL = range.url, let linksColor = styles.linksColor {
-                theString.addAttribute(.link, value: rangeURL, range: shiftedRange)
-                theString.addAttribute(.foregroundColor, value: linksColor, range: shiftedRange)
-            }
+            lengthShift += range.shift
+            range.apply(styles, to: theString, withShift: lengthShift)
         }
 
         return theString

--- a/WordPressKit/FormattableContentRange.swift
+++ b/WordPressKit/FormattableContentRange.swift
@@ -1,179 +1,125 @@
 import Foundation
 
-
-
-// MARK: - FormattableContentRange Entity
+// MARK: - DefaultFormattableContentRange Entity
 //
 public class FormattableContentRange {
-    /// Kind of the current Range
-    ///
-    let kind: Kind
+    public let kind: Kind
+    public let range: NSRange
 
-    /// Text Range Associated!
-    ///
-    let range: NSRange
+    public func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) {
+        var shiftedRange        = range
+        shiftedRange.location   += shift
 
-    /// Resource URL, if any.
-    ///
-    fileprivate(set) var url: URL?
-
-    /// Comment ID, if any.
-    ///
-    public fileprivate(set) var commentID: NSNumber?
-
-    /// Post ID, if any.
-    ///
-    fileprivate(set) var postID: NSNumber?
-
-    /// Site ID, if any.
-    ///
-    fileprivate(set) var siteID: NSNumber?
-
-    /// User ID, if any.
-    ///
-    fileprivate(set) var userID: NSNumber?
-
-    /// String Payload, if any.
-    ///
-    fileprivate(set) var value: String?
-
-
-    /// Designated Initializer
-    ///
-    init?(dictionary: [String: AnyObject]) {
-        guard let theKind = FormattableContentRange.kind(for: dictionary),
-            let indices = dictionary[RangeKeys.Indices] as? [Int],
-            let start = indices.first,
-            let end = indices.last
-            else {
-                return nil
-        }
-
-        kind = theKind
-        range = NSMakeRange(start, end - start)
-        siteID = dictionary[RangeKeys.SiteId] as? NSNumber
-
-        if let rawURL = dictionary[RangeKeys.URL] as? String {
-            url = URL(string: rawURL)
-        }
-
-        //  SORRY: << Let me stress this. Sorry, i'm 1000% against Duck Typing.
-        //  ======
-        //  `id` is coupled with the `kind`. Which, in turn, is also duck typed.
-        //
-        //      type = comment  => id = comment_id
-        //      type = user     => id = user_id
-        //      type = post     => id = post_id
-        //      type = site     => id = site_id
-        //
-        switch kind {
-        case .Comment:
-            commentID = dictionary[RangeKeys.Id] as? NSNumber
-            postID = dictionary[RangeKeys.PostId] as? NSNumber
-        case .Noticon:
-            value = dictionary[RangeKeys.Value] as? String
-        case .Post:
-            postID = dictionary[RangeKeys.Id] as? NSNumber
-        case .Site:
-            siteID = dictionary[RangeKeys.Id] as? NSNumber
-        case .User:
-            userID = dictionary[RangeKeys.Id] as? NSNumber
-        default:
-            break
+        if let rangeStyle = styles.rangeStylesMap?[kind] {
+            string.addAttributes(rangeStyle, range: shiftedRange)
         }
     }
 
+    var shift: Int {
+        return 0
+    }
 
-    /// AVOID USING This Initializer at all costs.
-    ///
-    /// The Notifications stack was designed to render the Model entities, retrieved via the Backend's API, for several reasons.
-    /// Most important one is: iOS, Android, WordPress.com and the WordPress Desktop App need to look consistent, all over.
-    ///
-    /// If you're tampering with the Backend Response, just to get a new UI component onscreen, means that you'll break consistency.
-    /// Please consider patching the backend first, so that the actual response contains (whatever) you need it to contain!.
-    ///
-    /// Alternatively, depending on what you need to get done, you may also consider modifying the way the current blocks look like.
-    ///
-    public init(kind: Kind, range: NSRange, url: URL? = nil, commentID: NSNumber? = nil, postID: NSNumber? = nil, siteID: NSNumber? = nil, userID: NSNumber? = nil, value: String? = nil) {
-        self.kind = kind
+    init(kind: Kind, range: NSRange) {
         self.range = range
-        self.url = url
+        self.kind = kind
+    }
+}
+
+extension FormattableContentRange {
+    public struct Kind: Equatable, Hashable {
+        let rawType: String
+
+        public init(_ rawType: String) {
+            self.rawType = rawType
+        }
+    }
+}
+
+class FormattableUserRange: FormattableContentRange {
+    public let userID: NSNumber
+
+    init(userID: NSNumber, range: NSRange) {
+        self.userID = userID
+        super.init(kind: FormattableContentRange.Kind.user, range: range)
+    }
+}
+
+public class FormattablePostRange: FormattableContentRange {
+    public let postID: NSNumber
+
+    init(postID: NSNumber, range: NSRange) {
+        self.postID = postID
+        super.init(kind: FormattableContentRange.Kind.post, range: range)
+    }
+}
+
+public class FormattableCommentRange: FormattableContentRange {
+    public let commentID: NSNumber
+    public let postID: NSNumber
+
+    init(commentID: NSNumber, postID: NSNumber, range: NSRange) {
         self.commentID = commentID
         self.postID = postID
-        self.siteID = siteID
-        self.userID = userID
+        super.init(kind: FormattableContentRange.Kind.comment, range: range)
+    }
+}
+
+public class FormattableNoticonRange: FormattableContentRange {
+    public let value: String
+    override var shift: Int {
+        return 1
+    }
+
+    init(value: String, range: NSRange) {
         self.value = value
+        super.init(kind: FormattableContentRange.Kind.noticon, range: range)
     }
 
-
-    /// Returns the FormattableContentRange Kind, for a given raw Notification Range.
-    ///
-    /// - Details:
-    ///     I truly hope the reviewer, and the Opensource Community can forgive this ongoing hack.
-    ///     Notifications can now carry URL's without specifying an explicit 'Type'. For that reason,
-    ///     surprise!... we're now also inferring the Notification Type.
-    ///
-    private static func kind(for dictionary: [String: AnyObject]) -> Kind? {
-        if let type = dictionary[RangeKeys.RawType] as? String,
-            let kind = Kind(rawValue: type) {
-            return kind
-        }
-
-        if let _ = dictionary[RangeKeys.SiteId] {
-            return .Site
-        }
-
-        if let _ = dictionary[RangeKeys.URL] {
-            return .Link
-        }
-
-        return nil
+    public override func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) {
+        //do noticon stuff
+        super.apply(styles, to: string, withShift: shift)
     }
 }
 
+public class FormattableSiteRange: FormattableContentRange {
+    public let siteID: NSNumber
 
-// MARK: - FormattableContentRange Parsers
-//
-extension FormattableContentRange {
-    /// Parses FormattableContentRange instances, given an array of raw ranges.
-    ///
-    class func rangesFromArray(_ ranges: [[String: AnyObject]]?) -> [FormattableContentRange] {
-        let parsed = ranges?.compactMap {
-            return FormattableContentRange(dictionary: $0)
-        }
-
-        return parsed ?? []
+    init(siteID: NSNumber, range: NSRange) {
+        self.siteID = siteID
+        super.init(kind: FormattableContentRange.Kind.site, range: range)
     }
 }
 
+public class FormattableLinkRange: FormattableContentRange {
+    public let url: URL
 
-// MARK: - FormattableContentRange Types
-//
-public extension FormattableContentRange {
-    /// Known kinds of Range
-    ///
-    public enum Kind: String {
-        case User = "user"
-        case Post = "post"
-        case Comment = "comment"
-        case Stats = "stat"
-        case Follow = "follow"
-        case Blockquote = "blockquote"
-        case Noticon = "noticon"
-        case Site = "site"
-        case Match = "match"
-        case Link = "link"
+    init(url: URL, range: NSRange) {
+        self.url = url
+        super.init(kind: FormattableContentRange.Kind.link, range: range)
     }
 
-    /// Parsing Keys
-    ///
-    fileprivate enum RangeKeys {
-        static let RawType = "type"
-        static let URL = "url"
-        static let Indices = "indices"
-        static let Id = "id"
-        static let Value = "value"
-        static let SiteId = "site_id"
-        static let PostId = "post_id"
+    public override func apply(_ styles: FormattableContentStyles, to string: NSMutableAttributedString, withShift shift: Int) {
+        super.apply(styles, to: string, withShift: shift)
+
+        var shiftedRange        = range
+        shiftedRange.location   += shift
+
+        if let linksColor = styles.linksColor {
+            string.addAttribute(.link, value: url, range: shiftedRange)
+            string.addAttribute(.foregroundColor, value: linksColor, range: shiftedRange)
+        }
     }
+}
+
+extension FormattableContentRange.Kind {
+    static let user       = FormattableContentRange.Kind("user")
+    static let post       = FormattableContentRange.Kind("post")
+    static let comment    = FormattableContentRange.Kind("comment")
+    static let stats      = FormattableContentRange.Kind("stat")
+    static let follow     = FormattableContentRange.Kind("follow")
+    static let blockquote = FormattableContentRange.Kind("blockquote")
+    static let noticon    = FormattableContentRange.Kind("noticon")
+    static let site       = FormattableContentRange.Kind("site")
+    static let match      = FormattableContentRange.Kind("match")
+    static let link       = FormattableContentRange.Kind("link")
 }

--- a/WordPressKit/FormattableContentStyles.swift
+++ b/WordPressKit/FormattableContentStyles.swift
@@ -2,7 +2,7 @@
 public protocol FormattableContentStyles {
     var attributes: [NSAttributedStringKey: Any] { get }
     var quoteStyles: [NSAttributedStringKey: Any]? { get }
-    var rangeStylesMap: [FormattableContentRange.Kind: [NSAttributedStringKey: Any]]? { get }
+    var rangeStylesMap: [NotificationContentRange.Kind: [NSAttributedStringKey: Any]]? { get }
     var linksColor: UIColor? { get }
     var key: String { get }
 }

--- a/WordPressKit/FormattableTextContent.swift
+++ b/WordPressKit/FormattableTextContent.swift
@@ -25,7 +25,7 @@ open class FormattableTextContent: FormattableContent {
         let rawRanges   = dictionary[Constants.BlockKeys.Ranges] as? [[String: AnyObject]]
 
         actions = commandActions
-        ranges = FormattableContentRange.rangesFromArray(rawRanges)
+        ranges = FormattableTextContent.rangesFrom(rawRanges)
         parent = note
         internalText = dictionary[Constants.BlockKeys.Text] as? String
         meta = dictionary[Constants.BlockKeys.Meta] as? [String: AnyObject]
@@ -34,6 +34,90 @@ open class FormattableTextContent: FormattableContent {
     public init(text: String, ranges: [FormattableContentRange]) {
         self.internalText = text
         self.ranges = ranges
+    }
+
+    private static func rangesFrom(_ rawRanges: [[String: AnyObject]]?) -> [FormattableContentRange] {
+        let parsed = rawRanges?.compactMap { rawRange -> FormattableContentRange? in
+
+            guard let indices = rawRange[RangeKeys.indices] as? [Int],
+                let start = indices.first,
+                let end = indices.last else {
+                    return nil
+            }
+            let range = NSMakeRange(start, end - start)
+            return self.rangeFrom(rawRange, range: range)
+        }
+
+        return parsed ?? []
+    }
+
+    private static func rangeFrom(_ rawRange: [String: AnyObject], range: NSRange) -> FormattableContentRange? {
+        if let type = rawRange[RangeKeys.rawType] as? String {
+            let kind = FormattableContentRange.Kind(type)
+            switch kind {
+            case .user:
+                guard let userID = rawRange[RangeKeys.id] as? NSNumber else {
+                    fatalError()
+                }
+                return FormattableUserRange(userID: userID, range: range)
+            case .post:
+                guard let postID = rawRange[RangeKeys.postId] as? NSNumber else {
+                    fatalError()
+                }
+                return FormattablePostRange(postID: postID, range: range)
+            case .comment:
+                guard let postID = rawRange[RangeKeys.postId] as? NSNumber, let commentID = rawRange[RangeKeys.id] as? NSNumber else {
+                    fatalError()
+                }
+                return FormattableCommentRange(commentID: commentID, postID: postID, range: range)
+            case .noticon:
+                guard let value = rawRange[RangeKeys.value] as? String else {
+                    fatalError()
+                }
+                return FormattableNoticonRange(value: value, range: range)
+            case .site:
+                guard let siteID = rawRange[RangeKeys.siteId] as? NSNumber else {
+                    fatalError()
+                }
+                return FormattableSiteRange(siteID: siteID, range: range)
+            case .link:
+                guard let urlString = rawRange[RangeKeys.url] as? String, let url = URL(string: urlString) else {
+                    fatalError()
+                }
+                return FormattableLinkRange(url: url, range: range)
+            case .blockquote, .stats, .follow, .match:
+                return FormattableContentRange(kind: kind, range: range)
+            default: break
+            }
+        }
+        // No type comming from payload
+        if let siteID = rawRange[RangeKeys.siteId] as? NSNumber {
+            return FormattableSiteRange(siteID: siteID, range: range)
+        } else if let urlString = rawRange[RangeKeys.url] as? String, let url = URL(string: urlString) {
+            return FormattableLinkRange(url: url, range: range)
+        }
+
+        return nil
+    }
+}
+
+fileprivate enum RangeKeys {
+    static let rawType = "type"
+    static let url = "url"
+    static let indices = "indices"
+    static let id = "id"
+    static let value = "value"
+    static let siteId = "site_id"
+    static let postId = "post_id"
+}
+
+public extension FormattableMediaItem {
+    fileprivate enum MediaKeys {
+        static let RawType      = "type"
+        static let URL          = "url"
+        static let Indices      = "indices"
+        static let Width        = "width"
+        static let Height       = "height"
     }
 }
 

--- a/WordPressKit/FormattableTextContent.swift
+++ b/WordPressKit/FormattableTextContent.swift
@@ -31,84 +31,15 @@ open class FormattableTextContent: FormattableContent {
         meta = dictionary[Constants.BlockKeys.Meta] as? [String: AnyObject]
     }
 
-    public init(text: String, ranges: [FormattableContentRange]) {
+    public init(text: String, ranges: [NotificationContentRange]) {
         self.internalText = text
         self.ranges = ranges
     }
 
-    private static func rangesFrom(_ rawRanges: [[String: AnyObject]]?) -> [FormattableContentRange] {
-        let parsed = rawRanges?.compactMap { rawRange -> FormattableContentRange? in
-
-            guard let indices = rawRange[RangeKeys.indices] as? [Int],
-                let start = indices.first,
-                let end = indices.last else {
-                    return nil
-            }
-            let range = NSMakeRange(start, end - start)
-            return self.rangeFrom(rawRange, range: range)
-        }
-
+    private static func rangesFrom(_ rawRanges: [[String: AnyObject]]?) -> [NotificationContentRange] {
+        let parsed = rawRanges?.compactMap(NotificationContentRangeFactory.contentRange)
         return parsed ?? []
     }
-
-    private static func rangeFrom(_ rawRange: [String: AnyObject], range: NSRange) -> FormattableContentRange? {
-        if let type = rawRange[RangeKeys.rawType] as? String {
-            let kind = FormattableContentRange.Kind(type)
-            switch kind {
-            case .user:
-                guard let userID = rawRange[RangeKeys.id] as? NSNumber else {
-                    fatalError()
-                }
-                return FormattableUserRange(userID: userID, range: range)
-            case .post:
-                guard let postID = rawRange[RangeKeys.postId] as? NSNumber else {
-                    fatalError()
-                }
-                return FormattablePostRange(postID: postID, range: range)
-            case .comment:
-                guard let postID = rawRange[RangeKeys.postId] as? NSNumber, let commentID = rawRange[RangeKeys.id] as? NSNumber else {
-                    fatalError()
-                }
-                return FormattableCommentRange(commentID: commentID, postID: postID, range: range)
-            case .noticon:
-                guard let value = rawRange[RangeKeys.value] as? String else {
-                    fatalError()
-                }
-                return FormattableNoticonRange(value: value, range: range)
-            case .site:
-                guard let siteID = rawRange[RangeKeys.siteId] as? NSNumber else {
-                    fatalError()
-                }
-                return FormattableSiteRange(siteID: siteID, range: range)
-            case .link:
-                guard let urlString = rawRange[RangeKeys.url] as? String, let url = URL(string: urlString) else {
-                    fatalError()
-                }
-                return FormattableLinkRange(url: url, range: range)
-            case .blockquote, .stats, .follow, .match:
-                return FormattableContentRange(kind: kind, range: range)
-            default: break
-            }
-        }
-        // No type comming from payload
-        if let siteID = rawRange[RangeKeys.siteId] as? NSNumber {
-            return FormattableSiteRange(siteID: siteID, range: range)
-        } else if let urlString = rawRange[RangeKeys.url] as? String, let url = URL(string: urlString) {
-            return FormattableLinkRange(url: url, range: range)
-        }
-
-        return nil
-    }
-}
-
-fileprivate enum RangeKeys {
-    static let rawType = "type"
-    static let url = "url"
-    static let indices = "indices"
-    static let id = "id"
-    static let value = "value"
-    static let siteId = "site_id"
-    static let postId = "post_id"
 }
 
 public extension FormattableMediaItem {

--- a/WordPressKit/NotificationContentRangeFactory.swift
+++ b/WordPressKit/NotificationContentRangeFactory.swift
@@ -1,0 +1,96 @@
+
+struct NotificationContentRangeFactory {
+    static func contentRange(from dictionary: [String: AnyObject]) -> NotificationContentRange? {
+        guard let range = rangeFrom(dictionary) else {
+            return nil
+        }
+        let properties = propertiesFrom(dictionary, with: range)
+
+        if let kind = kindString(from: dictionary) {
+            return contentRange(ofKind: kind, with: properties, from: dictionary)
+        }
+
+        return contentRangeWithoutKindSpecified(with: properties, from: dictionary)
+    }
+
+    private static func rangeFrom(_ dictionary: [String: AnyObject]) -> NSRange? {
+        guard let indices = dictionary[RangeKeys.indices] as? [Int],
+            let start = indices.first,
+            let end = indices.last else {
+                return nil
+        }
+        return NSMakeRange(start, end - start)
+    }
+
+    private static func propertiesFrom(_ dictionary: [String: AnyObject], with range: NSRange) -> NotificationContentRange.Properties {
+        var properties = NotificationContentRange.Properties(range: range)
+
+        properties.siteID = dictionary[RangeKeys.siteId] as? NSNumber
+        properties.postID = dictionary[RangeKeys.postId] as? NSNumber
+
+        if let url = dictionary[RangeKeys.url] as? String {
+            properties.url = URL(string: url)
+        }
+        return properties
+    }
+
+    private static func kindString(from dictionary: [String: AnyObject]) -> String? {
+        return dictionary[RangeKeys.rawType] as? String
+    }
+
+    private static func contentRange(ofKind type: String, with properties: NotificationContentRange.Properties, from dictionary: [String: AnyObject]) -> NotificationContentRange? {
+        var properties = properties
+        let kind = NotificationContentRange.Kind(type)
+
+        switch kind {
+        case .comment:
+            let commentID = dictionary[RangeKeys.id] as? NSNumber
+            return FormattableCommentRange(commentID: commentID, properties: properties)
+        case .noticon:
+            guard let value = dictionary[RangeKeys.value] as? String else {
+                fallthrough
+            }
+            return FormattableNoticonRange(value: value, properties: properties)
+        case .post:
+            properties.postID = dictionary[RangeKeys.id] as? NSNumber
+            return NotificationContentRange(kind: kind, properties: properties)
+        case .site:
+            properties.siteID = dictionary[RangeKeys.id] as? NSNumber
+            return NotificationContentRange(kind: kind, properties: properties)
+        case .user:
+            properties.userID = dictionary[RangeKeys.id] as? NSNumber
+            return NotificationContentRange(kind: kind, properties: properties)
+        default:
+            return NotificationContentRange(kind: kind, properties: properties)
+        }
+    }
+
+    private static func contentRangeWithoutKindSpecified(with properties: NotificationContentRange.Properties, from dictionary: [String: AnyObject]) -> NotificationContentRange? {
+        if containsSiteID(dictionary) {
+            return NotificationContentRange(kind: .site, properties: properties)
+        }
+        if containsValidURL(dictionary) {
+            return NotificationContentRange(kind: .link, properties: properties)
+        }
+        return nil
+    }
+
+    private static func containsSiteID(_ dictionary: [String: AnyObject]) -> Bool {
+        return (dictionary[RangeKeys.siteId] as? NSNumber) != nil
+    }
+
+    private static func containsValidURL(_ dictionary: [String: AnyObject]) -> Bool {
+        let urlString = dictionary[RangeKeys.url] as? String ?? ""
+        return URL(string: urlString) != nil
+    }
+
+    enum RangeKeys {
+        static let rawType = "type"
+        static let url = "url"
+        static let indices = "indices"
+        static let id = "id"
+        static let value = "value"
+        static let siteId = "site_id"
+        static let postId = "post_id"
+    }
+}


### PR DESCRIPTION
This PR refactor `FormattableContentRange` to make it more extendible.

The `Noticon` range is quite special, since it will insert some characters in the text, affecting al next ranges in the content. Ranges now have the ability of telling the rest how much was the shift created by that insertion.

To test:
- Check that builds properly.
- Check out [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/9717).
- Follow the tests steps in that PR.