### PR TITLE
Feature/quick start award

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.1-beta.3):
+  - WordPressKit (1.4.1-beta.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 2359103f4af16cce5b1eedf9b60f3babe3ff7070
+  WordPressKit: b04985318513580173475bf02ddb77bc3d926220
   WordPressShared: fc613aa29351c73677c421daacb36eacf53f100d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.1-beta.2):
+  - WordPressKit (1.4.1-beta.3):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: e71c993dbd909006b7032cb8bed783ecf2907d18
+  WordPressKit: 2359103f4af16cce5b1eedf9b60f3babe3ff7070
   WordPressShared: fc613aa29351c73677c421daacb36eacf53f100d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.1-beta.4):
+  - WordPressKit (1.4.2-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: b04985318513580173475bf02ddb77bc3d926220
+  WordPressKit: f520d09ee011f11ee8017aee640025cb017b5612
   WordPressShared: fc613aa29351c73677c421daacb36eacf53f100d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.1-beta.3"
+  s.version       = "1.4.1-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -361,6 +361,8 @@
 		93F50A441F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F50A431F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift */; };
 		93F50A471F227F3600B5BEBA /* xmlrpc-response-getprofile.xml in Resources */ = {isa = PBXBuildFile; fileRef = 93F50A451F227F3600B5BEBA /* xmlrpc-response-getprofile.xml */; };
 		93F50A481F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml in Resources */ = {isa = PBXBuildFile; fileRef = 93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */; };
+		9AEAA774215E774A00876E62 /* site-quick-start-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 9AEAA772215E71C000876E62 /* site-quick-start-success.json */; };
+		9AEAA775215E774A00876E62 /* site-quick-start-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 9AEAA773215E723200876E62 /* site-quick-start-failure.json */; };
 		9F3E0B9B208732B3009CB5BA /* RemoteReaderSiteInfoSubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3E0B9A208732B2009CB5BA /* RemoteReaderSiteInfoSubscription.swift */; };
 		9F3E0B9E208733C3009CB5BA /* ReaderServiceDeliveryFrequency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3E0B9C208733C2009CB5BA /* ReaderServiceDeliveryFrequency.swift */; };
 		9F3E0BA22087345F009CB5BA /* ServiceRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3E0BA02087345E009CB5BA /* ServiceRequest.swift */; };
@@ -786,6 +788,8 @@
 		93F50A431F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersServiceRemoteXMLRPCTests.swift; sourceTree = "<group>"; };
 		93F50A451F227F3600B5BEBA /* xmlrpc-response-getprofile.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-response-getprofile.xml"; sourceTree = "<group>"; };
 		93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-response-valid-but-unexpected-dictionary.xml"; sourceTree = "<group>"; };
+		9AEAA772215E71C000876E62 /* site-quick-start-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-quick-start-success.json"; sourceTree = "<group>"; };
+		9AEAA773215E723200876E62 /* site-quick-start-failure.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-quick-start-failure.json"; sourceTree = "<group>"; };
 		9F3E0B9A208732B2009CB5BA /* RemoteReaderSiteInfoSubscription.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteReaderSiteInfoSubscription.swift; sourceTree = "<group>"; };
 		9F3E0B9C208733C2009CB5BA /* ReaderServiceDeliveryFrequency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderServiceDeliveryFrequency.swift; sourceTree = "<group>"; };
 		9F3E0BA02087345E009CB5BA /* ServiceRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceRequest.swift; sourceTree = "<group>"; };
@@ -1452,6 +1456,8 @@
 				74D67F2C1F15C3740010C5ED /* site-viewers-delete-bad-json.json */,
 				74D67F2D1F15C3740010C5ED /* site-viewers-delete-failure.json */,
 				74D67F2E1F15C3740010C5ED /* site-viewers-delete-success.json */,
+				9AEAA772215E71C000876E62 /* site-quick-start-success.json */,
+				9AEAA773215E723200876E62 /* site-quick-start-failure.json */,
 				E1787DAF200E564B004CB3AF /* timezones.json */,
 				FFE247A920C891E5002DF3A2 /* WordPressComAuthenticateWithIDToken2FANeededSuccess.json */,
 				FFE247AB20C891E5002DF3A2 /* WordPressComAuthenticateWithIDTokenBearerTokenSuccess.json */,
@@ -1868,6 +1874,7 @@
 				93AC8ECE1ED32FD000900F5A /* stats-v1.1-latest-post-views.json in Resources */,
 				74A44DD81F13C7AC006CD8F4 /* remote-notification.json in Resources */,
 				740B23E31F17FB4200067A2A /* xmlrpc-metaweblog-editpost-change-type-failure.xml in Resources */,
+				9AEAA775215E774A00876E62 /* site-quick-start-failure.json in Resources */,
 				74D67F311F15C3740010C5ED /* site-followers-delete-failure.json in Resources */,
 				74B335E81F06F7200053A184 /* WordPressComRestApiFailUnauthorized.json in Resources */,
 				FFE247C220C9D749002DF3A2 /* reader-site-search-no-blog-or-feed-id.json in Resources */,
@@ -1900,6 +1907,7 @@
 				17BF9A7320C7E18200BF57D2 /* reader-site-search-failure.json in Resources */,
 				FFE247B120C891E6002DF3A2 /* WordPressComSocial2FACodeSuccess.json in Resources */,
 				93AC8ECF1ED32FD000900F5A /* stats-v1.1-latest-post.json in Resources */,
