### PR TITLE
Allow WordPressShared to be updated easily

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -18,6 +18,6 @@ target 'WordPressKit' do
     pod 'OHHTTPStubs', '6.1.0'
     pod 'OHHTTPStubs/Swift', '6.1.0'
     pod 'OCMock', '~> 3.4.2'
-    pod 'WordPressShared', '1.2.0-beta.1'
+    pod 'WordPressShared', '~> 1.2.0-beta.1'
   end
 end

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.2-beta.3"
+  s.version       = "1.4.2-beta.4"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.7.3'
   s.dependency 'CocoaLumberjack', '3.4.2'
-  s.dependency 'WordPressShared', '1.2.0-beta.1'
+  s.dependency 'WordPressShared', '~> 1.2.0-beta.1'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.3'
   s.dependency 'UIDeviceIdentifier', '~> 0.4'


### PR DESCRIPTION
This adds `~>` to the `Podfile` and `podspec` so that we can update the `WordPressShared` pod independently of this one.

To test:
- In WPiOS change the `Podfile` to use this for WordPressKit: `pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => 'cc932dd33bcbee94a4c86ddd6fe8def350321e53'`
- Verify `pod install` still works
- Verify the app still builds