### PR TITLE
Exposed new WPCOM service method for Verticals user prompts

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (0.5.0)
-  - WordPressKit (1.7.0-beta.3):
+  - WordPressKit (1.7.0-beta.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: 6fb17936573479ebd0e1512e3eec1518f97a5ab5
+  WordPressKit: 82eb3086856865052b4f9673c7cd7e4e72b8bd93
   WordPressShared: f55be10963c8f6dbbc8e896450805ba1dd5353f7
   wpxmlrpc: bfc572f62ce7ee897f6f38b098d2ba08732ecef4
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.7.0-beta.3"
+  s.version       = "1.7.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		731BA83A21DED358000FDFCD /* site-creation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 731BA83921DECE93000FDFCD /* site-creation-success.json */; };
 		7328420421CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7328420321CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift */; };
 		7328420621CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7328420521CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift */; };
+		736C971021E80D48007A4200 /* SiteVerticalsPromptResponseDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736C970F21E80D48007A4200 /* SiteVerticalsPromptResponseDecodingTests.swift */; };
+		73A2F38A21E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A2F38921E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift */; };
+		73A2F38D21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A2F38C21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift */; };
+		73A2F38E21E7FD9B00388609 /* site-verticals-prompt.json in Resources */ = {isa = PBXBuildFile; fileRef = 73A2F38B21E7FC2A00388609 /* site-verticals-prompt.json */; };
 		73D592FB21E550D300E4CF84 /* site-verticals-multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D592F821E550D200E4CF84 /* site-verticals-multiple.json */; };
 		73D592FC21E550D300E4CF84 /* site-verticals-single.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D592F921E550D300E4CF84 /* site-verticals-single.json */; };
 		73D592FD21E550D300E4CF84 /* site-verticals-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D592FA21E550D300E4CF84 /* site-verticals-empty.json */; };
@@ -497,6 +501,10 @@
 		731BA83921DECE93000FDFCD /* site-creation-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-creation-success.json"; sourceTree = "<group>"; };
 		7328420321CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemote+SiteCreation.swift"; sourceTree = "<group>"; };
 		7328420521CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemoteTests+SiteCreation.swift"; sourceTree = "<group>"; };
+		736C970F21E80D48007A4200 /* SiteVerticalsPromptResponseDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteVerticalsPromptResponseDecodingTests.swift; sourceTree = "<group>"; };
+		73A2F38921E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemote+SiteVerticalsPrompt.swift"; sourceTree = "<group>"; };
+		73A2F38B21E7FC2A00388609 /* site-verticals-prompt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-verticals-prompt.json"; sourceTree = "<group>"; };
+		73A2F38C21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift"; sourceTree = "<group>"; };
 		73D592F821E550D200E4CF84 /* site-verticals-multiple.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-verticals-multiple.json"; sourceTree = "<group>"; };
 		73D592F921E550D300E4CF84 /* site-verticals-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-verticals-single.json"; sourceTree = "<group>"; };
 		73D592FA21E550D300E4CF84 /* site-verticals-empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-verticals-empty.json"; sourceTree = "<group>"; };
@@ -1013,11 +1021,13 @@
 				731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */,
 				731BA83721DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift */,
 				74C473AE1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift */,
+				736C970F21E80D48007A4200 /* SiteVerticalsPromptResponseDecodingTests.swift */,
 				73D5930221E552CD00E4CF84 /* SiteVerticalsRequestEncodingTests.swift */,
 				73D592FF21E550F500E4CF84 /* SiteVerticalsResponseDecodingTests.swift */,
 				E1787DB1200E5690004CB3AF /* TimeZoneServiceRemoteTests.swift */,
 				7328420521CD798A00126755 /* WordPressComServiceRemoteTests+SiteCreation.swift */,
 				73D5930421E5541200E4CF84 /* WordPressComServiceRemoteTests+SiteVerticals.swift */,
+				73A2F38C21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift */,
 			);
 			name = Site;
 			sourceTree = "<group>";
@@ -1287,6 +1297,7 @@
 				93F50A361F226B9300B5BEBA /* WordPressComServiceRemote.m */,
 				7328420321CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift */,
 				730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */,
+				73A2F38921E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift */,
 				9368C7A11EC62F800092CE8E /* WPStatsServiceRemote.h */,
 				9368C7A21EC62F800092CE8E /* WPStatsServiceRemote.m */,
 				E182BF691FD961810001D850 /* Endpoint.swift */,
@@ -1537,6 +1548,7 @@
 				7434E1DD1F17C3C900C40DDB /* site-users-update-role-unknown-user-failure.json */,
 				73D592FA21E550D300E4CF84 /* site-verticals-empty.json */,
 				73D592F821E550D200E4CF84 /* site-verticals-multiple.json */,
+				73A2F38B21E7FC2A00388609 /* site-verticals-prompt.json */,
 				73D592F921E550D300E4CF84 /* site-verticals-single.json */,
 				74D67F2B1F15C3740010C5ED /* site-viewers-delete-auth-failure.json */,
 				74D67F2C1F15C3740010C5ED /* site-viewers-delete-bad-json.json */,
