### PR TITLE
Migration to Swift 4.2

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -18,6 +18,6 @@ target 'WordPressKit' do
     pod 'OHHTTPStubs', '6.1.0'
     pod 'OHHTTPStubs/Swift', '6.1.0'
     pod 'OCMock', '~> 3.4.2'
-    pod 'WordPressShared', '~> 1.1.1-beta.2'
+    pod 'WordPressShared', '1.1.1-beta.2'
   end
 end

--- a/Podfile
+++ b/Podfile
@@ -17,6 +17,6 @@ target 'WordPressKit' do
 
     pod 'OHHTTPStubs', '6.1.0'
     pod 'OHHTTPStubs/Swift', '6.1.0'
-    pod 'OCMock', '~> 3.4'
+    pod 'OCMock', '~> 3.4.2'
   end
 end

--- a/Podfile
+++ b/Podfile
@@ -18,5 +18,6 @@ target 'WordPressKit' do
     pod 'OHHTTPStubs', '6.1.0'
     pod 'OHHTTPStubs/Swift', '6.1.0'
     pod 'OCMock', '~> 3.4.2'
+    pod 'WordPressShared', '~> 1.1.1-beta.2'
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.1-beta.1):
+  - WordPressKit (1.4.1-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -44,6 +44,7 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - WordPressKit (from `./`)
+  - WordPressShared (~> 1.1.1-beta.2)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -69,10 +70,10 @@ SPEC CHECKSUMS:
   OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 05f0300e8e38c7ee2a9eb88369f07088ccdeea5f
+  WordPressKit: 7bec576e243151dd9a483fe1035f73e0deb4ce9f
   WordPressShared: c4d4356a06fc73bde9b782f26768d42e62a330ef
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: f3420a5d5cec0d4a30b641feed5430422f32ed7a
+PODFILE CHECKSUM: 9bd6ab8c30fa44c675c4c08697d8d1ae0229d9d4
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (4.7.2)
+  - Alamofire (4.7.3)
   - CocoaLumberjack (3.4.2):
     - CocoaLumberjack/Default (= 3.4.2)
     - CocoaLumberjack/Extensions (= 3.4.2)
@@ -10,7 +10,7 @@ PODS:
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
   - NSObject-SafeExpectations (0.0.3)
-  - OCMock (3.4.1)
+  - OCMock (3.4.2)
   - OHHTTPStubs (6.1.0):
     - OHHTTPStubs/Default (= 6.1.0)
   - OHHTTPStubs/Core (6.1.0)
@@ -28,19 +28,19 @@ PODS:
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
   - WordPressKit (1.4.1-beta.1):
-    - Alamofire (~> 4.7)
+    - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (~> 1.0.3)
+    - WordPressShared (~> 1.1.1-beta.2)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.0.7):
+  - WordPressShared (1.1.1-beta.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - wpxmlrpc (0.8.3)
 
 DEPENDENCIES:
-  - OCMock (~> 3.4)
+  - OCMock (~> 3.4.2)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - WordPressKit (from `./`)
@@ -62,17 +62,17 @@ EXTERNAL SOURCES:
     :path: "./"
 
 SPEC CHECKSUMS:
-  Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
+  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
-  OCMock: 2cd0716969bab32a2283ff3a46fd26a8c8b4c5e3
+  OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 38693f8a8ec6ddf0dd7c4554b780588e9e491837
-  WordPressShared: db964b81e02ff9be1ea2ff65ca9a4d57c49e82ba
+  WordPressKit: 05f0300e8e38c7ee2a9eb88369f07088ccdeea5f
+  WordPressShared: c4d4356a06fc73bde9b782f26768d42e62a330ef
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: f9a8f48eb9684c55a8f317e05d210f8dca50da7f
+PODFILE CHECKSUM: f3420a5d5cec0d4a30b641feed5430422f32ed7a
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - WordPressKit (from `./`)
-  - WordPressShared (~> 1.1.1-beta.2)
+  - WordPressShared (= 1.1.1-beta.2)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -74,6 +74,6 @@ SPEC CHECKSUMS:
   WordPressShared: c4d4356a06fc73bde9b782f26768d42e62a330ef
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 9bd6ab8c30fa44c675c4c08697d8d1ae0229d9d4
+PODFILE CHECKSUM: 86b5d1ec95c00c49d7440b352dba6b896fa7157d
 
 COCOAPODS: 1.5.3

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.7.3'
   s.dependency 'CocoaLumberjack', '3.4.2'
-  s.dependency 'WordPressShared', '~> 1.1.1-beta.2'
+  s.dependency 'WordPressShared', '1.1.1-beta.2'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.3'
   s.dependency 'UIDeviceIdentifier', '~> 0.4'

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.header_dir    = 'WordPressKit'
 
-  s.dependency 'Alamofire', '~> 4.7.2'
+  s.dependency 'Alamofire', '~> 4.7.3'
   s.dependency 'CocoaLumberjack', '3.4.2'
   s.dependency 'WordPressShared', '~> 1.0.3'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.1-beta.1"
+  s.version       = "1.4.1-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   s.requires_arc  = true
   s.header_dir    = 'WordPressKit'
 
-  s.dependency 'Alamofire', '~> 4.7'
+  s.dependency 'Alamofire', '~> 4.7.2'
   s.dependency 'CocoaLumberjack', '3.4.2'
   s.dependency 'WordPressShared', '~> 1.0.3'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license       = "GPLv2"
   s.author        = { "Jorge Leandro Perez" => "jorge.perez@automattic.com" }
   s.platform      = :ios, "10.0"
-  s.swift_version = '4.0'
+  s.swift_version = '4.2'
   s.source        = { :git => "https://github.com/wordpress-mobile/WordPressKit-iOS.git", :tag => s.version.to_s }
   s.source_files  = 'WordPressKit/**/*.{h,m,swift}'
   s.private_header_files = "WordPressKit/Private/*.h"
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.7.3'
   s.dependency 'CocoaLumberjack', '3.4.2'
-  s.dependency 'WordPressShared', '~> 1.0.3'
+  s.dependency 'WordPressShared', '~> 1.1.1-beta.2'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.3'
   s.dependency 'UIDeviceIdentifier', '~> 0.4'

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -1959,28 +1959,28 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
+				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
+				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
 				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
 				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
-				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
 				"${BUILT_PRODUCTS_DIR}/NSObject-SafeExpectations/NSObject_SafeExpectations.framework",
 				"${BUILT_PRODUCTS_DIR}/UIDeviceIdentifier/UIDeviceIdentifier.framework",
 				"${BUILT_PRODUCTS_DIR}/WordPressKit/WordPressKit.framework",
-				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
 				"${BUILT_PRODUCTS_DIR}/wpxmlrpc/wpxmlrpc.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressShared.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSObject_SafeExpectations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UIDeviceIdentifier.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressShared.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/wpxmlrpc.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -2319,7 +2319,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -2345,7 +2345,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -2366,7 +2366,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressKitTests/WordPressKitTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -2386,7 +2386,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressKitTests/WordPressKitTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -2467,7 +2467,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = "Release-Internal";
 		};
