### PR TITLE
Blog: get all authors API

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -18,6 +18,6 @@ target 'WordPressKit' do
     pod 'OHHTTPStubs', '6.1.0'
     pod 'OHHTTPStubs/Swift', '6.1.0'
     pod 'OCMock', '~> 3.4.2'
-    pod 'WordPressShared', '~> 1.4'
+    pod 'WordPressShared', '~> 1.5.0-beta.1'
   end
 end

--- a/Podfile
+++ b/Podfile
@@ -18,6 +18,6 @@ target 'WordPressKit' do
     pod 'OHHTTPStubs', '6.1.0'
     pod 'OHHTTPStubs/Swift', '6.1.0'
     pod 'OCMock', '~> 3.4.2'
-    pod 'WordPressShared', '~> 1.5.0-beta.1'
+    pod 'WordPressShared', '~> 1.4'
   end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -32,9 +32,9 @@ PODS:
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (~> 1.4)
+    - WordPressShared (~> 1.5.0-beta.1)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.4.0):
+  - WordPressShared (1.5.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - wpxmlrpc (0.8.3)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - WordPressKit (from `./`)
-  - WordPressShared (~> 1.4)
+  - WordPressShared (~> 1.5.0-beta.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -70,10 +70,10 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 28a429d2c3ccc098e07633928bd82cb062f4f39b
-  WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
+  WordPressKit: e544957ac03714fb10b405be654399989bc20c12
+  WordPressShared: f6272345642887904f5aefff9d65d566e6c5d634
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: a6284d738a2e335fc7b8db139fe8a0ff19c1a138
+PODFILE CHECKSUM: 6a605a60c974b4fadce86636aafb3b3f0da57aaf
 
 COCOAPODS: 1.5.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.5-beta.1):
+  - WordPressKit (1.4.5-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 6aa14988654e00eb678771b696727944f71cc896
+  WordPressKit: 1f70b833c5cc54b2240a778612536e25ed65e6de
   WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.5-beta.2):
+  - WordPressKit (1.5.0-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 1f70b833c5cc54b2240a778612536e25ed65e6de
+  WordPressKit: 28a429d2c3ccc098e07633928bd82cb062f4f39b
   WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -32,9 +32,9 @@ PODS:
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
     - UIDeviceIdentifier (~> 0.4)
-    - WordPressShared (~> 1.5.0-beta.1)
+    - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.3)
-  - WordPressShared (1.5.0-beta.1):
+  - WordPressShared (1.4.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - wpxmlrpc (0.8.3)
@@ -44,7 +44,7 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - WordPressKit (from `./`)
-  - WordPressShared (~> 1.5.0-beta.1)
+  - WordPressShared (~> 1.4)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -70,10 +70,10 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: e544957ac03714fb10b405be654399989bc20c12
-  WordPressShared: f6272345642887904f5aefff9d65d566e6c5d634
+  WordPressKit: 28a429d2c3ccc098e07633928bd82cb062f4f39b
+  WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 
-PODFILE CHECKSUM: 6a605a60c974b4fadce86636aafb3b3f0da57aaf
+PODFILE CHECKSUM: a6284d738a2e335fc7b8db139fe8a0ff19c1a138
 
 COCOAPODS: 1.5.3

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.7.3'
   s.dependency 'CocoaLumberjack', '3.4.2'
-  s.dependency 'WordPressShared', '~> 1.4'
+  s.dependency 'WordPressShared', '~> 1.5.0-beta.1'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.3'
   s.dependency 'UIDeviceIdentifier', '~> 0.4'

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.5-beta.2"
+  s.version       = "1.5.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.5-beta.1"
+  s.version       = "1.4.5-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.7.3'
   s.dependency 'CocoaLumberjack', '3.4.2'
-  s.dependency 'WordPressShared', '~> 1.5.0-beta.1'
+  s.dependency 'WordPressShared', '~> 1.4'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.3'
   s.dependency 'UIDeviceIdentifier', '~> 0.4'

--- a/WordPressKit/BlogServiceRemote.h
+++ b/WordPressKit/BlogServiceRemote.h
@@ -14,13 +14,15 @@ typedef void (^SuccessHandler)(void);
 @protocol BlogServiceRemote <NSObject>
 
 /**
- *  @brief      Synchronizes a blog's authors.
- *
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
+ Synchronizes all blog's authors.
+
+ @param number Limit the total number of users returned.
+ @param success The block that will be executed on success.  Can be nil.
+ @param failure The block that will be executed on failure.  Can be nil.
  */
-- (void)getAuthorsWithSuccess:(UsersHandler)success
-                      failure:(void (^)(NSError *error))failure;
+- (void)getAllAuthorsWithNumber:(NSNumber *)number
+                        success:(UsersHandler)success
+                        failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Synchronizes a blog's post types.

--- a/WordPressKit/BlogServiceRemote.h
+++ b/WordPressKit/BlogServiceRemote.h
@@ -14,6 +14,15 @@ typedef void (^SuccessHandler)(void);
 @protocol BlogServiceRemote <NSObject>
 
 /**
+ *  @brief      Synchronizes a blog's authors.
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)getAuthorsWithSuccess:(UsersHandler)success
+                      failure:(void (^)(NSError *error))failure;
+
+/**
  Synchronizes all blog's authors.
 
  @param number Limit the total number of users returned.

--- a/WordPressKit/BlogServiceRemote.h
+++ b/WordPressKit/BlogServiceRemote.h
@@ -14,24 +14,13 @@ typedef void (^SuccessHandler)(void);
 @protocol BlogServiceRemote <NSObject>
 
 /**
- *  @brief      Synchronizes a blog's authors.
- *
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
- */
-- (void)getAuthorsWithSuccess:(UsersHandler)success
-                      failure:(void (^)(NSError *error))failure;
-
-/**
  Synchronizes all blog's authors.
 
- @param number Limit the total number of users returned.
  @param success The block that will be executed on success.  Can be nil.
  @param failure The block that will be executed on failure.  Can be nil.
  */
-- (void)getAllAuthorsWithNumber:(NSNumber *)number
-                        success:(UsersHandler)success
-                        failure:(void (^)(NSError *error))failure;
+- (void)getAllAuthorsWithSuccess:(UsersHandler)success
+                         failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Synchronizes a blog's post types.

--- a/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/BlogServiceRemoteREST.m
@@ -81,6 +81,15 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
                                failure:failure];
 }
 