@@ -1897,6 +1909,7 @@
 				436D564C211CCCB900CEAA33 /* domain-contact-information-response-success.json in Resources */,
 				93BD275A1EE73442002BB00B /* is-available-email-success.json in Resources */,
 				17BF9A6C20C7DC3300BF57D2 /* reader-site-search-success.json in Resources */,
+				73A2F38E21E7FD9B00388609 /* site-verticals-prompt.json in Resources */,
 				74D67F141F15C2D70010C5ED /* site-roles-bad-json-failure.json in Resources */,
 				40E4698B2017C2840030DB5F /* plugin-directory-popular.json in Resources */,
 				93AC8ED01ED32FD000900F5A /* stats-v1.1-post-details.json in Resources */,
@@ -2144,6 +2157,7 @@
 				74650F721F0EA1A700188EDB /* GravatarServiceRemote.swift in Sources */,
 				B5969E1D20A49AC4005E9DF1 /* NSString+MD5.m in Sources */,
 				8236EB4D2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift in Sources */,
+				73A2F38A21E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift in Sources */,
 				740B23BB1F17EC7300067A2A /* PostServiceRemoteXMLRPC.m in Sources */,
 				74B5F0E31EF82D2100B411E7 /* SiteServiceRemoteWordPressComREST.m in Sources */,
 				74E2295C1F1E77290085F7F2 /* KeyringConnectionExternalUser.swift in Sources */,
@@ -2268,6 +2282,7 @@
 				93F50A3A1F226BB600B5BEBA /* WordPressComServiceRemoteRestTests.swift in Sources */,
 				93AC8EE01ED32FD000900F5A /* StatsStreakTests.m in Sources */,
 				E13EE14C1F332C4400C15787 /* PluginServiceRemoteTests.swift in Sources */,
+				736C971021E80D48007A4200 /* SiteVerticalsPromptResponseDecodingTests.swift in Sources */,
 				74B335D81F06F1CA0053A184 /* MockWordPressComRestApi.swift in Sources */,
 				74B5F0DE1EF82A9600B411E7 /* BlogServiceRemoteRESTTests.m in Sources */,
 				74E2294B1F1E73340085F7F2 /* SharingServiceRemoteTests.m in Sources */,
@@ -2292,6 +2307,7 @@
 				73D5930521E5541200E4CF84 /* WordPressComServiceRemoteTests+SiteVerticals.swift in Sources */,
 				17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */,
 				93AC8EE11ED32FD000900F5A /* StatsStringUtilitiesTest.m in Sources */,
+				73A2F38D21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift in Sources */,
 				74C473AF1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift in Sources */,
 				74A44DD51F13C6D8006CD8F4 /* PushAuthenticationServiceRemoteTests.swift in Sources */,
 				731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */,

--- a/WordPressKit/WordPressComServiceRemote+SiteVerticals.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteVerticals.swift
@@ -1,7 +1,5 @@
 import Foundation
 
-import WordPressShared
-
 // MARK: - SiteVerticalsRequest
 
 /// Allows the construction of a request for site verticals.
