### PR TITLE
Add support for redeeming a cart and for changing a primary domain on a site.

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.4.5-beta.1):
+  - WordPressKit (1.5.0-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 6aa14988654e00eb678771b696727944f71cc896
+  WordPressKit: dd63cde48c272cbb4786dd2958adbc0a9e28a95b
   WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.4.5-beta.1"
+  s.version       = "1.5.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -59,6 +59,22 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 
+    public func setPrimaryDomainForSite(siteID: Int, domain: String, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        let endpoint = "sites/\(siteID)/domains/primary"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
+
+        let parameters: [String: AnyObject] = ["domain": domain as AnyObject]
+
+        wordPressComRestApi.POST(path, parameters: parameters,
+                                success: { response, _ in
+
+            success()
+        }, failure: { error, _ in
+
+            failure(error)
+        })
+    }
+
     @objc public func getStates(for countryCode: String,
                                 success: @escaping ([State]) -> Void,
                                 failure: @escaping (Error) -> Void) {


### PR DESCRIPTION
This adds support for the WPKit to 

a) redeem a cart (using credits), i.e. to get a free bundled domain with your plan
b) change a primary domain on a site.

To test: 

Check out a counterpart WPiOS PR that's gonna go up in 3...2...1.. 