+/**
+ This method is called recursively to fetch all authors.
+ The success block is called whenever the response users array is nil or empty.
+ 
+ @param remoteUsers The loaded remote users
+ @param offset The first n users to be skipped in the returned array
+ @param success The block that will be executed on success
+ @param failure The block that will be executed on failure
+ */
 - (void)getAllAuthorsWithRemoteUsers:(NSMutableArray <RemoteUser *>*)remoteUsers
                               offset:(NSNumber *)offset
                              success:(UsersHandler)success

--- a/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/BlogServiceRemoteREST.m
@@ -118,7 +118,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
                                   if (![responseUsers wp_isValidObject] || responseUsers.count == 0) {
                                       success([users copy]);
                                   } else {
-                                      [users addObjectsFromArray:[self usersFromJSONArray:users]];
+                                      [users addObjectsFromArray:[self usersFromJSONArray:responseUsers]];
                                       [self getAllAuthorsWithRemoteUsers:users
                                                                   offset:@(users.count)
                                                                  success:success

--- a/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/BlogServiceRemoteREST.m
@@ -72,6 +72,29 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 
 @implementation BlogServiceRemoteREST
 
+- (void)getAuthorsWithSuccess:(UsersHandler)success
+                      failure:(void (^)(NSError *error))failure
+{
+    NSDictionary *parameters = @{@"authors_only":@(YES)};
+    
+    NSString *path = [self pathForUsers];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    
+    [self.wordPressComRestApi GET:requestUrl
+                       parameters:parameters
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                              if (success) {
+                                  NSArray *users = [self usersFromJSONArray:responseObject[@"users"]];
+                                  success(users);
+                              }
+                          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                              if (failure) {
+                                  failure(error);
+                              }
+                          }];
+}
+
 - (void)getAllAuthorsWithNumber:(NSNumber *)number
                         success:(UsersHandler)success
                         failure:(void (^)(NSError *error))failure

--- a/WordPressKit/BlogServiceRemoteXMLRPC.m
+++ b/WordPressKit/BlogServiceRemoteXMLRPC.m
@@ -21,6 +21,16 @@ static NSString * const RemotePostTypePublicKey = @"public";
                                failure:failure];
 }
 