@@ -2487,7 +2487,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressKitTests/WordPressKitTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = "Release-Internal";
 		};
@@ -2568,7 +2568,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = "Release-Alpha";
 		};
@@ -2588,7 +2588,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressKitTests/WordPressKitTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = "Release-Alpha";
 		};

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -2235,6 +2235,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -2289,6 +2290,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2438,6 +2440,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2539,6 +2542,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/WordPressKit/GravatarServiceRemote.swift
+++ b/WordPressKit/GravatarServiceRemote.swift
@@ -76,7 +76,7 @@ open class GravatarServiceRemote {
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")
 
         // Body
-        let gravatarData = UIImagePNGRepresentation(image)!
+        let gravatarData = image.pngData()!
         let requestBody = bodyWithGravatarData(gravatarData, account: accountEmail, boundary: boundary)
 
         // Task

--- a/WordPressKit/HTTPAuthenticationAlertController.swift
+++ b/WordPressKit/HTTPAuthenticationAlertController.swift
@@ -38,17 +38,17 @@ open class HTTPAuthenticationAlertController {
     static fileprivate func controllerForServerTrustChallenge(_ challenge: URLAuthenticationChallenge) -> UIAlertController {
         let title = NSLocalizedString("Certificate error", comment: "Popup title for wrong SSL certificate.")
         let message = String(format: NSLocalizedString("The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?", comment: ""), challenge.protectionSpace.host)
-        let controller =  UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.alert)
+        let controller =  UIAlertController(title: title, message: message, preferredStyle: .alert)
 
         let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button label"),
-                                         style: UIAlertActionStyle.default,
+                                         style: .default,
                                          handler: { (action) in
                                             executeHandlerForChallenge(challenge, disposition: .cancelAuthenticationChallenge, credential: nil)
         })
         controller.addAction(cancelAction)
 
         let trustAction = UIAlertAction(title: NSLocalizedString("Trust", comment: "Connect when the SSL certificate is invalid"),
-                                        style: UIAlertActionStyle.default,
+                                        style: .default,
                                         handler: { (action) in
                                             let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
                                             URLCredentialStorage.shared.setDefaultCredential(credential, for: challenge.protectionSpace)
@@ -63,7 +63,7 @@ open class HTTPAuthenticationAlertController {
         let message = NSLocalizedString("Please enter your credentials", comment: "Popup message to ask for user credentials (fields shown below).")
         let controller =  UIAlertController(title: title,
                                             message: message,
-                                            preferredStyle: UIAlertControllerStyle.alert)
+                                            preferredStyle: .alert)
 
         controller.addTextField( configurationHandler: { (textField) in
             textField.placeholder = NSLocalizedString("Username", comment: "Login dialog username placeholder")

--- a/WordPressKit/NSMutableAttributedString+extensions.swift
+++ b/WordPressKit/NSMutableAttributedString+extensions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension NSMutableAttributedString {
-    func applyAttributes(toQuotes attributes: [NSAttributedStringKey: Any]?) {
+    func applyAttributes(toQuotes attributes: [NSAttributedString.Key: Any]?) {
         guard let attributes = attributes else {
             return
         }

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -662,7 +662,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
 /**
  Parse whether the post belongs to a wpcom blog.
 
- @param A dictionary representing a post object from the REST API
+ @param dict A dictionary representing a post object from the REST API
  @return YES if the post belongs to a wpcom blog, else NO
  */
 - (BOOL)isWPComFromPostDictionary:(NSDictionary *)dict
@@ -903,7 +903,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
  Formats a post's summary.  The excerpts provided by the REST API contain HTML and have some extra content appened to the end.
  HTML is stripped and the extra bit is removed.
 
- @param string The summary to format.
+ @param summary The summary to format.
  @return The formatted summary.
  */
 - (NSString *)formatSummary:(NSString *)summary

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -295,7 +295,7 @@ open class WordPressComRestApi: NSObject {
         return !(authToken.isEmpty)
     }
 
-    override open var hashValue: Int {
+    override open var hash: Int {
         return "\(String(describing: oAuthToken)),\(String(describing: userAgent))".hashValue
     }
 


### PR DESCRIPTION
There are not too many changes to the actual code (which I'd argue is a Good Thing ™️ ), but it took me a while to figure out how to fix the dependency with WordPressShared.

Also, I fixed a couple of `pod lint` documentation warnings. Still, to pass linting, it seems necessary to `pod lib lint --allow-warnings`, as there are a couple of warnings in `wpxmlrpc`