### PR TITLE
Exposed new WPCOM service method for enhanced site creation

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.6.1-beta.1):
+  - WordPressKit (1.7.0-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 578231ba2fdd51b920c178a1a8e82aec09c6fa15
+  WordPressKit: 4c6b7320a5bc604cb3a87d8f80298f2fa0e14ab6
   WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.6.0-beta.1):
+  - WordPressKit (1.6.1-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 0a36f22916424c030cca58416e66560b7fc2bbbd
+  WordPressKit: 578231ba2fdd51b920c178a1a8e82aec09c6fa15
   WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.6.1-beta.1"
+  s.version       = "1.7.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.6.0-beta.1"
+  s.version       = "1.6.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -40,6 +40,11 @@
 		439A44DA2107C93000795ED7 /* RemotePlan_ApiVersion1_3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 439A44D92107C93000795ED7 /* RemotePlan_ApiVersion1_3.swift */; };
 		439A44DC2107CE3C00795ED7 /* site-plans-v3-empty-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 439A44DB2107CE3C00795ED7 /* site-plans-v3-empty-failure.json */; };
 		439A44DE2107CF6F00795ED7 /* site-plans-v3-bad-json-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 439A44DD2107CF6F00795ED7 /* site-plans-v3-bad-json-failure.json */; };
+		731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */; };
+		731BA83821DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83721DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift */; };
+		731BA83A21DED358000FDFCD /* site-creation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 731BA83921DECE93000FDFCD /* site-creation-success.json */; };
+		7328420421CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7328420321CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift */; };
+		7328420621CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7328420521CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift */; };
 		7403A2E41EF06ED500DED7DC /* AccountSettingsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7403A2E31EF06ED500DED7DC /* AccountSettingsRemote.swift */; };
 		7403A2E61EF06F7000DED7DC /* AccountSettingsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7403A2E51EF06F7000DED7DC /* AccountSettingsRemoteTests.swift */; };
 		7403A2F41EF06FEB00DED7DC /* me-settings-auth-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 7403A2E71EF06FEB00DED7DC /* me-settings-auth-failure.json */; };
