### PR TITLE
Tweak podspec number so we're bumping from 1.2 to 1.2.1, instead of 1.3

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.3"
+  s.version       = "1.2.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
Tweaking the podspec version to go back to a three digit schema.  Looks like that's what we were using prior to 1142bd739109190a72a51f0a6c3be545abcdfcb6.  With this change we'll be consistent with the naming schema in our other pods.