+
+/**
+ This method is called recursively to fetch all authors.
+ The success block is called whenever the response users array is nil or empty.
+
+ @param remoteUsers The loaded remote users
+ @param offset The first n users to be skipped in the returned array
+ @param success The block that will be executed on success
+ @param failure The block that will be executed on failure
+ */
 - (void)getAllAuthorsWithRemoteUsers:(NSMutableArray <RemoteUser *>*)remoteUsers
                               offset:(NSNumber *)offset
                              success:(UsersHandler)success

--- a/WordPressKit/BlogServiceRemoteXMLRPC.m
+++ b/WordPressKit/BlogServiceRemoteXMLRPC.m
@@ -12,6 +12,28 @@ static NSString * const RemotePostTypePublicKey = @"public";
 
 @implementation BlogServiceRemoteXMLRPC
 
+- (void)getAuthorsWithSuccess:(UsersHandler)success
+                      failure:(void (^)(NSError *))failure
+{
+    NSDictionary *filter = @{@"who":@"authors"};
+    NSArray *parameters = [self XMLRPCArgumentsWithExtra:filter];
+    [self.api callMethod:@"wp.getUsers"
+              parameters:parameters
+                 success:^(id responseObject, NSHTTPURLResponse *response) {
+                     NSArray <RemoteUser *> *users = [[responseObject allObjects] wp_map:^id(NSDictionary *xmlrpcUser) {
+                         return [self remoteUserFromXMLRPCDictionary:xmlrpcUser];
+                     }];
+                     if (success) {
+                         success(users);
+                     }
+                     
+                 } failure:^(NSError *error, NSHTTPURLResponse *response) {
+                     if (failure) {
+                         failure(error);
+                     }
+                 }];
+}
+
 - (void)getAllAuthorsWithNumber:(NSNumber *)number
                         success:(UsersHandler)success
                         failure:(void (^)(NSError *error))failure

--- a/WordPressKit/BlogServiceRemoteXMLRPC.m
+++ b/WordPressKit/BlogServiceRemoteXMLRPC.m
@@ -12,71 +12,45 @@ static NSString * const RemotePostTypePublicKey = @"public";
 
 @implementation BlogServiceRemoteXMLRPC
 