@@ -479,6 +484,11 @@
 		439A44DD2107CF6F00795ED7 /* site-plans-v3-bad-json-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-plans-v3-bad-json-failure.json"; sourceTree = "<group>"; };
 		6C2A33D76FD1052D6F30466D /* Pods-WordPressKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.debug.xcconfig"; sourceTree = "<group>"; };
 		6F2E0CC4FA01B5475A378DA2 /* Pods-WordPressKitTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationRequestEncodingTests.swift; sourceTree = "<group>"; };
+		731BA83721DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationResponseDecodingTests.swift; sourceTree = "<group>"; };
+		731BA83921DECE93000FDFCD /* site-creation-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-creation-success.json"; sourceTree = "<group>"; };
+		7328420321CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemote+SiteCreation.swift"; sourceTree = "<group>"; };
+		7328420521CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemoteTests+SiteCreation.swift"; sourceTree = "<group>"; };
 		7403A2E31EF06ED500DED7DC /* AccountSettingsRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemote.swift; sourceTree = "<group>"; };
 		7403A2E51EF06F7000DED7DC /* AccountSettingsRemoteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountSettingsRemoteTests.swift; sourceTree = "<group>"; };
 		7403A2E71EF06FEB00DED7DC /* me-settings-auth-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = "me-settings-auth-failure.json"; path = "WordPressKitTests/me-settings-auth-failure.json"; sourceTree = SOURCE_ROOT; };
@@ -986,8 +996,11 @@
 		74C473AD1EF2F7BF009918F2 /* Site */ = {
 			isa = PBXGroup;
 			children = (
+				731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */,
+				731BA83721DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift */,
 				74C473AE1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift */,
 				E1787DB1200E5690004CB3AF /* TimeZoneServiceRemoteTests.swift */,
+				7328420521CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift */,
 			);
 			name = Site;
 			sourceTree = "<group>";
@@ -1255,6 +1268,7 @@
 				93F50A3E1F227C8900B5BEBA /* UsersServiceRemoteXMLRPC.swift */,
 				93F50A351F226B9300B5BEBA /* WordPressComServiceRemote.h */,
 				93F50A361F226B9300B5BEBA /* WordPressComServiceRemote.m */,
+				7328420321CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift */,
 				9368C7A11EC62F800092CE8E /* WPStatsServiceRemote.h */,
 				9368C7A21EC62F800092CE8E /* WPStatsServiceRemote.m */,
 				E182BF691FD961810001D850 /* Endpoint.swift */,
@@ -1470,6 +1484,7 @@
 				74C473C81EF335B8009918F2 /* site-active-purchases-empty-response.json */,
 				74C473C61EF334D4009918F2 /* site-active-purchases-none-active-success.json */,
 				74C473C41EF33242009918F2 /* site-active-purchases-two-active-success.json */,
+				731BA83921DECE93000FDFCD /* site-creation-success.json */,
 				74C473B21EF3204B009918F2 /* site-delete-auth-failure.json */,
 				74C473B41EF320CC009918F2 /* site-delete-bad-json-failure.json */,
 				74C473B81EF325F6009918F2 /* site-delete-missing-status-failure.json */,
@@ -1900,6 +1915,7 @@
 				E1787DB0200E564B004CB3AF /* timezones.json in Resources */,
 				93BD275E1EE73442002BB00B /* me-bad-json-failure.json in Resources */,
 				FFE247AF20C891E6002DF3A2 /* WordPressComOAuthWrongPasswordFail.json in Resources */,
+				731BA83A21DED358000FDFCD /* site-creation-success.json in Resources */,
 				829BA4301FACF187003ADEEA /* activity-rewind-status-restore-failure.json in Resources */,
 				74D67F391F15C3740010C5ED /* site-viewers-delete-bad-json.json in Resources */,
 				93BD27631EE73442002BB00B /* me-sites-visibility-bad-json-failure.json in Resources */,
@@ -2137,6 +2153,7 @@
 				7403A2E41EF06ED500DED7DC /* AccountSettingsRemote.swift in Sources */,
 				93C674E81EE8345300BFAF05 /* RemoteBlog.m in Sources */,
 				93BD27831EE73944002BB00B /* WordPressRSDParser.swift in Sources */,
+				7328420421CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift in Sources */,
 				826016F31F9FA17B00533B6C /* Activity.swift in Sources */,
 				7E3E7A4A20E443890075D159 /* Scanner+extensions.swift in Sources */,
 				742362E31F1025B400BD0A7F /* RemoteMenuLocation.m in Sources */,
@@ -2217,6 +2234,7 @@
 				74155E251EF87DDF00A06AEA /* ServiceRemoteRESTTests.m in Sources */,
 				74D67F0A1F15C24C0010C5ED /* PeopleServiceRemoteTests.swift in Sources */,
 				9F3E0BAE20873836009CB5BA /* ReaderTopicServiceRemoteTest+Subscriptions.swift in Sources */,
+				7328420621CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift in Sources */,
 				74585B901F0D51F900E7E667 /* DomainsServiceRemoteRESTTests.swift in Sources */,
 				9AB6D64A218727D60008F274 /* PostServiceRemoteRESTRevisionsTest.swift in Sources */,
 				7430C9BD1F192C0F0051B8E6 /* ReaderPostServiceRemoteTests.m in Sources */,
@@ -2232,6 +2250,7 @@
 				740B23D31F17F6BB00067A2A /* PostServiceRemoteXMLRPCTests.swift in Sources */,
 				93188D221F2264E60028ED4D /* TaxonomyServiceRemoteRESTTests.m in Sources */,
 				74FC6F3B1F191BB400112505 /* NotificationSyncServiceRemoteTests.swift in Sources */,
+				731BA83821DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift in Sources */,
 				74FA25F71F1FDA200044BC54 /* MediaServiceRemoteRESTTests.swift in Sources */,
 				7433BC051EFC4556002D9E92 /* PlanServiceRemoteTests.swift in Sources */,
 				740B23D61F17F7C100067A2A /* XMLRPCTestable.swift in Sources */,
@@ -2247,6 +2266,7 @@
 				93AC8EE11ED32FD000900F5A /* StatsStringUtilitiesTest.m in Sources */,
 				74C473AF1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift in Sources */,
 				74A44DD51F13C6D8006CD8F4 /* PushAuthenticationServiceRemoteTests.swift in Sources */,
+				731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */,
 				931924241F1662FA0069CBCC /* JSONLoader.swift in Sources */,
 				93AC8EE21ED32FD000900F5A /* WPStatsServiceRemoteTests.m in Sources */,
 				E1787DB2200E5690004CB3AF /* TimeZoneServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
@@ -1,0 +1,210 @@
+
+import Foundation
+
+// MARK: - SiteCreationRequest
+
+/// This value type is intended to express a site creation request.
+///
+public struct SiteCreationRequest: Encodable {
+    let segmentIdentifier: Int64
+    let verticalIdentifier: String?
+    let title: String
+    let tagline: String?
+    let siteURLString: String
+    let isPublic: Bool
+    let languageIdentifier: String
+    let shouldValidate: Bool
+    let clientIdentifier: String
+    let clientSecret: String
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        try container.encode(clientIdentifier, forKey: .clientIdentifier)
+        try container.encode(clientSecret, forKey: .clientSecret)
+        try container.encode(languageIdentifier, forKey: .languageIdentifier)
+        try container.encode(shouldValidate, forKey: .shouldValidate)
+        try container.encode(siteURLString, forKey: .siteURLString)
+        try container.encode(title, forKey: .title)
+
+        let publicValue = isPublic ? 1 : 0
+        try container.encode(publicValue, forKey: .isPublic)
+
+        let siteInfo: SiteInformation?
+        if let tagline = tagline {
+            siteInfo = SiteInformation(tagline: tagline)
+        } else {
+            siteInfo = nil
+        }
+        let options = SiteCreationOptions(segmentIdentifier: segmentIdentifier, verticalIdentifier: verticalIdentifier, siteInformation: siteInfo)
+
+        try container.encode(options, forKey: .options)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case clientIdentifier   = "client_id"
+        case clientSecret       = "client_secret"
+        case languageIdentifier = "lang_id"
+        case isPublic           = "public"
+        case shouldValidate     = "validate"
+        case siteURLString      = "blog_name"
+        case title              = "blog_title"
+        case options            = "options"
+    }
+}
+
+private struct SiteCreationOptions: Encodable {
+    let segmentIdentifier: Int64
+    let verticalIdentifier: String?
+    let siteInformation: SiteInformation?
+
+    enum CodingKeys: String, CodingKey {
+        case segmentIdentifier  = "site_segment"
+        case verticalIdentifier = "site_vertical"
+        case siteInformation    = "site_information"
+    }
+}
+
+private struct SiteInformation: Encodable {
+    let tagline: String?
+
+    enum CodingKeys: String, CodingKey {
+        case tagline = "site_tagline"
+    }
+}
+
+// MARK: - SiteCreationResponse
+
+/// This value type is intended to express a site creation response.
+///
+public struct SiteCreationResponse: Decodable {
+    struct CreatedSite: Decodable {
+        let identifier: String
+        let title: String
+        let urlString: String
+        let xmlrpcString: String
+
+        enum CodingKeys: String, CodingKey {
+            case identifier     = "blogid"
+            case title          = "blogname"
+            case urlString      = "url"
+            case xmlrpcString   = "xmlrpc"
+        }
+    }
+    
+    let createdSite: CreatedSite
+    let success: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case createdSite = "blog_details"
+        case success
+    }
+}
+
+// MARK: - WordPressComServiceRemote (Site Creation)
+
+/// Describes the errors that could arise during the process of site creation.
+///
+/// - requestEncodingFailure:   unable to encode the request parameters.
+/// - responseDecodingFailure:  unable to decode the server response.
+/// - serviceFailure:           the service returned an unexpected error.
+///
+public enum SiteCreationError: Error {
+    case requestEncodingFailure
+    case responseDecodingFailure
+    case serviceFailure
+}
+
+/// Advises the caller of results related to site creation requests.
+///
+/// - success: the site creation request succeeded with the accompanying result.
+/// - failure: the site creation request failed due to the accompanying error.
+///
+public enum SiteCreationResult {
+    case success(SiteCreationResponse)
+    case failure(SiteCreationError)
+}
+
+public typealias SiteCreationResultHandler = ((SiteCreationResult) -> ())
+
+/// Site creation services, exclusive to WordPress.com.
+/// 
+public extension WordPressComServiceRemote {
+    
+    /// Initiates a request to create a new WPCOM site.
+    ///
+    /// - Parameters:
+    ///   - request:    the value object with which to compose the request.
+    ///   - completion: a closure including the result of the site creation attempt.
+    ///
+    func createWPComSite(request: SiteCreationRequest, completion: @escaping SiteCreationResultHandler) {
+
+        let endpoint = "sites/new"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
+
+        let requestParameters: [String : AnyObject]
+        do {
+            requestParameters = try encodeRequestParameters(request: request)
+        } catch {
+            DDLogError("Failed to encode \(SiteCreationRequest.self) : \(error)")
+
+            completion(.failure(SiteCreationError.requestEncodingFailure))
+            return
+        }
+
+        wordPressComRestApi.POST(
+            path,
+            parameters: requestParameters,
+            success: { [weak self] responseObject, httpResponse in
+                DDLogInfo("\(responseObject) | \(String(describing: httpResponse))")
+
+                guard let self = self else {
+                    return
+                }
+
+                do {
+                    let response = try self.decodeResponse(responseObject: responseObject)
+                    completion(.success(response))
+                } catch {
+                    DDLogError("Failed to decode \(SiteCreationResponse.self) : \(error.localizedDescription)")
+                    completion(.failure(SiteCreationError.responseDecodingFailure))
+                }
+        },
+            failure: { error, httpResponse in
+                DDLogError("\(error) | \(String(describing: httpResponse))")
+                completion(.failure(SiteCreationError.serviceFailure))
+        })
+    }
+}
+
+// MARK: - Serialization support
+
+private extension WordPressComServiceRemote {
+
+    func encodeRequestParameters(request: SiteCreationRequest) throws -> [String : AnyObject] {
+
+        let encoder = JSONEncoder()
+
+        let jsonData = try encoder.encode(request)
+        let serializedJSON = try JSONSerialization.jsonObject(with: jsonData, options: [])
+
+        let requestParameters: [String : AnyObject]
+        if let jsonDictionary = serializedJSON as? [String : AnyObject] {
+            requestParameters = jsonDictionary
+        } else {
+            requestParameters = [:]
+        }
+
+        return requestParameters
+    }
+
+    func decodeResponse(responseObject: AnyObject) throws -> SiteCreationResponse {
+
+        let decoder = JSONDecoder()
+
+        let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
+        let response = try decoder.decode(SiteCreationResponse.self, from: data)
+
+        return response
+    }
+}

--- a/WordPressKitTests/Mock Data/site-creation-success.json
+++ b/WordPressKitTests/Mock Data/site-creation-success.json
@@ -1,0 +1,9 @@
+{
+    "success": true,
+    "blog_details": {
+        "url": "https://10711c.wordpress.com/",
+        "blogid": "156355635",
+        "blogname": "10711c",
+        "xmlrpc": "https://10711c.wordpress.com/xmlrpc.php"
+    }
+}

--- a/WordPressKitTests/SiteCreationRequestEncodingTests.swift
+++ b/WordPressKitTests/SiteCreationRequestEncodingTests.swift
@@ -84,7 +84,7 @@ class SiteCreationRequestEncodingTests: XCTestCase {
         XCTAssertNotNil(jsonDictionary["validate"])
     }
 
-    func testSiteCreationRequestEncoding_WorksWithoutValidation() {
+    func testSiteCreationRequestEncoding_WorksWithValidate_SetToFalse() {
         // Given
         let request = SiteCreationRequest(
             segmentIdentifier: 1,
@@ -124,7 +124,7 @@ class SiteCreationRequestEncodingTests: XCTestCase {
         XCTAssertNotNil(jsonDictionary["validate"])
     }
 
-    func testSiteCreationRequestEncoding_WorksSansVertical() {
+    func testSiteCreationRequestEncoding_WorksWithoutVertical() {
         // Given
         let request = SiteCreationRequest(
             segmentIdentifier: 1,
@@ -164,7 +164,7 @@ class SiteCreationRequestEncodingTests: XCTestCase {
         XCTAssertNotNil(jsonDictionary["validate"])
     }
 
-    func testSiteCreationRequestEncoding_WorksSansTagline() {
+    func testSiteCreationRequestEncoding_WorksWithoutTagline() {
         // Given
         let request = SiteCreationRequest(
             segmentIdentifier: 1,

--- a/WordPressKitTests/SiteCreationRequestEncodingTests.swift
+++ b/WordPressKitTests/SiteCreationRequestEncodingTests.swift
@@ -6,17 +6,28 @@ class SiteCreationRequestEncodingTests: XCTestCase {
 
     func testSiteCreationRequestEncoding_WithAllParameters_IsSuccessful() {
         // Given
+        let expectedSegmentId = Int64(1)
+        let expectedVerticalId = "p2v10"
+        let expectedBlogTitle = "Come on in"
+        let expectedTagline = "This is a site I like"
+        let expectedBlogName = "Cool Restaurant"
+        let expectedPublicValue = true
+        let expectedLanguageId = "TEST-ENGLISH"
+        let expectedValidateValue = true
+        let expectedClientId = "TEST-ID"
+        let expectedClientSecret = "TEST-SECRET"
+
         let request = SiteCreationRequest(
-            segmentIdentifier: 1,
-            verticalIdentifier: "p2v10",
-            title: "Come on in",
-            tagline: "This is a site I like",
-            siteURLString: "Cool Restaurant",
-            isPublic: true,
-            languageIdentifier: "TEST-ENGLISH",
-            shouldValidate: true,
-            clientIdentifier: "TEST-ID",
-            clientSecret: "TEST-SECRET"
+            segmentIdentifier: expectedSegmentId,
+            verticalIdentifier: expectedVerticalId,
+            title: expectedBlogTitle,
+            tagline: expectedTagline,
+            siteURLString: expectedBlogName,
+            isPublic: expectedPublicValue,
+            languageIdentifier: expectedLanguageId,
+            shouldValidate: expectedValidateValue,
+            clientIdentifier: expectedClientId,
+            clientSecret: expectedClientSecret
         )
 
         // When
@@ -34,29 +45,75 @@ class SiteCreationRequestEncodingTests: XCTestCase {
         let jsonDictionary = serializedJSON as! [String : AnyObject]
 
         // Then
-        XCTAssertNotNil(jsonDictionary["blog_name"])
-        XCTAssertNotNil(jsonDictionary["blog_title"])
-        XCTAssertNotNil(jsonDictionary["client_id"])
-        XCTAssertNotNil(jsonDictionary["client_secret"])
-        XCTAssertNotNil(jsonDictionary["public"])
-        XCTAssertNotNil(jsonDictionary["lang_id"])
-        XCTAssertNotNil(jsonDictionary["options"])
-        XCTAssertNotNil(jsonDictionary["validate"])
+        let actualBlogName = jsonDictionary["blog_name"] as? String
+        XCTAssertNotNil(actualBlogName)
+        XCTAssertEqual(expectedBlogName, actualBlogName!)
+
+        let actualBlogTitle = jsonDictionary["blog_title"] as? String
+        XCTAssertNotNil(actualBlogTitle)
+        XCTAssertEqual(expectedBlogTitle, actualBlogTitle!)
+
+        let actualClientId = jsonDictionary["client_id"] as? String
+        XCTAssertNotNil(actualClientId)
+        XCTAssertEqual(expectedClientId, actualClientId!)
+
+        let actualClientSecret = jsonDictionary["client_secret"] as? String
+        XCTAssertNotNil(actualClientSecret)
+        XCTAssertEqual(expectedClientSecret, actualClientSecret!)
+
+        let actualPublicValue = jsonDictionary["public"] as? Bool
+        XCTAssertNotNil(actualPublicValue)
+        XCTAssertEqual(expectedPublicValue, actualPublicValue!)
+
+        let actualLanguageId = jsonDictionary["lang_id"] as? String
+        XCTAssertNotNil(actualLanguageId)
+
+        let actualValidateValue = jsonDictionary["validate"] as? Bool
+        XCTAssertNotNil(actualValidateValue)
+
+        let actualOptions = jsonDictionary["options"] as? [String : AnyObject]
+        XCTAssertNotNil(actualOptions)
+
+        let actualSegmentId = actualOptions!["site_segment"] as? Int64
+        XCTAssertNotNil(actualSegmentId)
+        XCTAssertEqual(expectedSegmentId, actualSegmentId!)
+
+        let actualVerticalId = actualOptions!["site_vertical"] as? String
+        XCTAssertNotNil(actualVerticalId)
+        XCTAssertEqual(expectedVerticalId, actualVerticalId!)
+
+        let actualSiteInfo = actualOptions!["site_information"] as? [String : AnyObject]
+        XCTAssertNotNil(actualSiteInfo)
+
+        let actualTagline = actualSiteInfo!["site_tagline"] as? String
+        XCTAssertNotNil(actualTagline)
+        XCTAssertEqual(expectedTagline, actualTagline!)
     }
 
     func testSiteCreationRequestEncoding_WorksWithPrivate() {
         // Given
+        let expectedSegmentId = Int64(1)
+        let expectedVerticalId = "p2v10"
+        let expectedBlogTitle = "Come on in"
+        let expectedTagline = "This is a site I like"
+        let expectedBlogName = "Cool Restaurant"
+        let expectedPublicValue = false
+        let expectedLanguageId = "TEST-ENGLISH"
+        let expectedValidateValue = true
+        let expectedClientId = "TEST-ID"
+        let expectedClientSecret = "TEST-SECRET"
+
         let request = SiteCreationRequest(
-            segmentIdentifier: 1,
-            verticalIdentifier: "p2v10",
-            title: "Come on in",
-            tagline: "This is a site I like",
-            siteURLString: "Cool Restaurant",
-            isPublic: false,
-            languageIdentifier: "TEST-ENGLISH",
-            shouldValidate: true,
-            clientIdentifier: "TEST-ID",
-            clientSecret: "TEST-SECRET"
+            segmentIdentifier: expectedSegmentId,
+            verticalIdentifier: expectedVerticalId,
+            title: expectedBlogTitle,
+            tagline: expectedTagline,
+            siteURLString: expectedBlogName,
+            isPublic: expectedPublicValue,
+            languageIdentifier: expectedLanguageId,
+            shouldValidate: expectedValidateValue,
+            clientIdentifier: expectedClientId,
+            clientSecret: expectedClientSecret
         )
 
         // When
@@ -74,29 +131,75 @@ class SiteCreationRequestEncodingTests: XCTestCase {
         let jsonDictionary = serializedJSON as! [String : AnyObject]
 
         // Then
-        XCTAssertNotNil(jsonDictionary["blog_name"])
-        XCTAssertNotNil(jsonDictionary["blog_title"])
-        XCTAssertNotNil(jsonDictionary["client_id"])
-        XCTAssertNotNil(jsonDictionary["client_secret"])
-        XCTAssertNotNil(jsonDictionary["public"])
-        XCTAssertNotNil(jsonDictionary["lang_id"])
-        XCTAssertNotNil(jsonDictionary["options"])
-        XCTAssertNotNil(jsonDictionary["validate"])
+        let actualBlogName = jsonDictionary["blog_name"] as? String
+        XCTAssertNotNil(actualBlogName)
+        XCTAssertEqual(expectedBlogName, actualBlogName!)
+
+        let actualBlogTitle = jsonDictionary["blog_title"] as? String
+        XCTAssertNotNil(actualBlogTitle)
+        XCTAssertEqual(expectedBlogTitle, actualBlogTitle!)
+
+        let actualClientId = jsonDictionary["client_id"] as? String
+        XCTAssertNotNil(actualClientId)
+        XCTAssertEqual(expectedClientId, actualClientId!)
+
+        let actualClientSecret = jsonDictionary["client_secret"] as? String
+        XCTAssertNotNil(actualClientSecret)
+        XCTAssertEqual(expectedClientSecret, actualClientSecret!)
+
+        let actualPublicValue = jsonDictionary["public"] as? Bool
+        XCTAssertNotNil(actualPublicValue)
+        XCTAssertEqual(expectedPublicValue, actualPublicValue!)
+
+        let actualLanguageId = jsonDictionary["lang_id"] as? String
+        XCTAssertNotNil(actualLanguageId)
+
+        let actualValidateValue = jsonDictionary["validate"] as? Bool
+        XCTAssertNotNil(actualValidateValue)
+
+        let actualOptions = jsonDictionary["options"] as? [String : AnyObject]
+        XCTAssertNotNil(actualOptions)
+
+        let actualSegmentId = actualOptions!["site_segment"] as? Int64
+        XCTAssertNotNil(actualSegmentId)
+        XCTAssertEqual(expectedSegmentId, actualSegmentId!)
+
+        let actualVerticalId = actualOptions!["site_vertical"] as? String
+        XCTAssertNotNil(actualVerticalId)
+        XCTAssertEqual(expectedVerticalId, actualVerticalId!)
+
+        let actualSiteInfo = actualOptions!["site_information"] as? [String : AnyObject]
+        XCTAssertNotNil(actualSiteInfo)
+
+        let actualTagline = actualSiteInfo!["site_tagline"] as? String
+        XCTAssertNotNil(actualTagline)
+        XCTAssertEqual(expectedTagline, actualTagline!)
     }
 
     func testSiteCreationRequestEncoding_WorksWithValidate_SetToFalse() {
         // Given
+        let expectedSegmentId = Int64(1)
+        let expectedVerticalId = "p2v10"
+        let expectedBlogTitle = "Come on in"
+        let expectedTagline = "This is a site I like"
+        let expectedBlogName = "Cool Restaurant"
+        let expectedPublicValue = true
+        let expectedLanguageId = "TEST-ENGLISH"
+        let expectedValidateValue = false
+        let expectedClientId = "TEST-ID"
+        let expectedClientSecret = "TEST-SECRET"
+
         let request = SiteCreationRequest(
-            segmentIdentifier: 1,
-            verticalIdentifier: "p2v10",
-            title: "Come on in",
-            tagline: "This is a site I like",
-            siteURLString: "Cool Restaurant",
-            isPublic: true,
-            languageIdentifier: "TEST-ENGLISH",
-            shouldValidate: false,
-            clientIdentifier: "TEST-ID",
-            clientSecret: "TEST-SECRET"
+            segmentIdentifier: expectedSegmentId,
+            verticalIdentifier: expectedVerticalId,
+            title: expectedBlogTitle,
+            tagline: expectedTagline,
+            siteURLString: expectedBlogName,
+            isPublic: expectedPublicValue,
+            languageIdentifier: expectedLanguageId,
+            shouldValidate: expectedValidateValue,
+            clientIdentifier: expectedClientId,
+            clientSecret: expectedClientSecret
         )
 
         // When
@@ -114,29 +217,75 @@ class SiteCreationRequestEncodingTests: XCTestCase {
         let jsonDictionary = serializedJSON as! [String : AnyObject]
 
         // Then
-        XCTAssertNotNil(jsonDictionary["blog_name"])
-        XCTAssertNotNil(jsonDictionary["blog_title"])
-        XCTAssertNotNil(jsonDictionary["client_id"])
-        XCTAssertNotNil(jsonDictionary["client_secret"])
-        XCTAssertNotNil(jsonDictionary["public"])
-        XCTAssertNotNil(jsonDictionary["lang_id"])
-        XCTAssertNotNil(jsonDictionary["options"])
-        XCTAssertNotNil(jsonDictionary["validate"])
+        let actualBlogName = jsonDictionary["blog_name"] as? String
+        XCTAssertNotNil(actualBlogName)
+        XCTAssertEqual(expectedBlogName, actualBlogName!)
+
+        let actualBlogTitle = jsonDictionary["blog_title"] as? String
+        XCTAssertNotNil(actualBlogTitle)
+        XCTAssertEqual(expectedBlogTitle, actualBlogTitle!)
+
+        let actualClientId = jsonDictionary["client_id"] as? String
+        XCTAssertNotNil(actualClientId)
+        XCTAssertEqual(expectedClientId, actualClientId!)
+
+        let actualClientSecret = jsonDictionary["client_secret"] as? String
+        XCTAssertNotNil(actualClientSecret)
+        XCTAssertEqual(expectedClientSecret, actualClientSecret!)
+
+        let actualPublicValue = jsonDictionary["public"] as? Bool
+        XCTAssertNotNil(actualPublicValue)
+        XCTAssertEqual(expectedPublicValue, actualPublicValue!)
+
+        let actualLanguageId = jsonDictionary["lang_id"] as? String
+        XCTAssertNotNil(actualLanguageId)
+
+        let actualValidateValue = jsonDictionary["validate"] as? Bool
+        XCTAssertNotNil(actualValidateValue)
+
+        let actualOptions = jsonDictionary["options"] as? [String : AnyObject]
+        XCTAssertNotNil(actualOptions)
+
+        let actualSegmentId = actualOptions!["site_segment"] as? Int64
+        XCTAssertNotNil(actualSegmentId)
+        XCTAssertEqual(expectedSegmentId, actualSegmentId!)
+
+        let actualVerticalId = actualOptions!["site_vertical"] as? String
+        XCTAssertNotNil(actualVerticalId)
+        XCTAssertEqual(expectedVerticalId, actualVerticalId!)
+
+        let actualSiteInfo = actualOptions!["site_information"] as? [String : AnyObject]
+        XCTAssertNotNil(actualSiteInfo)
+
+        let actualTagline = actualSiteInfo!["site_tagline"] as? String
+        XCTAssertNotNil(actualTagline)
+        XCTAssertEqual(expectedTagline, actualTagline!)
     }
 
     func testSiteCreationRequestEncoding_WorksWithoutVertical() {
         // Given
+        let expectedSegmentId = Int64(1)
+        let expectedVerticalId: String? = nil
+        let expectedBlogTitle = "Come on in"
+        let expectedTagline = "This is a site I like"
+        let expectedBlogName = "Cool Restaurant"
+        let expectedPublicValue = true
+        let expectedLanguageId = "TEST-ENGLISH"
+        let expectedValidateValue = true
+        let expectedClientId = "TEST-ID"
+        let expectedClientSecret = "TEST-SECRET"
+
         let request = SiteCreationRequest(
-            segmentIdentifier: 1,
-            verticalIdentifier: nil,
-            title: "Come on in",
-            tagline: "This is a site I like",
-            siteURLString: "Cool Restaurant",
-            isPublic: true,
-            languageIdentifier: "TEST-ENGLISH",
-            shouldValidate: false,
-            clientIdentifier: "TEST-ID",
-            clientSecret: "TEST-SECRET"
+            segmentIdentifier: expectedSegmentId,
+            verticalIdentifier: expectedVerticalId,
+            title: expectedBlogTitle,
+            tagline: expectedTagline,
+            siteURLString: expectedBlogName,
+            isPublic: expectedPublicValue,
+            languageIdentifier: expectedLanguageId,
+            shouldValidate: expectedValidateValue,
+            clientIdentifier: expectedClientId,
+            clientSecret: expectedClientSecret
         )
 
         // When
@@ -154,29 +303,74 @@ class SiteCreationRequestEncodingTests: XCTestCase {
         let jsonDictionary = serializedJSON as! [String : AnyObject]
 
         // Then
-        XCTAssertNotNil(jsonDictionary["blog_name"])
-        XCTAssertNotNil(jsonDictionary["blog_title"])
-        XCTAssertNotNil(jsonDictionary["client_id"])
-        XCTAssertNotNil(jsonDictionary["client_secret"])
-        XCTAssertNotNil(jsonDictionary["public"])
-        XCTAssertNotNil(jsonDictionary["lang_id"])
-        XCTAssertNotNil(jsonDictionary["options"])
-        XCTAssertNotNil(jsonDictionary["validate"])
+        let actualBlogName = jsonDictionary["blog_name"] as? String
+        XCTAssertNotNil(actualBlogName)
+        XCTAssertEqual(expectedBlogName, actualBlogName!)
+
+        let actualBlogTitle = jsonDictionary["blog_title"] as? String
+        XCTAssertNotNil(actualBlogTitle)
+        XCTAssertEqual(expectedBlogTitle, actualBlogTitle!)
+
+        let actualClientId = jsonDictionary["client_id"] as? String
+        XCTAssertNotNil(actualClientId)
+        XCTAssertEqual(expectedClientId, actualClientId!)
+
+        let actualClientSecret = jsonDictionary["client_secret"] as? String
+        XCTAssertNotNil(actualClientSecret)
+        XCTAssertEqual(expectedClientSecret, actualClientSecret!)
+
+        let actualPublicValue = jsonDictionary["public"] as? Bool
+        XCTAssertNotNil(actualPublicValue)
+        XCTAssertEqual(expectedPublicValue, actualPublicValue!)
+
+        let actualLanguageId = jsonDictionary["lang_id"] as? String
+        XCTAssertNotNil(actualLanguageId)
+
+        let actualValidateValue = jsonDictionary["validate"] as? Bool
+        XCTAssertNotNil(actualValidateValue)
+
+        let actualOptions = jsonDictionary["options"] as? [String : AnyObject]
+        XCTAssertNotNil(actualOptions)
+
+        let actualSegmentId = actualOptions!["site_segment"] as? Int64
+        XCTAssertNotNil(actualSegmentId)
+        XCTAssertEqual(expectedSegmentId, actualSegmentId!)
+
+        let actualVerticalId = actualOptions!["site_vertical"] as? String
+        XCTAssertNil(actualVerticalId)
+
+        let actualSiteInfo = actualOptions!["site_information"] as? [String : AnyObject]
+        XCTAssertNotNil(actualSiteInfo)
+
+        let actualTagline = actualSiteInfo!["site_tagline"] as? String
+        XCTAssertNotNil(actualTagline)
+        XCTAssertEqual(expectedTagline, actualTagline!)
     }
 
     func testSiteCreationRequestEncoding_WorksWithoutTagline() {
         // Given
+        let expectedSegmentId = Int64(1)
+        let expectedVerticalId = "p2v10"
+        let expectedBlogTitle = "Come on in"
+        let expectedTagline: String? = nil
+        let expectedBlogName = "Cool Restaurant"
+        let expectedPublicValue = true
+        let expectedLanguageId = "TEST-ENGLISH"
+        let expectedValidateValue = true
+        let expectedClientId = "TEST-ID"
+        let expectedClientSecret = "TEST-SECRET"
+
         let request = SiteCreationRequest(
-            segmentIdentifier: 1,
-            verticalIdentifier: "p2v10",
-            title: "Come on in",
-            tagline: nil,
-            siteURLString: "Cool Restaurant",
-            isPublic: true,
-            languageIdentifier: "TEST-ENGLISH",
-            shouldValidate: false,
-            clientIdentifier: "TEST-ID",
-            clientSecret: "TEST-SECRET"
+            segmentIdentifier: expectedSegmentId,
+            verticalIdentifier: expectedVerticalId,
+            title: expectedBlogTitle,
+            tagline: expectedTagline,
+            siteURLString: expectedBlogName,
+            isPublic: expectedPublicValue,
+            languageIdentifier: expectedLanguageId,
+            shouldValidate: expectedValidateValue,
+            clientIdentifier: expectedClientId,
+            clientSecret: expectedClientSecret
         )
 
         // When
@@ -194,13 +388,44 @@ class SiteCreationRequestEncodingTests: XCTestCase {
         let jsonDictionary = serializedJSON as! [String : AnyObject]
 
         // Then
-        XCTAssertNotNil(jsonDictionary["blog_name"])
-        XCTAssertNotNil(jsonDictionary["blog_title"])
-        XCTAssertNotNil(jsonDictionary["client_id"])
-        XCTAssertNotNil(jsonDictionary["client_secret"])
-        XCTAssertNotNil(jsonDictionary["public"])
-        XCTAssertNotNil(jsonDictionary["lang_id"])
-        XCTAssertNotNil(jsonDictionary["options"])
-        XCTAssertNotNil(jsonDictionary["validate"])
+        let actualBlogName = jsonDictionary["blog_name"] as? String
+        XCTAssertNotNil(actualBlogName)
+        XCTAssertEqual(expectedBlogName, actualBlogName!)
+
+        let actualBlogTitle = jsonDictionary["blog_title"] as? String
+        XCTAssertNotNil(actualBlogTitle)
+        XCTAssertEqual(expectedBlogTitle, actualBlogTitle!)
+
+        let actualClientId = jsonDictionary["client_id"] as? String
+        XCTAssertNotNil(actualClientId)
+        XCTAssertEqual(expectedClientId, actualClientId!)
+
+        let actualClientSecret = jsonDictionary["client_secret"] as? String
+        XCTAssertNotNil(actualClientSecret)
+        XCTAssertEqual(expectedClientSecret, actualClientSecret!)
+
+        let actualPublicValue = jsonDictionary["public"] as? Bool
+        XCTAssertNotNil(actualPublicValue)
+        XCTAssertEqual(expectedPublicValue, actualPublicValue!)
+
+        let actualLanguageId = jsonDictionary["lang_id"] as? String
+        XCTAssertNotNil(actualLanguageId)
+
+        let actualValidateValue = jsonDictionary["validate"] as? Bool
+        XCTAssertNotNil(actualValidateValue)
+
+        let actualOptions = jsonDictionary["options"] as? [String : AnyObject]
+        XCTAssertNotNil(actualOptions)
+
+        let actualSegmentId = actualOptions!["site_segment"] as? Int64
+        XCTAssertNotNil(actualSegmentId)
+        XCTAssertEqual(expectedSegmentId, actualSegmentId!)
+
+        let actualVerticalId = actualOptions!["site_vertical"] as? String
+        XCTAssertNotNil(actualVerticalId)
+        XCTAssertEqual(expectedVerticalId, actualVerticalId!)
+
+        let actualSiteInfo = actualOptions!["site_information"] as? [String : AnyObject]
+        XCTAssertNil(actualSiteInfo)
     }
 }

--- a/WordPressKitTests/SiteCreationRequestEncodingTests.swift
+++ b/WordPressKitTests/SiteCreationRequestEncodingTests.swift
@@ -1,0 +1,206 @@
+
+import XCTest
+@testable import WordPressKit
+
+class SiteCreationRequestEncodingTests: XCTestCase {
+
+    func testSiteCreationRequestEncoding_WithAllParameters_IsSuccessful() {
+        // Given
+        let request = SiteCreationRequest(
+            segmentIdentifier: 1,
+            verticalIdentifier: "p2v10",
+            title: "Come on in",
+            tagline: "This is a site I like",
+            siteURLString: "Cool Restaurant",
+            isPublic: true,
+            languageIdentifier: "TEST-ENGLISH",
+            shouldValidate: true,
+            clientIdentifier: "TEST-ID",
+            clientSecret: "TEST-SECRET"
+        )
+
+        // When
+        let encoder = JSONEncoder()
+
+        XCTAssertNoThrow(try encoder.encode(request))
+        let encodedJSON = try! encoder.encode(request)
+
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
+        let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
+
+        if let _ = serializedJSON as? [String : AnyObject] {} else {
+            XCTFail("Failed to encode a proper JSON dictionary!")
+        }
+        let jsonDictionary = serializedJSON as! [String : AnyObject]
+
+        // Then
+        XCTAssertNotNil(jsonDictionary["blog_name"])
+        XCTAssertNotNil(jsonDictionary["blog_title"])
+        XCTAssertNotNil(jsonDictionary["client_id"])
+        XCTAssertNotNil(jsonDictionary["client_secret"])
+        XCTAssertNotNil(jsonDictionary["public"])
+        XCTAssertNotNil(jsonDictionary["lang_id"])
+        XCTAssertNotNil(jsonDictionary["options"])
+        XCTAssertNotNil(jsonDictionary["validate"])
+    }
+
+    func testSiteCreationRequestEncoding_WorksWithPrivate() {
+        // Given
+        let request = SiteCreationRequest(
+            segmentIdentifier: 1,
+            verticalIdentifier: "p2v10",
+            title: "Come on in",
+            tagline: "This is a site I like",
+            siteURLString: "Cool Restaurant",
+            isPublic: false,
+            languageIdentifier: "TEST-ENGLISH",
+            shouldValidate: true,
+            clientIdentifier: "TEST-ID",
+            clientSecret: "TEST-SECRET"
+        )
+
+        // When
+        let encoder = JSONEncoder()
+
+        XCTAssertNoThrow(try encoder.encode(request))
+        let encodedJSON = try! encoder.encode(request)
+
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
+        let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
+
+        if let _ = serializedJSON as? [String : AnyObject] {} else {
+            XCTFail("Failed to encode a proper JSON dictionary!")
+        }
+        let jsonDictionary = serializedJSON as! [String : AnyObject]
+
+        // Then
+        XCTAssertNotNil(jsonDictionary["blog_name"])
+        XCTAssertNotNil(jsonDictionary["blog_title"])
+        XCTAssertNotNil(jsonDictionary["client_id"])
+        XCTAssertNotNil(jsonDictionary["client_secret"])
+        XCTAssertNotNil(jsonDictionary["public"])
+        XCTAssertNotNil(jsonDictionary["lang_id"])
+        XCTAssertNotNil(jsonDictionary["options"])
+        XCTAssertNotNil(jsonDictionary["validate"])
+    }
+
+    func testSiteCreationRequestEncoding_WorksWithoutValidation() {
+        // Given
+        let request = SiteCreationRequest(
+            segmentIdentifier: 1,
+            verticalIdentifier: "p2v10",
+            title: "Come on in",
+            tagline: "This is a site I like",
+            siteURLString: "Cool Restaurant",
+            isPublic: true,
+            languageIdentifier: "TEST-ENGLISH",
+            shouldValidate: false,
+            clientIdentifier: "TEST-ID",
+            clientSecret: "TEST-SECRET"
+        )
+
+        // When
+        let encoder = JSONEncoder()
+
+        XCTAssertNoThrow(try encoder.encode(request))
+        let encodedJSON = try! encoder.encode(request)
+
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
+        let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
+
+        if let _ = serializedJSON as? [String : AnyObject] {} else {
+            XCTFail("Failed to encode a proper JSON dictionary!")
+        }
+        let jsonDictionary = serializedJSON as! [String : AnyObject]
+
+        // Then
+        XCTAssertNotNil(jsonDictionary["blog_name"])
+        XCTAssertNotNil(jsonDictionary["blog_title"])
+        XCTAssertNotNil(jsonDictionary["client_id"])
+        XCTAssertNotNil(jsonDictionary["client_secret"])
+        XCTAssertNotNil(jsonDictionary["public"])
+        XCTAssertNotNil(jsonDictionary["lang_id"])
+        XCTAssertNotNil(jsonDictionary["options"])
+        XCTAssertNotNil(jsonDictionary["validate"])
+    }
+
+    func testSiteCreationRequestEncoding_WorksSansVertical() {
+        // Given
+        let request = SiteCreationRequest(
+            segmentIdentifier: 1,
+            verticalIdentifier: nil,
+            title: "Come on in",
+            tagline: "This is a site I like",
+            siteURLString: "Cool Restaurant",
+            isPublic: true,
+            languageIdentifier: "TEST-ENGLISH",
+            shouldValidate: false,
+            clientIdentifier: "TEST-ID",
+            clientSecret: "TEST-SECRET"
+        )
+
+        // When
+        let encoder = JSONEncoder()
+
+        XCTAssertNoThrow(try encoder.encode(request))
+        let encodedJSON = try! encoder.encode(request)
+
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
+        let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
+
+        if let _ = serializedJSON as? [String : AnyObject] {} else {
+            XCTFail("Failed to encode a proper JSON dictionary!")
+        }
+        let jsonDictionary = serializedJSON as! [String : AnyObject]
+
+        // Then
+        XCTAssertNotNil(jsonDictionary["blog_name"])
+        XCTAssertNotNil(jsonDictionary["blog_title"])
+        XCTAssertNotNil(jsonDictionary["client_id"])
+        XCTAssertNotNil(jsonDictionary["client_secret"])
+        XCTAssertNotNil(jsonDictionary["public"])
+        XCTAssertNotNil(jsonDictionary["lang_id"])
+        XCTAssertNotNil(jsonDictionary["options"])
+        XCTAssertNotNil(jsonDictionary["validate"])
+    }
+
+    func testSiteCreationRequestEncoding_WorksSansTagline() {
+        // Given
+        let request = SiteCreationRequest(
+            segmentIdentifier: 1,
+            verticalIdentifier: "p2v10",
+            title: "Come on in",
+            tagline: nil,
+            siteURLString: "Cool Restaurant",
+            isPublic: true,
+            languageIdentifier: "TEST-ENGLISH",
+            shouldValidate: false,
+            clientIdentifier: "TEST-ID",
+            clientSecret: "TEST-SECRET"
+        )
+
+        // When
+        let encoder = JSONEncoder()
+
+        XCTAssertNoThrow(try encoder.encode(request))
+        let encodedJSON = try! encoder.encode(request)
+
+        XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
+        let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
+
+        if let _ = serializedJSON as? [String : AnyObject] {} else {
+            XCTFail("Failed to encode a proper JSON dictionary!")
+        }
+        let jsonDictionary = serializedJSON as! [String : AnyObject]
+
+        // Then
+        XCTAssertNotNil(jsonDictionary["blog_name"])
+        XCTAssertNotNil(jsonDictionary["blog_title"])
+        XCTAssertNotNil(jsonDictionary["client_id"])
+        XCTAssertNotNil(jsonDictionary["client_secret"])
+        XCTAssertNotNil(jsonDictionary["public"])
+        XCTAssertNotNil(jsonDictionary["lang_id"])
+        XCTAssertNotNil(jsonDictionary["options"])
+        XCTAssertNotNil(jsonDictionary["validate"])
+    }
+}

--- a/WordPressKitTests/SiteCreationResponseDecodingTests.swift
+++ b/WordPressKitTests/SiteCreationResponseDecodingTests.swift
@@ -1,0 +1,33 @@
+
+import XCTest
+@testable import WordPressKit
+
+class SiteCreationResponseDecodingTests: XCTestCase {
+
+    func testSiteCreationResponseDecoding_IsSuccessful() {
+        // Given
+        let testClass: AnyClass = SiteCreationResponseDecodingTests.self
+        let bundle = Bundle(for: testClass)
+        let url = bundle.url(forResource: "site-creation-success", withExtension: "json")
+
+        XCTAssertNotNil(url)
+        let jsonURL = url!
+
+        XCTAssertNoThrow(try Data(contentsOf: jsonURL))
+        let jsonData = try! Data(contentsOf: jsonURL)
+
+        // When
+        let decoder = JSONDecoder()
+        XCTAssertNoThrow(try decoder.decode(SiteCreationResponse.self, from: jsonData))
+        let response = try! decoder.decode(SiteCreationResponse.self, from: jsonData)
+
+        // Then
+        XCTAssertTrue(response.success)
+
+        let site = response.createdSite
+        XCTAssertEqual(site.identifier, "156355635")
+        XCTAssertEqual(site.title, "10711c")
+        XCTAssertEqual(site.urlString, "https://10711c.wordpress.com/")
+        XCTAssertEqual(site.xmlrpcString, "https://10711c.wordpress.com/xmlrpc.php")
+    }
+}

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
@@ -1,0 +1,48 @@
+
+import XCTest
+@testable import WordPressKit
+
+class SiteCreationServiceTests: RemoteTestCase, RESTTestable {
+
+    func testSiteCreationRequest_Succeeds() {
+        // Given
+        let endpoint = "sites/new"
+        let fileName = "site-creation-success.json"
+        stubRemoteResponse(endpoint, filename: fileName, contentType: .ApplicationJSON)
+
+        let request = SiteCreationRequest(
+            segmentIdentifier: 1,
+            verticalIdentifier: "p2v10",
+            title: "Come on in",
+            tagline: "This is a site I like",
+            siteURLString: "Cool Restaurant",
+            isPublic: true,
+            languageIdentifier: "TEST-ENGLISH",
+            shouldValidate: true,
+            clientIdentifier: "TEST-ID",
+            clientSecret: "TEST-SECRET"
+        )
+
+        // When, Then
+        let siteCreationExpectation = expectation(description: "Initiate site creation request")
+        let remote = WordPressComServiceRemote(wordPressComRestApi: getRestApi())
+        remote.createWPComSite(request: request) { result in
+            siteCreationExpectation.fulfill()
+
+            switch result {
+            case .success(let response):
+                XCTAssertTrue(response.success)
+
+                let site = response.createdSite
+                XCTAssertEqual(site.identifier, "156355635")
+                XCTAssertEqual(site.title, "10711c")
+                XCTAssertEqual(site.urlString, "https://10711c.wordpress.com/")
+                XCTAssertEqual(site.xmlrpcString, "https://10711c.wordpress.com/xmlrpc.php")
+            case .failure(_):
+                XCTFail()
+            }
+        }
+
+        waitForExpectations(timeout: timeout)
+    }
+}

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
@@ -10,12 +10,15 @@ class SiteCreationServiceTests: RemoteTestCase, RESTTestable {
         let fileName = "site-creation-success.json"
         stubRemoteResponse(endpoint, filename: fileName, contentType: .ApplicationJSON)
 
+        let expectedTitle = "10711c"
+        let expectedUrlString = "https://10711c.wordpress.com/"
+
         let request = SiteCreationRequest(
             segmentIdentifier: 1,
             verticalIdentifier: "p2v10",
-            title: "Come on in",
+            title: expectedTitle,
             tagline: "This is a site I like",
-            siteURLString: "Cool Restaurant",
+            siteURLString: expectedUrlString,
             isPublic: true,
             languageIdentifier: "TEST-ENGLISH",
             shouldValidate: true,
@@ -35,9 +38,10 @@ class SiteCreationServiceTests: RemoteTestCase, RESTTestable {
 
                 let site = response.createdSite
                 XCTAssertEqual(site.identifier, "156355635")
-                XCTAssertEqual(site.title, "10711c")
-                XCTAssertEqual(site.urlString, "https://10711c.wordpress.com/")
+                XCTAssertEqual(site.title, expectedTitle)
+                XCTAssertEqual(site.urlString, expectedUrlString)
                 XCTAssertEqual(site.xmlrpcString, "https://10711c.wordpress.com/xmlrpc.php")
+
             case .failure(_):
                 XCTFail()
             }


### PR DESCRIPTION
### Description

Implements the service to fulfill the service implementation of [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/10711).

### Testing

1. Checkout the branch. Confirm that it builds & existing tests pass.

There no Step 2! Yet. 😄 Please allow me to explain.

### Explanation

There is an associated change to WPiOS noted in the aforementioned issue. That PR is forthcoming.

Moreover, the changes proposed to `sites/new` have not been implemented on the services side. This PR implements the specification agreed upon in `p9wMUP-bH-p2`. Any issues that arise will be identified & resolved during [integration testing](
https://github.com/wordpress-mobile/WordPress-iOS/issues/10712).