### PR TITLE
Improve error handling on uploads calls

### DIFF
--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -266,7 +266,7 @@ open class WordPressComRestApi: NSObject {
                 if let taskIdentifier = upload.task?.taskIdentifier {
                     requestEnqueued?(NSNumber(value: taskIdentifier))
                 }
-                let dataRequest = upload.responseJSON(completionHandler: { response in                    
+                let dataRequest = upload.validate().responseJSON(completionHandler: { response in                    
                     switch response.result {
                     case .success(let responseObject):
                         progress.completedUnitCount = progress.totalUnitCount

--- a/WordPressKitTests/MediaServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/MediaServiceRemoteRESTTests.swift
@@ -106,6 +106,18 @@ class MediaServiceRemoteRESTTests: XCTestCase {
         XCTAssertEqual(errorDescription, response["errors"]![0])
     }
 
+    func testCreateMultipleMediaErrorDictionary() {
+
+        let response = ["errors": [["error": "upload_error", "message": "some error", "file": "file.jpg"]]]
+        let media = [mockRemoteMedia(), mockRemoteMedia()]
+        var errorDescription = ""
+        mediaServiceRemote.uploadMedia(media, requestEnqueued: { _ in }, success: { _ in }, failure: {
+            errorDescription = ($0?.localizedDescription)!
+        })
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+        XCTAssertEqual(errorDescription, response["errors"]![0]["message"])
+    }
+
     func testUpdateMediaPath() {
 
         let media = mockRemoteMedia()


### PR DESCRIPTION
While testing uploading of photos saved in the new HEIC format of Apple, I found out two things:

- Our WordPressRestAPI object was not validating httpResponses for calls that use multipart part POST calls
- When these uploads where failing the error list returned was in the following format:
```
 { errorList: 
      [{
      error:"upload_error", 
      message:"Sorry, this file type is not permitted for security reasons.", 
      file:"a.jpg"
      }]
}
``` 

This was not compatible with the format that the code was expecting for `errorList` that was an array of strings.

The code on this PR does two things:
- Validates responses for the multipartPost call on `WordPressComRestApi` by chaining a  `validate()` call on the upload method.
- Improves the parsing on MediaServiceRemoteRest, to cater the two possible scenarios of error list format.

@bummytime do you mind check this? Did you remember to see any of these error messages when doing the app share extensions? 