-- (void)getAuthorsWithSuccess:(UsersHandler)success
-                      failure:(void (^)(NSError *))failure
+- (void)getAllAuthorsWithSuccess:(UsersHandler)success
+                         failure:(void (^)(NSError *error))failure
 {
-    NSDictionary *filter = @{@"who":@"authors"};
-    NSArray *parameters = [self XMLRPCArgumentsWithExtra:filter];
-    [self.api callMethod:@"wp.getUsers"
-              parameters:parameters
-                 success:^(id responseObject, NSHTTPURLResponse *response) {
-                     NSArray <RemoteUser *> *users = [[responseObject allObjects] wp_map:^id(NSDictionary *xmlrpcUser) {
-                         return [self remoteUserFromXMLRPCDictionary:xmlrpcUser];
-                     }];
-                     if (success) {
-                         success(users);
-                     }
-                     
-                 } failure:^(NSError *error, NSHTTPURLResponse *response) {
-                     if (failure) {
-                         failure(error);
-                     }
-                 }];
-}
-
-- (void)getAllAuthorsWithNumber:(NSNumber *)number
-                        success:(UsersHandler)success
-                        failure:(void (^)(NSError *error))failure
-{
-    NSMutableArray *remoteUsers = [NSMutableArray array];
-    [self getAllAuthorsWithRemoteUsers:remoteUsers
-                                number:number
+    [self getAllAuthorsWithRemoteUsers:nil
                                 offset:nil
                                success:success
                                failure:failure];
 }
 
-- (void)getAllAuthorsWithRemoteUsers:(NSMutableArray <RemoteUser *>*)remoteusers
-                              number:(NSNumber *)number
+- (void)getAllAuthorsWithRemoteUsers:(NSMutableArray <RemoteUser *>*)remoteUsers
                               offset:(NSNumber *)offset
                              success:(UsersHandler)success
                              failure:(void (^)(NSError *error))failure
 {
-    NSMutableDictionary *filter = [@{ @"who":@"authors" } mutableCopy];
+    NSMutableDictionary *filter = [@{ @"who":@"authors",
+                                      @"number": @(100)
+                                    } mutableCopy];
     
-    if (offset != nil) {
+    if ([offset wp_isValidObject]) {
         filter[@"offset"] = offset.stringValue;
-    }
-    
-    if (number != nil) {
-        filter[@"number"] = number.stringValue;
     }
     
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:filter];
     [self.api callMethod:@"wp.getUsers"
               parameters:parameters
                  success:^(id responseObject, NSHTTPURLResponse *response) {
-                     NSArray <RemoteUser *> *users = [[responseObject allObjects] wp_map:^id(NSDictionary *xmlrpcUser) {
+                     NSArray <RemoteUser *> *responseUsers = [[responseObject allObjects] wp_map:^id(NSDictionary *xmlrpcUser) {
                          return [self remoteUserFromXMLRPCDictionary:xmlrpcUser];
                      }];
+                     
+                     NSMutableArray *users = [remoteUsers wp_isValidObject] ? [remoteUsers mutableCopy] : [NSMutableArray array];
+                     
                      if (success) {
-                         if (users == nil || users.count == 0) {
-                             success(remoteusers);
+                         if (![responseUsers wp_isValidObject] || responseUsers.count == 0) {
+                             success([users copy]);
                          } else {
-                             [remoteusers addObjectsFromArray:users];
-                             [self getAllAuthorsWithRemoteUsers:remoteusers
-                                                         number:number
-                                                         offset:@(remoteusers.count)
+                             [users addObjectsFromArray:responseUsers];
+                             [self getAllAuthorsWithRemoteUsers:users
+                                                         offset:@(users.count)
                                                         success:success
                                                         failure:failure];
                          }

--- a/WordPressKitTests/BlogServiceRemoteRESTTests.m
+++ b/WordPressKitTests/BlogServiceRemoteRESTTests.m
@@ -43,8 +43,9 @@ static NSTimeInterval const TestExpectationTimeout = 5;
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
 
-    [service getAuthorsWithSuccess:^(NSArray<RemoteUser *> *users) {}
-                           failure:^(NSError *error) {}];
+    [service getAllAuthorsWithNumber:@(50)
+                             success:^(NSArray<RemoteUser *> *users) {}
+                             failure:^(NSError *error) {}];
 }
 
 #pragma mark - Synchronizing site details for a blog

--- a/WordPressKitTests/BlogServiceRemoteRESTTests.m
+++ b/WordPressKitTests/BlogServiceRemoteRESTTests.m
@@ -43,9 +43,8 @@ static NSTimeInterval const TestExpectationTimeout = 5;
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
 
-    [service getAllAuthorsWithNumber:@(50)
-                             success:^(NSArray<RemoteUser *> *users) {}
-                             failure:^(NSError *error) {}];
+    [service getAllAuthorsWithSuccess:^(NSArray<RemoteUser *> *users) {}
+                              failure:^(NSError *error) {}];
 }
 
 #pragma mark - Synchronizing site details for a blog


### PR DESCRIPTION
This PR adds a new method to the `BlogRemoteService` which allows to load all the authors for a specific blog. This because the current method `- (void)getAuthorsWithSuccess:(UsersHandler)success failure:(void (^)(NSError *error))failure` loads only the default number (20) of authors without check if there are more.

The new method `- (void)getAllAuthorsWithNumber:(NSNumber *)number success:(UsersHandler)success failure:(void (^)(NSError *error))failure` recursively calls a private method passing the number of users returned and the offset.

This new API works with REST and XMLRPC services.

Using a SemVer spec I updated the new version to _1.5.0-beta.1_.

**To Test:**
- Simply run the Unit Test

**P.S.**
I also run a test on a WP iOS spike, testing with Wp.com blog, self-hosted jetpack and self-hosted non-jetpack blogs. Everything worked fine.