### PR TITLE
Sticky Post for self-hosted sites/XML-RPC-API 

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.3.0):
+  - WordPressKit (1.4.0-beta.3):
     - Alamofire (~> 4.7)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -69,7 +69,7 @@ SPEC CHECKSUMS:
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: b1d591df2c5a7948b5db04484e97cd3327c7e9a6
+  WordPressKit: 37b7f2befc801c527ccd7c2cdef5d952707cbcd1
   WordPressShared: db964b81e02ff9be1ea2ff65ca9a4d57c49e82ba
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.0-beta.2"
+  s.version       = "1.4.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteXMLRPC.m
+++ b/WordPressKit/PostServiceRemoteXMLRPC.m
@@ -319,6 +319,9 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSArray *terms = [xmlrpcDictionary arrayForKey:@"terms"];
     post.tags = [self tagsFromXMLRPCTermsArray:terms];
     post.categories = [self remoteCategoriesFromXMLRPCTermsArray:terms];
+    
+    NSNumber *stickyPost = [xmlrpcDictionary numberForKeyPath:@"sticky"] ?: @0;
+    post.isStickyPost = stickyPost.boolValue;
 
     // Pick an image to use for display
     if (post.postThumbnailPath) {
@@ -409,6 +412,8 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     if ([post.metadata count] > 0) {
         postParams[@"custom_fields"] = post.metadata;
     }
+    
+    postParams[@"sticky"] = post.isStickyPost ? @"true" : @"false";
 
     // Scheduled posts need to sync with a status of 'publish'.
     // Passing a status of 'future' will set the post status to 'draft'

--- a/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
@@ -9,6 +9,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
     let postID: NSNumber = 1
     let postTitle = "Hello world!"
     let postContent = "Welcome to WordPress."
+    let postIsSticky = true
 
     let getPostSuccessMockFilename              = "xmlrpc-wp-getpost-success.xml"
     let getPostBadXMLFailureFilename            = "xmlrpc-wp-getpost-bad-xml-failure.xml"
@@ -140,6 +141,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 post.postID = postID
                 post.title = postTitle
                 post.content = postContent
+                post.isStickyPost = postIsSticky
                 return post
             }()
 
@@ -264,6 +266,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 post.postID = postID
                 post.title = postTitle
                 post.content = postContent
+                post.isStickyPost = postIsSticky
                 return post
             }()
 


### PR DESCRIPTION
This PR is a followup of [this task](https://github.com/wordpress-mobile/WordPress-iOS/pull/10077).
Following @SergioEstevao suggestion, I updated the decode/encode methods to handle the `sticky` JSON property also for self-hosted non-Jetpack blogs.