### PR TITLE
Incremented podspec version

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.1-beta.2"
+  s.version       = "1.4.1-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
Relaxing the dependency version in the `.podspec` requires an updated pod version to push to trunk.