### PR TITLE
Enable self-hosted to set parent page

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.2-beta.1):
+  - WordPressKit (1.4.2-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: f520d09ee011f11ee8017aee640025cb017b5612
+  WordPressKit: 1ff38b1bc95198b1cf40338461bdf0d71441fe42
   WordPressShared: fc613aa29351c73677c421daacb36eacf53f100d
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.2-beta.1"
+  s.version       = "1.4.2-beta.2"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 

--- a/WordPressKit/PostServiceRemoteXMLRPC.m
+++ b/WordPressKit/PostServiceRemoteXMLRPC.m
@@ -414,6 +414,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     }
     
     postParams[@"sticky"] = post.isStickyPost ? @"true" : @"false";
+    postParams[@"wp_page_parent_id"] = post.parentID ? post.parentID.stringValue : @"0";
 
     // Scheduled posts need to sync with a status of 'publish'.
     // Passing a status of 'future' will set the post status to 'draft'

--- a/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
@@ -10,6 +10,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
     let postTitle = "Hello world!"
     let postContent = "Welcome to WordPress."
     let postIsSticky = true
+    let postParentId: NSNumber = 2
 
     let getPostSuccessMockFilename              = "xmlrpc-wp-getpost-success.xml"
     let getPostBadXMLFailureFilename            = "xmlrpc-wp-getpost-bad-xml-failure.xml"
@@ -142,6 +143,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 post.title = postTitle
                 post.content = postContent
                 post.isStickyPost = postIsSticky
+                post.parentID = postParentId
                 return post
             }()
 
@@ -267,6 +269,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 post.title = postTitle
                 post.content = postContent
                 post.isStickyPost = postIsSticky
+                post.parentID = nil
                 return post
             }()
 


### PR DESCRIPTION
This PR enables self-hosted non jetpack blog to setup a parent page.
This feature was present only for wp.com and self-hosted jetpack blogs.

**To Test:**
- Run Unit Test