### PR TITLE
Issue/make active plan optional

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.1-beta.1):
+  - WordPressKit (1.4.1-beta.2):
     - Alamofire (~> 4.7)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -69,7 +69,7 @@ SPEC CHECKSUMS:
   OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 38693f8a8ec6ddf0dd7c4554b780588e9e491837
+  WordPressKit: a5446ddf86c224da98c96796d36d0a38b7ef4fab
   WordPressShared: db964b81e02ff9be1ea2ff65ca9a4d57c49e82ba
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.1-beta.1"
+  s.version       = "1.4.1-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PlanServiceRemote.swift
+++ b/WordPressKit/PlanServiceRemote.swift
@@ -3,7 +3,7 @@ import WordPressShared
 import CocoaLumberjack
 
 public class PlanServiceRemote: ServiceRemoteWordPressComREST {
-    public typealias SitePlans = (activePlan: RemotePlan, availablePlans: [RemotePlan])
+    public typealias SitePlans = (activePlan: RemotePlan?, availablePlans: [RemotePlan])
 
     public enum ResponseError: Error {
         case decodingFailure
@@ -37,7 +37,7 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
 
 }
 
-private func mapPlansResponse(_ response: AnyObject) throws -> (activePlan: RemotePlan, availablePlans: [RemotePlan]) {
+private func mapPlansResponse(_ response: AnyObject) throws -> (activePlan: RemotePlan?, availablePlans: [RemotePlan]) {
     guard let json = response as? [[String: AnyObject]] else {
         throw PlanServiceRemote.ResponseError.decodingFailure
     }
@@ -73,9 +73,7 @@ private func mapPlansResponse(_ response: AnyObject) throws -> (activePlan: Remo
         }
     })
 
-    guard let activePlan = parsedResponse.0 else {
-        throw PlanServiceRemote.ResponseError.noActivePlan
-    }
+    let activePlan = parsedResponse.0
     let availablePlans = parsedResponse.1
     return (activePlan, availablePlans)
 }

--- a/WordPressKit/RemotePlan.swift
+++ b/WordPressKit/RemotePlan.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public typealias PricedPlan = (plan: RemotePlan, price: String)
-public typealias SitePricedPlans = (siteID: Int, activePlan: RemotePlan, availablePlans: [PricedPlan])
+public typealias SitePricedPlans = (siteID: Int, activePlan: RemotePlan?, availablePlans: [PricedPlan])
 public typealias RemotePlanFeatures = [PlanID: [RemotePlanFeature]]
 
 public typealias PlanID = Int

--- a/WordPressKitTests/PlanServiceRemoteTests.swift
+++ b/WordPressKitTests/PlanServiceRemoteTests.swift
@@ -41,30 +41,13 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(sitePlansEndpoint, filename: getPlansSuccessMockFilename, contentType: .ApplicationJSON)
         remote.getPlansForSite(siteID, success: { sitePlans in
-            XCTAssertEqual(sitePlans.activePlan.id, 1, "The active plan id should be 1")
+            XCTAssertEqual(sitePlans.activePlan?.id, 1, "The active plan id should be 1")
             XCTAssertEqual(sitePlans.availablePlans.count, 4, "The availible plans count should be 4")
             expect.fulfill()
         }) { error in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
-
-        waitForExpectations(timeout: timeout, handler: nil)
-    }
-
-    func testGetPlansWithEmptyResponseArrayFails() {
-        let expect = expectation(description: "Get plans with empty response array success")
-
-        stubRemoteResponse(sitePlansEndpoint, filename: getPlansEmptyFailureMockFilename, contentType: .ApplicationJSON)
-        remote.getPlansForSite(siteID, success: { sitePlans in
-            XCTFail("The site should always return plans.")
-            expect.fulfill()
-        }, failure: { error in
-            let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: PlanServiceRemote.ResponseError.self), "The error domain should be PlanServiceRemote.ResponseError")
-            XCTAssertEqual(error.code, PlanServiceRemote.ResponseError.noActivePlan.hashValue, "The error code should be 2 - no active plan")
-            expect.fulfill()
-        })
 
         waitForExpectations(timeout: timeout, handler: nil)
     }


### PR DESCRIPTION
This PR tweaks the remote Plans service and model making the active plan optional, and not throwing an exception when an active plan is not matched to one of the plans returned from the v1.2 endpoint.   This will allow WPiOS to still show the plans returned from the endpoint instead of presenting an error.
See: https://github.com/wordpress-mobile/WordPress-iOS/issues/9856

It also removes the test for an empty response since that test was, in practice, checking for an exception when an active plan was not found. 

To test: 
Run tests and confirm they pass. 

@jklausa could I trouble you for a review of this one? 