@@ -84,7 +82,7 @@ public extension WordPressComServiceRemote {
         let endpoint = "verticals"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        var requestParameters: [String : AnyObject]
+        let requestParameters: [String : AnyObject]
         do {
             requestParameters = try encodeRequestParameters(request: request)
         } catch {
@@ -93,9 +91,6 @@ public extension WordPressComServiceRemote {
             completion(.failure(SiteVerticalsError.requestEncodingFailure))
             return
         }
-
-        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
-        requestParameters["locale"] = locale as AnyObject
 
         wordPressComRestApi.GET(
             path,

--- a/WordPressKit/WordPressComServiceRemote+SiteVerticalsPrompt.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteVerticalsPrompt.swift
@@ -1,0 +1,87 @@
+
+import Foundation
+
+// MARK: - Site Verticals Prompt : Request
+
+public typealias SiteVerticalsPromptRequest = Int64
+
+// MARK: - Site Verticals Prompt : Response
+
+public struct SiteVerticalsPrompt: Decodable {
+    public let title: String
+    public let subtitle: String
+    public let hint: String
+    
+    public init(title: String, subtitle: String, hint: String) {
+        self.title = title
+        self.subtitle = subtitle
+        self.hint = hint
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case title      = "site_topic_header"
+        case subtitle   = "site_topic_subheader"
+        case hint       = "site_topic_placeholder"
+    }
+}
+
+public typealias SiteVerticalsPromptServiceCompletion = ((SiteVerticalsPrompt?) -> ())
+
+/// Site verticals services, exclusive to WordPress.com.
+///
+public extension WordPressComServiceRemote {
+    
+    /// Retrieves the prompt information presented to users when searching Verticals.
+    ///
+    /// - Parameters:
+    ///   - request:    the value object with which to compose the request.
+    ///   - completion: a closure including the result of the request for site verticals.
+    ///
+    func retrieveVerticalsPrompt(request: SiteVerticalsPromptRequest, completion: @escaping SiteVerticalsPromptServiceCompletion) {
+        
+        let endpoint = "verticals/prompt"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
+        
+        let requestParameters: [String : AnyObject] = [
+            "segment_id" : request as AnyObject
+        ]
+        
+        wordPressComRestApi.GET(
+            path,
+            parameters: requestParameters,
+            success: { [weak self] responseObject, httpResponse in
+                DDLogInfo("\(responseObject) | \(String(describing: httpResponse))")
+                
+                guard let self = self else {
+                    return
+                }
+                
+                do {
+                    let response = try self.decodeResponse(responseObject: responseObject)
+                    completion(response)
+                } catch {
+                    DDLogError("Failed to decode SiteVerticalsPrompt : \(error.localizedDescription)")
+                    completion(nil)
+                }
+            },
+            failure: { error, httpResponse in
+                DDLogError("\(error) | \(String(describing: httpResponse))")
+                completion(nil)
+        })
+    }
+}
+
+//// MARK: - Serialization support
+//
+private extension WordPressComServiceRemote {
+    
+    func decodeResponse(responseObject: AnyObject) throws -> SiteVerticalsPrompt {
+        
+        let decoder = JSONDecoder()
+        
+        let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
+        let response = try decoder.decode(SiteVerticalsPrompt.self, from: data)
+        
+        return response
+    }
+}

--- a/WordPressKitTests/Mock Data/site-verticals-prompt.json
+++ b/WordPressKitTests/Mock Data/site-verticals-prompt.json
@@ -1,0 +1,5 @@
+{
+    "site_topic_header": "What will your blog be about?",
+    "site_topic_subheader": "We'll use your answer to add sections to your website.",
+    "site_topic_placeholder": "e.g., Landscaping, Consulting... etc",
+}

--- a/WordPressKitTests/SiteVerticalsPromptResponseDecodingTests.swift
+++ b/WordPressKitTests/SiteVerticalsPromptResponseDecodingTests.swift
@@ -1,0 +1,33 @@
+
+import XCTest
+@testable import WordPressKit
+
+final class SiteVerticalsPromptResponseDecodingTests: XCTestCase {
+
+    func testSiteVerticalsPromptResponseDecoding_IsSuccessful() {
+        // Given
+        let testClass: AnyClass = SiteVerticalsPromptResponseDecodingTests.self
+        let bundle = Bundle(for: testClass)
+        let url = bundle.url(forResource: "site-verticals-prompt", withExtension: "json")
+
+        XCTAssertNotNil(url)
+        let jsonURL = url!
+
+        XCTAssertNoThrow(try Data(contentsOf: jsonURL))
+        let jsonData = try! Data(contentsOf: jsonURL)
+
+        // When
+        let decoder = JSONDecoder()
+        XCTAssertNoThrow(try decoder.decode(SiteVerticalsPrompt.self, from: jsonData))
+        let response = try! decoder.decode(SiteVerticalsPrompt.self, from: jsonData)
+
+        let expectedTitle = "What will your blog be about?"
+        let expectedSubtitle = "We'll use your answer to add sections to your website."
+        let expectedHint = "e.g., Landscaping, Consulting... etc"
+
+        // Then
+        XCTAssertEqual(response.title, expectedTitle)
+        XCTAssertEqual(response.subtitle, expectedSubtitle)
+        XCTAssertEqual(response.hint, expectedHint)
+    }
+}

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteVerticals.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteVerticals.swift
@@ -34,7 +34,4 @@ final class SiteCreationVerticalsTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout)
     }
-
-    func testSiteVerticalsRequest() {
-    }
 }

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import WordPressKit
+
+final class SiteCreationVerticalsPromptTests: RemoteTestCase, RESTTestable {
+
+    func testSiteVerticalsPromptRequest_Succeeds() {
+        // Given
+        let endpoint = "verticals/prompt"
+        let fileName = "site-verticals-prompt.json"
+        stubRemoteResponse(endpoint, filename: fileName, contentType: .ApplicationJSON)
+
+        // When
+        let request = Int64(1) as SiteVerticalsPromptRequest
+
+        // Then
+        let promptExpectation = expectation(description: "Initiate site verticals prompt request")
+        let remote = WordPressComServiceRemote(wordPressComRestApi: getRestApi())
+        remote.retrieveVerticalsPrompt(request: request) { prompt in
+            promptExpectation.fulfill()
+            XCTAssertNotNil(prompt)
+        }
+
+        waitForExpectations(timeout: timeout)
+    }
+}


### PR DESCRIPTION
### Description

Implements the service to fulfill [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/10671).

### Testing

- Checkout the branch. Confirm that it builds & tests pass.
- For additional assurance, consider checking out the WPiOS branch `issue/10671-site-creation-verticals-prompt` and verify that it builds and that tests pass.