### PR TITLE
Revised podspec to use optimistic version of WordPressShared dependency

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -18,6 +18,6 @@ target 'WordPressKit' do
     pod 'OHHTTPStubs', '6.1.0'
     pod 'OHHTTPStubs/Swift', '6.1.0'
     pod 'OCMock', '~> 3.4.2'
-    pod 'WordPressShared', '1.1.1-beta.2'
+    pod 'WordPressShared', '1.1.1-beta.4'
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -32,9 +32,9 @@ PODS:
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (= 1.1.1-beta.2)
+    - WordPressShared (~> 1.1.1-beta.4)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.1.1-beta.2):
+  - WordPressShared (1.1.1-beta.4):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - wpxmlrpc (0.8.3)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - WordPressKit (from `./`)
-  - WordPressShared (= 1.1.1-beta.2)
+  - WordPressShared (= 1.1.1-beta.4)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -70,10 +70,10 @@ SPEC CHECKSUMS:
   OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: e32079ad12f2f1a5791a126af518096bd940f5b0
-  WordPressShared: c4d4356a06fc73bde9b782f26768d42e62a330ef
+  WordPressKit: e71c993dbd909006b7032cb8bed783ecf2907d18
+  WordPressShared: fc613aa29351c73677c421daacb36eacf53f100d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 86b5d1ec95c00c49d7440b352dba6b896fa7157d
+PODFILE CHECKSUM: c725572e316775a133097acaac2bef6747c44fd0
 
 COCOAPODS: 1.5.3

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.7.3'
   s.dependency 'CocoaLumberjack', '3.4.2'
-  s.dependency 'WordPressShared', '1.1.1-beta.2'
+  s.dependency 'WordPressShared', '~> 1.1.1-beta.4'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.3'
   s.dependency 'UIDeviceIdentifier', '~> 0.4'


### PR DESCRIPTION
This change supports [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/10210).