### PR TITLE
Mark as sticky Post

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.2.1):
+  - WordPressKit (1.3.0):
     - Alamofire (~> 4.7)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -69,7 +69,7 @@ SPEC CHECKSUMS:
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 70ac5d8c5568a4af3a6422ebcdad49610ff3a99a
+  WordPressKit: b1d591df2c5a7948b5db04484e97cd3327c7e9a6
   WordPressShared: db964b81e02ff9be1ea2ff65ca9a4d57c49e82ba
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.2):
+  - WordPressKit (1.2.1):
     - Alamofire (~> 4.7)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -69,7 +69,7 @@ SPEC CHECKSUMS:
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: a0910e9786558f1b793e88bed191540d6b7a511d
+  WordPressKit: 70ac5d8c5568a4af3a6422ebcdad49610ff3a99a
   WordPressShared: db964b81e02ff9be1ea2ff65ca9a4d57c49e82ba
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.2.1"
+  s.version       = "1.3.0"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -363,6 +363,9 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     post.commentCount = [jsonPost numberForKeyPath:@"discussion.comment_count"] ?: @0;
     post.likeCount = [jsonPost numberForKeyPath:@"like_count"] ?: @0;
 
+    NSNumber *stickyPost = [jsonPost numberForKeyPath:@"sticky"] ?: @0;
+    post.isStickyPost = stickyPost.boolValue;
+    
     // FIXME: remove conversion once API is fixed #38-io
     // metadata should always be an array but it's returning false when there are no custom fields
     post.metadata = [jsonPost arrayForKey:@"metadata"];
@@ -435,6 +438,8 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     }
     parameters[@"featured_image"] = post.postThumbnailID ? [post.postThumbnailID stringValue] : @"";
     parameters[@"metadata"] = [self metadataForPost:post];
+    
+    parameters[@"sticky"] = post.isStickyPost ? @"1" : @"0";
 
     // Scheduled posts need to sync with a status of 'publish'.
     // Passing a status of 'future' will set the post status to 'draft'

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -439,7 +439,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     parameters[@"featured_image"] = post.postThumbnailID ? [post.postThumbnailID stringValue] : @"";
     parameters[@"metadata"] = [self metadataForPost:post];
     
-    parameters[@"sticky"] = post.isStickyPost ? @"1" : @"0";
+    parameters[@"sticky"] = post.isStickyPost ? @"true" : @"false";
 
     // Scheduled posts need to sync with a status of 'publish'.
     // Passing a status of 'future' will set the post status to 'draft'

--- a/WordPressKit/RemotePost.h
+++ b/WordPressKit/RemotePost.h
@@ -42,6 +42,7 @@ extern NSString * const PostStatusDeleted;
 @property (nonatomic, strong) NSArray *tags;
 @property (nonatomic, strong) NSString *pathForDisplayImage;
 @property (nonatomic, assign) BOOL isFeaturedImageChanged;
+@property (nonatomic, assign) BOOL isStickyPost;
 
 /**
  Array of custom fields. Each value is a dictionary containing {ID, key, value}

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -144,6 +144,7 @@
     OCMStub([post password]).andReturn(@"Password");
     OCMStub([post type]).andReturn(@"Type");
     OCMStub([post metadata]).andReturn(@[]);
+    OCMStub([post isStickyPost]).andReturn(YES);
 
     XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:dotComID]);
 
@@ -187,7 +188,8 @@
     OCMStub([post password]).andReturn(@"Password");
     OCMStub([post type]).andReturn(@"Type");
     OCMStub([post metadata]).andReturn(@[]);
-    
+    OCMStub([post isStickyPost]).andReturn(YES);
+
     XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:dotComID]);
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@?context=edit", dotComID, post.postID];


### PR DESCRIPTION
This is related to this: [Mark as Sticky Post](https://github.com/wordpress-mobile/WordPress-iOS/issues/9661)
I updated the `RemotePost` model to map the `sticky` value from the JSON response. I also updated the methods to decode/encode the `RemotePost` model in order to create or update the model whenever it's used.
`PostServiceRemoteRESTTests.m` is updated using the new property as well.

**To Test**
- Make sure it builds
- Run the test