### PR TITLE
Ensure that all attributes of SiteCreationResponse are visible

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.7.0-beta.1):
+  - WordPressKit (1.7.0-beta.2):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 4c6b7320a5bc604cb3a87d8f80298f2fa0e14ab6
+  WordPressKit: e2791dc68dcd72bd97043edc06dc0d11acd53728
   WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.7.0-beta.1"
+  s.version       = "1.7.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
@@ -101,26 +101,28 @@ private struct SiteInformation: Encodable {
 /// This value type is intended to express a site creation response.
 ///
 public struct SiteCreationResponse: Decodable {
-    struct CreatedSite: Decodable {
-        let identifier: String
-        let title: String
-        let urlString: String
-        let xmlrpcString: String
-
-        enum CodingKeys: String, CodingKey {
-            case identifier     = "blogid"
-            case title          = "blogname"
-            case urlString      = "url"
-            case xmlrpcString   = "xmlrpc"
-        }
-    }
-    
-    let createdSite: CreatedSite
-    let success: Bool
+    public let createdSite: CreatedSite
+    public let success: Bool
 
     enum CodingKeys: String, CodingKey {
         case createdSite = "blog_details"
         case success
+    }
+}
+
+/// This value type describes the site that was created.
+///
+public struct CreatedSite: Decodable {
+    public let identifier: String
+    public let title: String
+    public let urlString: String
+    public let xmlrpcString: String
+
+    enum CodingKeys: String, CodingKey {
+        case identifier     = "blogid"
+        case title          = "blogname"
+        case urlString      = "url"
+        case xmlrpcString   = "xmlrpc"
     }
 }
 


### PR DESCRIPTION
### Description

This PR continues the implementation of this [WPiOS issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/10711), beginning with #63 and continuing with #64.

Unfortunately during #64, I overlooked the need to designate `CreatedSite` & `SiteCreationResponse` as `public`. This PR corrects that oversight.

### Testing

- Checkout the branch. Confirm that it builds & existing tests pass.
- For additional assurance, consider checking out the WPiOS branch `issue/10711-wip` and verify that it builds and that tests pass.