### PR TITLE
ReaderPostServiceRemote: Support loading post for a feed

### DIFF
--- a/WordPressKit/ReaderPostServiceRemote.h
+++ b/WordPressKit/ReaderPostServiceRemote.h
@@ -47,6 +47,7 @@
  */
 - (void)fetchPost:(NSUInteger)postID
          fromSite:(NSUInteger)siteID
+           isFeed:(BOOL)isFeed
           success:(void (^)(RemoteReaderPost *post))success
           failure:(void (^)(NSError *error))failure;
 

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -129,10 +129,13 @@ static const NSUInteger ReaderPostTitleLength = 30;
 
 - (void)fetchPost:(NSUInteger)postID
          fromSite:(NSUInteger)siteID
+           isFeed:(BOOL)isFeed
           success:(void (^)(RemoteReaderPost *post))success
           failure:(void (^)(NSError *error))failure {
 
-    NSString *path = [NSString stringWithFormat:@"read/sites/%lu/posts/%lu/?meta=site", (unsigned long)siteID, (unsigned long)postID];
+    NSString *feedType = (isFeed) ? @"feed" : @"sites";
+    NSString *path = [NSString stringWithFormat:@"read/%@/%lu/posts/%lu/?meta=site", feedType, (unsigned long)siteID, (unsigned long)postID];
+
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
     


### PR DESCRIPTION
As part of https://github.com/wordpress-mobile/WordPress-iOS/issues/9670, we need to support loading reader posts in two ways – those that are part of `feeds`, and those that are part of `blogs`:

* `/read/feeds/{feed_id}/posts/{post_id}`
* `/read/blogs/{blog_id}/posts/{post_id}`

This PR adds an extra parameter to `fetchPost:fromSite:success:failure:`, to hit a different endpoint depending on whether the post is part of a feed or not. This mirrors similar logic in WPAndroid: https://github.com/wordpress-mobile/WordPress-Android/pull/4606/files#diff-ba46e60d6bdcf8a2ac89517e49ef56a9R243.

**To Test:**

* Check out the Reader Universal Links [branch](https://github.com/wordpress-mobile/WordPress-iOS/tree/issue/9670-reader-universal-links) / PR on WPiOS, and ensure that both the Blog Post and Feed Post routes load correctly.
* Tap through some posts on the Reader and double check I didn't break anything :)