### PR TITLE
1.2 Release.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.1"
+  s.version       = "1.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
Let's tag a release before upcoming code freeze, so we can pin the version in WPiOS to a release, not just a raw git SHA hash.