+				9AEAA774215E774A00876E62 /* site-quick-start-success.json in Resources */,
 				93BD275D1EE73442002BB00B /* me-auth-failure.json in Resources */,
 				74D67F361F15C3740010C5ED /* site-users-delete-site-owner-failure.json in Resources */,
 				74C473CB1EF33696009918F2 /* site-active-purchases-auth-failure.json in Resources */,

--- a/WordPressKit/SiteManagementServiceRemote.swift
+++ b/WordPressKit/SiteManagementServiceRemote.swift
@@ -100,6 +100,27 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
                 failure?(error)
         })
     }
+    
+    /// Trigger a masterbar notification celebrating completion of mobile quick start.
+    ///
+    /// - Parameters:
+    ///   - siteID: The WordPress.com ID of the site.
+    ///   - success: Optional success block
+    ///   - failure: Optional failure block with NSError
+    ///
+    @objc open func markQuickStartAsCompleted(_ siteID: NSNumber, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
+        let endpoint = "sites/\(siteID)/mobile-quick-start"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
+
+        wordPressComRestApi.POST(path,
+                                 parameters: nil,
+                                 success: { response, httpResponse in
+                                    success?()
+        },
+                                 failure: { error, httpResponse in
+                                    failure?(error)
+        })
+    }
 
     /// Keys found in API results
     ///

--- a/WordPressKit/SiteManagementServiceRemote.swift
+++ b/WordPressKit/SiteManagementServiceRemote.swift
@@ -108,7 +108,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
     ///   - success: Optional success block
     ///   - failure: Optional failure block with NSError
     ///
-    @objc open func markQuickStartAsCompleted(_ siteID: NSNumber, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
+    @objc open func markQuickStartChecklistAsComplete(_ siteID: NSNumber, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
         let endpoint = "sites/\(siteID)/mobile-quick-start"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 

--- a/WordPressKitTests/Mock Data/site-quick-start-failure.json
+++ b/WordPressKitTests/Mock Data/site-quick-start-failure.json
@@ -1,0 +1,4 @@
+{
+    "error":"unknown_error",
+    "message":"Unknown error"
+}

--- a/WordPressKitTests/Mock Data/site-quick-start-success.json
+++ b/WordPressKitTests/Mock Data/site-quick-start-success.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/WordPressKitTests/SiteManagementServiceRemoteTests.swift
+++ b/WordPressKitTests/SiteManagementServiceRemoteTests.swift
@@ -26,11 +26,15 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
     let getActivePurchasesAuthFailureMockFilename           = "site-active-purchases-auth-failure.json"
     let getActivePurchasesBadJsonFailureMockFilename        = "site-active-purchases-bad-json-failure.json"
 
+    let markQuickStartAsCompletedSuccessMockFilename        = "site-quick-start-success.json"
+    let markQuickStartAsCompletedFailureMockFilename        = "site-quick-start-failure.json"
+
     // MARK: - Properties
 
     var siteDeleteEndpoint: String { return "sites/\(siteID)/delete" }
     var siteExportStartEndpoint: String { return "sites/\(siteID)/exports/start" }
     var sitePurchasesEndpoint: String { return "sites/\(siteID)/purchases" }
+    var siteMarkQuickStartAsCompletedEndPoint: String { return "sites/\(siteID)/mobile-quick-start" }
 
     var remote: SiteManagementServiceRemote!
 
@@ -419,6 +423,36 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         })
 
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+    
+    // MARK: - Mark Site Quick Start As Completed Tests
+    
+    func testMarkQuickStartAsCompletedSuccess() {
+        let expect = expectation(description: "Mark Site Quick Start as Completed success test")
+        
+        stubRemoteResponse(siteMarkQuickStartAsCompletedEndPoint, filename: markQuickStartAsCompletedSuccessMockFilename, contentType: .ApplicationJSON)
+        remote.markQuickStartAsCompleted(NSNumber(value: Int32(siteID)), success: {
+            expect.fulfill()
+        }, failure: { error in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+    
+    func testMarkQuickStartAsCompletedFailure() {
+        let expect = expectation(description: "Mark Site Quick Start as Completed failure test")
+        
+        stubRemoteResponse(siteMarkQuickStartAsCompletedEndPoint, filename: markQuickStartAsCompletedFailureMockFilename, contentType: .ApplicationJSON, status: 403)
+        remote.markQuickStartAsCompleted(NSNumber(value: Int32(siteID)), success: {
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        }, failure: { error in
+            expect.fulfill()
+        })
+        
         waitForExpectations(timeout: timeout, handler: nil)
     }
 

--- a/WordPressKitTests/SiteManagementServiceRemoteTests.swift
+++ b/WordPressKitTests/SiteManagementServiceRemoteTests.swift
@@ -432,7 +432,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Mark Site Quick Start as Completed success test")
         
         stubRemoteResponse(siteMarkQuickStartAsCompletedEndPoint, filename: markQuickStartAsCompletedSuccessMockFilename, contentType: .ApplicationJSON)
-        remote.markQuickStartAsCompleted(NSNumber(value: Int32(siteID)), success: {
+        remote.markQuickStartChecklistAsComplete(NSNumber(value: Int32(siteID)), success: {
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -446,7 +446,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Mark Site Quick Start as Completed failure test")
         
         stubRemoteResponse(siteMarkQuickStartAsCompletedEndPoint, filename: markQuickStartAsCompletedFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.markQuickStartAsCompleted(NSNumber(value: Int32(siteID)), success: {
+        remote.markQuickStartChecklistAsComplete(NSNumber(value: Int32(siteID)), success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in


### PR DESCRIPTION
This PR adds `markQuickStartChecklistAsComplete` function to the `SiteManagementServiceRemote`, in order to trigger a masterbar notification celebrating completion of mobile quick start.

**To Test:**
- Run Unit Test