### PR TITLE
Add ReaderPostServiceRemote `fetchPostAtURL` method

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.3.0"
+  s.version       = "1.4.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/ReaderPostServiceRemote.h
+++ b/WordPressKit/ReaderPostServiceRemote.h
@@ -52,6 +52,17 @@
           failure:(void (^)(NSError *error))failure;
 
 /**
+ Fetches a specific post from the specified URL
+
+ @param postURL The URL of the post to fetch
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)fetchPostAtURL:(NSURL *)postURL
+               success:(void (^)(RemoteReaderPost *post))success
+               failure:(void (^)(NSError *error))failure;
+
+/**
  Mark a post as liked by the user.
 
  @param postID The ID of the post.

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -162,6 +162,46 @@ static const NSUInteger ReaderPostTitleLength = 30;
               }];
 }
 
+/**
+ Fetches a specific post from the specified URL
+
+ @param postURL The URL of the post to fetch
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)fetchPostAtURL:(NSURL *)postURL
+               success:(void (^)(RemoteReaderPost *post))success
+               failure:(void (^)(NSError *error))failure
+{
+    NSString *path = [self apiPathForPostAtURL:postURL];
+
+    if (!path) {
+        failure(nil);
+        return;
+    }
+
+    [self.wordPressComRestApi GET:path
+                       parameters:nil
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                              if (!success) {
+                                  return;
+                              }
+                              dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
+                                  // Do all of this work on a background thread, then call success on the main thread.
+                                  // Do this to avoid any chance of blocking the UI while parsing.
+                                  RemoteReaderPost *post = [self formatPostDictionary:(NSDictionary *)responseObject];
+                                  dispatch_async(dispatch_get_main_queue(), ^{
+                                      success(post);
+                                  });
+                              });
+
+                          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                              if (failure) {
+                                  failure(error);
+                              }
+                          }];
+}
+
 - (void)likePost:(NSUInteger)postID
          forSite:(NSUInteger)siteID
          success:(void (^)(void))success
@@ -505,6 +545,25 @@ static const NSUInteger ReaderPostTitleLength = 30;
     sourceAttr.likeCount = [dict numberForKeyPath:@"featured_post_wpcom_data.like_count"];
     sourceAttr.taxonomies = [self slugsFromDiscoverPostTaxonomies:taxonomies];
     return sourceAttr;
+}
+
+- (nullable NSString *)apiPathForPostAtURL:(NSURL *)url
+{
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:nil];
+
+    NSString *hostname = components.host;
+    NSArray *pathComponents = [components.path pathComponents];
+    NSString *slug = [components.path lastPathComponent];
+
+    // We expect 6 path components for a post – year, month, day, slug, plus a '/' on either end
+    if (hostname == nil || pathComponents.count != 6 || slug == nil) {
+        return nil;
+    }
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/slug:%@?meta=site,likes", hostname, slug];
+
+    return [self pathForEndpoint:path
+                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 }
 
 

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -549,14 +549,14 @@ static const NSUInteger ReaderPostTitleLength = 30;
 
 - (nullable NSString *)apiPathForPostAtURL:(NSURL *)url
 {
-    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:nil];
+    NSURLComponents *components = [NSURLComponents componentsWithURL:url resolvingAgainstBaseURL:NO];
 
     NSString *hostname = components.host;
-    NSArray *pathComponents = [components.path pathComponents];
+    NSArray *pathComponents = [[components.path pathComponents] filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"SELF != '/'"] ];
     NSString *slug = [components.path lastPathComponent];
 
-    // We expect 6 path components for a post – year, month, day, slug, plus a '/' on either end
-    if (hostname == nil || pathComponents.count != 6 || slug == nil) {
+    // We expect 4 path components for a post – year, month, day, slug, plus a '/' on either end
+    if (hostname == nil || pathComponents.count != 4 || slug == nil) {
         return nil;
     }
 


### PR DESCRIPTION
This PR adds a new method to `ReaderPostServiceRemote` to fetch a post for a specific URL. It only works for WordPress.com subdomains, and attempts to split out the post slug from the URL. It then uses the `sites/:domain/posts/slug::post-slug?meta=site,likes` endpoint to fetch the post information.

This will be used in WordPress-iOS to display the detail for a post in a `ReaderDetailViewController` based solely on the post URL.

Please see https://github.com/wordpress-mobile/WordPress-iOS/pull/10079 for the associated WPiOS PR, for testing :)