### PR TITLE
Fix revisions API path

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.3-beta.3):
+  - WordPressKit (1.4.3-beta.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: ebe9ee1dca7fbed0ff9193ac0b3e2d8862ea56f6
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: a34b4cdfb172bca3954f18a6dc299b9358a8861f
+  WordPressKit: 358fa43d76ee198f507dc4bd33ffb5b003c48568
   WordPressShared: 7ef0253d54989b195e020a74100a8500be0a4315
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.3-beta.3"
+  s.version       = "1.4.3-beta.4"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 

--- a/WordPressKit/PostServiceRemoteREST+Revisions.swift
+++ b/WordPressKit/PostServiceRemoteREST+Revisions.swift
@@ -6,7 +6,7 @@ public extension PostServiceRemoteREST {
                                  postId: Int,
                                  success: @escaping ([RemoteRevision]?) -> Void,
                                  failure: @escaping (Error?) -> Void) {
-        let endpoint = "/sites/\(siteId)/post/\(postId)/diffs"
+        let endpoint = "sites/\(siteId)/post/\(postId)/diffs"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         wordPressComRestApi.GET(path,
                                 parameters: nil,

--- a/WordPressKitTests/PostServiceRemoteRESTRevisionsTest.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTRevisionsTest.swift
@@ -13,7 +13,7 @@ class PostServiceRemoteRESTRevisionsTest: RemoteTestCase, RESTTestable {
     private var remote: PostServiceRemoteREST!
 
     private var performEndpoint: String {
-        return "/sites/\(siteId)/post/\(postId)/diffs"
+        return "sites/\(siteId)/post/\(postId)/diffs"
     }
     
     


### PR DESCRIPTION
This PR fix a typo within the Revisions API. I removed a `/` that caused a duplication.

**To Test:**
- Run `PostServiceRemoteRESTRevisionsTest` 