### PR TITLE
Add support for AL for WPCom free sites.

### DIFF
--- a/WordPressKit/Activity.swift
+++ b/WordPressKit/Activity.swift
@@ -164,6 +164,15 @@ public class RewindStatus {
     public let reason: String?
     public let restore: RestoreStatus?
 
+    internal init(state: State) {
+        //FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
+        // stops returning 412's for those sites.
+        self.state = state
+        self.lastUpdated = Date()
+        self.reason = nil
+        self.restore = nil
+    }
+
     init(dictionary: [String: AnyObject]) throws {
         guard let rewindState = dictionary["state"] as? String else {
             throw Error.missingState

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -86,6 +86,13 @@ public class ActivityServiceRemote: ServiceRemoteWordPressComREST {
                                         failure(ResponseError.decodingFailure)
                                     }
                                 }, failure: { error, _ in
+                                    //FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
+                                    // stops returning 412's for those sites.
+                                    if let error = error as? WordPressComRestApiError, error == WordPressComRestApiError.preconditionFailure {
+                                        let status = RewindStatus(state: .unavailable)
+                                        success(status)
+                                        return
+                                    }
                                     failure(error)
                                 })
     }

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -21,6 +21,7 @@ import Alamofire
     case responseSerializationFailed
     case tooManyRequests
     case unknown
+    case preconditionFailure
 }
 
 open class WordPressComRestApi: NSObject {    
@@ -358,6 +359,13 @@ extension WordPressComRestApi {
             }
             return WordPressComRestApiError.unknown as NSError
         }
+
+        //FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
+        // stops returning 412's for those sites.
+        if httpResponse.statusCode == 412, let code = responseDictionary["code"] as? String, code == "no_connected_jetpack" {
+            return WordPressComRestApiError.preconditionFailure as NSError
+        }
+
         var errorDictionary: AnyObject? = responseDictionary as AnyObject?
         if let errorArray = responseDictionary["errors"] as? [AnyObject], errorArray.count > 0 {
             errorDictionary = errorArray.first


### PR DESCRIPTION
This adds a bunch of glue code needed for the WPiOS app not to freak out when trying to fetch the `Rewind` status for non-Atomic WPCom sites. We shouldn't need it long-term, but we want to ship this before next code freeze, so c'est la vive.