### PR TITLE
Fix/xmlrpc sticky post

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.5.0-beta.2):
+  - WordPressKit (1.5.1.beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: dd63cde48c272cbb4786dd2958adbc0a9e28a95b
+  WordPressKit: c149fcf74fc37836349f825d4ef1771079243ed3
   WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.5.0"
+  s.version       = "1.5.1.beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -363,8 +363,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     post.commentCount = [jsonPost numberForKeyPath:@"discussion.comment_count"] ?: @0;
     post.likeCount = [jsonPost numberForKeyPath:@"like_count"] ?: @0;
 
-    NSNumber *stickyPost = [jsonPost numberForKeyPath:@"sticky"] ?: @0;
-    post.isStickyPost = stickyPost.boolValue;
+    post.isStickyPost = [jsonPost numberForKeyPath:@"sticky"];
     
     // FIXME: remove conversion once API is fixed #38-io
     // metadata should always be an array but it's returning false when there are no custom fields
@@ -440,7 +439,9 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     parameters[@"featured_image"] = post.postThumbnailID ? [post.postThumbnailID stringValue] : @"";
     parameters[@"metadata"] = [self metadataForPost:post];
     
-    parameters[@"sticky"] = post.isStickyPost ? @"true" : @"false";
+    if (post.isStickyPost != nil) {
+        parameters[@"sticky"] = post.isStickyPost.boolValue ? @"true" : @"false";
+    }
 
     // Scheduled posts need to sync with a status of 'publish'.
     // Passing a status of 'future' will set the post status to 'draft'

--- a/WordPressKit/PostServiceRemoteXMLRPC.m
+++ b/WordPressKit/PostServiceRemoteXMLRPC.m
@@ -320,8 +320,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     post.tags = [self tagsFromXMLRPCTermsArray:terms];
     post.categories = [self remoteCategoriesFromXMLRPCTermsArray:terms];
     
-    NSNumber *stickyPost = [xmlrpcDictionary numberForKeyPath:@"sticky"] ?: @0;
-    post.isStickyPost = stickyPost.boolValue;
+    post.isStickyPost = [xmlrpcDictionary numberForKeyPath:@"sticky"];
 
     // Pick an image to use for display
     if (post.postThumbnailPath) {
@@ -412,8 +411,11 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     if ([post.metadata count] > 0) {
         postParams[@"custom_fields"] = post.metadata;
     }
-    
-    postParams[@"sticky"] = post.isStickyPost ? @"true" : @"false";
+
+    if (post.isStickyPost != nil) {
+        postParams[@"sticky"] = post.isStickyPost.boolValue ? @"true" : @"false";
+    }
+
     postParams[@"wp_page_parent_id"] = post.parentID ? post.parentID.stringValue : @"0";
 
     // Scheduled posts need to sync with a status of 'publish'.

--- a/WordPressKit/RemotePost.h
+++ b/WordPressKit/RemotePost.h
@@ -42,8 +42,8 @@ extern NSString * const PostStatusDeleted;
 @property (nonatomic, strong) NSArray *revisions;
 @property (nonatomic, strong) NSArray *tags;
 @property (nonatomic, strong) NSString *pathForDisplayImage;
+@property (nonatomic, assign) NSNumber *isStickyPost;
 @property (nonatomic, assign) BOOL isFeaturedImageChanged;
-@property (nonatomic, assign) BOOL isStickyPost;
 
 /**
  Array of custom fields. Each value is a dictionary containing {ID, key, value}

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -144,7 +144,7 @@
     OCMStub([post password]).andReturn(@"Password");
     OCMStub([post type]).andReturn(@"Type");
     OCMStub([post metadata]).andReturn(@[]);
-    OCMStub([post isStickyPost]).andReturn(YES);
+    OCMStub([post isStickyPost]).andReturn(@1);
     OCMStub([post parentID]).andReturn(@38);
 
     XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:dotComID]);
@@ -189,7 +189,7 @@
     OCMStub([post password]).andReturn(@"Password");
     OCMStub([post type]).andReturn(@"Type");
     OCMStub([post metadata]).andReturn(@[]);
-    OCMStub([post isStickyPost]).andReturn(YES);
+    OCMStub([post isStickyPost]).andReturn(@0);
     OCMStub([post parentID]).andReturn(nil);
 
     XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:dotComID]);

--- a/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
@@ -9,7 +9,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
     let postID: NSNumber = 1
     let postTitle = "Hello world!"
     let postContent = "Welcome to WordPress."
-    let postIsSticky = true
+    let postIsSticky: NSNumber = 1
     let postParentId: NSNumber = 2
 
     let getPostSuccessMockFilename              = "xmlrpc-wp-getpost-success.xml"


### PR DESCRIPTION
Refs. [#10370](https://github.com/wordpress-mobile/WordPress-iOS/issues/10370)

This change set the `sticky` value only if it exists. It has been changed with a NSNumber instead of a BOOL. It fixes a bug when an authors can not publish posts on self hosted sites.

**To Test:**
- Run the Unit tests