### PR TITLE
Update UIDeviceIdentifier to 1.1.4

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -26,12 +26,12 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (6.1.0)
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
-  - UIDeviceIdentifier (0.5.0)
+  - UIDeviceIdentifier (1.1.4)
   - WordPressKit (1.7.0-beta.4):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
-    - UIDeviceIdentifier (~> 0.4)
+    - UIDeviceIdentifier (~> 1.1.4)
     - WordPressShared (~> 1.4)
     - wpxmlrpc (= 0.8.4)
   - WordPressShared (1.6.0):
@@ -69,8 +69,8 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
-  UIDeviceIdentifier: a959a6d4f51036b4180dd31fb26483a820f1cc46
-  WordPressKit: f77ff3fe62e2985a81d59e234917abd0490220f2
+  UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
+  WordPressKit: c46c1ec1e175282742e88a851d0066c77eed1cbd
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -24,5 +24,5 @@ Pod::Spec.new do |s|
   s.dependency 'WordPressShared', '~> 1.4'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.4'
-  s.dependency 'UIDeviceIdentifier', '~> 0.4'
+  s.dependency 'UIDeviceIdentifier', '~> 1.1.4'
 end


### PR DESCRIPTION
This PR just updates the `UIDeviceIdentifier` to the latest version. We've already done so elsewhere, and are confident there are no breaking changes.

**To test:** 
You can run the unit test suite yourself, or just trust BuddyBuild's assessment 😃 