### PR TITLE
Modified locale handling to inspect request parameters

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (1.8.0):
+  - WordPressKit (2.0.0-beta.1):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: b547ad4cfdfc5893fc51b66ea024cccbb1655509
+  WordPressKit: f54ffbba343061975b72e64e5d49615c28156147
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (1.1.4)
-  - WordPressKit (1.8.0-beta.1):
+  - WordPressKit (1.8.0):
     - Alamofire (~> 4.7.3)
     - CocoaLumberjack (= 3.4.2)
     - NSObject-SafeExpectations (= 0.0.3)
@@ -70,7 +70,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressKit: f2edbc8f99f7c698306193cfe216fd6e5b74fa54
+  WordPressKit: b547ad4cfdfc5893fc51b66ea024cccbb1655509
   WordPressShared: a2fc2db66c210a05d317ae9678b5823dd6a4d708
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "1.8.0"
+  s.version       = "2.0.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		73A2F38A21E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A2F38921E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift */; };
 		73A2F38D21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A2F38C21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift */; };
 		73A2F38E21E7FD9B00388609 /* site-verticals-prompt.json in Resources */ = {isa = PBXBuildFile; fileRef = 73A2F38B21E7FC2A00388609 /* site-verticals-prompt.json */; };
+		73B3DAD621FBB20D00B2CF18 /* WordPressComRestApiTests+Locale.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B3DAD521FBB20D00B2CF18 /* WordPressComRestApiTests+Locale.swift */; };
 		73D592FB21E550D300E4CF84 /* site-verticals-multiple.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D592F821E550D200E4CF84 /* site-verticals-multiple.json */; };
 		73D592FC21E550D300E4CF84 /* site-verticals-single.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D592F921E550D300E4CF84 /* site-verticals-single.json */; };
 		73D592FD21E550D300E4CF84 /* site-verticals-empty.json in Resources */ = {isa = PBXBuildFile; fileRef = 73D592FA21E550D300E4CF84 /* site-verticals-empty.json */; };
@@ -510,6 +511,7 @@
 		73A2F38921E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemote+SiteVerticalsPrompt.swift"; sourceTree = "<group>"; };
 		73A2F38B21E7FC2A00388609 /* site-verticals-prompt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-verticals-prompt.json"; sourceTree = "<group>"; };
 		73A2F38C21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift"; sourceTree = "<group>"; };
+		73B3DAD521FBB20D00B2CF18 /* WordPressComRestApiTests+Locale.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApiTests+Locale.swift"; sourceTree = "<group>"; };
 		73D592F821E550D200E4CF84 /* site-verticals-multiple.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-verticals-multiple.json"; sourceTree = "<group>"; };
 		73D592F921E550D300E4CF84 /* site-verticals-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-verticals-single.json"; sourceTree = "<group>"; };
 		73D592FA21E550D300E4CF84 /* site-verticals-empty.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-verticals-empty.json"; sourceTree = "<group>"; };
@@ -1132,6 +1134,7 @@
 				740B23D51F17F7C100067A2A /* XMLRPCTestable.swift */,
 				FFE247A620C891D1002DF3A2 /* WordPressComOAuthTests.swift */,
 				74B335D91F06F3D60053A184 /* WordPressComRestApiTests.swift */,
+				73B3DAD521FBB20D00B2CF18 /* WordPressComRestApiTests+Locale.swift */,
 				74B335DB1F06F4180053A184 /* WordPressOrgXMLRPCApiTests.swift */,
 				93BD273E1EE732CC002BB00B /* Accounts */,
 				826016FE1F9FD59400533B6C /* Activity */,
@@ -2304,6 +2307,7 @@
 				74B335D81F06F1CA0053A184 /* MockWordPressComRestApi.swift in Sources */,
 				74B5F0DE1EF82A9600B411E7 /* BlogServiceRemoteRESTTests.m in Sources */,
 				74E2294B1F1E73340085F7F2 /* SharingServiceRemoteTests.m in Sources */,
+				73B3DAD621FBB20D00B2CF18 /* WordPressComRestApiTests+Locale.swift in Sources */,
 				9F3E0BAC20873785009CB5BA /* ServiceRequestTest.swift in Sources */,
 				93AC8EDE1ED32FD000900F5A /* StatsItemTests.m in Sources */,
 				740B23D31F17F6BB00067A2A /* PostServiceRemoteXMLRPCTests.swift in Sources */,

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -338,7 +338,7 @@ open class WordPressComRestApi: NSObject {
         let existingLocaleQueryItems = existingQueryItems.filter { $0.name == localeKey }
         if let parameters = parameters, parameters[localeKey] == nil, existingLocaleQueryItems.isEmpty {
             let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-            let localeQueryItem = URLQueryItem(name: WordPressComRestApi.localeKey, value: preferredLanguageIdentifier)
+            let localeQueryItem = URLQueryItem(name: localeKey, value: preferredLanguageIdentifier)
 
             existingQueryItems.append(localeQueryItem)
         }

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -43,7 +43,7 @@ open class WordPressComRestApi: NSObject {
     
     fileprivate let backgroundUploads: Bool
 
-    fileprivate static let localeKey = "locale"
+    static let localeKey = "locale"
 
     fileprivate let oAuthToken: String?
     fileprivate let userAgent: String?

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -299,8 +299,6 @@ open class WordPressComRestApi: NSObject {
         return "\(String(describing: oAuthToken)),\(String(describing: userAgent))".hashValue
     }
 
-    // AlamoFire our parameters via `SessionManager.request(_:method:parameters:encoding:headers:)`
-
     /// This method assembles a valid request URL for the specified path & parameters.
     /// The framework relies on a field (`appendsPreferredLanguageLocale`) to influence whether or not locale should be
     /// added to the path of requests. This approach did not consider request parameters.

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -1,0 +1,40 @@
+import Foundation
+import XCTest
+
+import WordPressShared
+@testable import WordPressKit
+
+extension WordPressComRestApiTests {
+
+    func testThatAppendingLocaleWorks() {
+
+        let path = "path/path"
+        let localeKey = "locale"
+        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
+        let expectedPath = "\(path)?\(localeKey)=\(preferredLanguageIdentifier)"
+
+        let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
+        XCTAssert(localeAppendedPath == expectedPath, "Expected the locale to be appended to the path as (\(expectedPath)) but instead encountered (\(localeAppendedPath)).")
+    }
+
+    func testThatAppendingLocaleWorksWithExistingParams() {
+
+        let path = "path/path?someKey=value"
+        let localeKey = "locale"
+        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
+        let expectedPath = "\(path)&\(localeKey)=\(preferredLanguageIdentifier)"
+
+        let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
+        XCTAssert(localeAppendedPath == expectedPath, "Expected the locale to be appended to the path as (\(expectedPath)) but instead encountered (\(localeAppendedPath)).")
+    }
+
+    func testThatAppendingLocaleIgnoresIfAlreadyIncluded() {
+
+        let localeKey = "locale"
+        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
+        let path = "path/path?\(localeKey)=\(preferredLanguageIdentifier)&someKey=value"
+
+        let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
+        XCTAssert(localeAppendedPath == path, "Expected the locale to already be appended to the path as (\(path)) but instead encountered (\(localeAppendedPath)).")
+    }
+}

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -81,7 +81,7 @@ extension WordPressComRestApiTests {
         XCTAssertTrue(queryStringIncludesSomeKey)
     }
 
-    func testThatAppendingLocaleIgnoresIfAlreadyIncludedInPath() {
+    func testThatLocaleIsNotAppendedIfAlreadyIncludedInPath() {
         // Given
         let preferredLanguageIdentifier = "foo"
         let path = "/path/path?locale=\(preferredLanguageIdentifier)"
@@ -119,5 +119,32 @@ extension WordPressComRestApiTests {
 
         let expectedQueryItemValue = preferredLanguageIdentifier
         XCTAssertEqual(expectedQueryItemValue, actualQueryItemValue!)
+    }
+
+    func testThatAppendingLocaleIsNotAppendedIfAlreadyIncludedInRequestParameters() {
+        // Given
+        let inputPath = "/path/path"
+        let expectedLocaleValue = "foo"
+
+        // When
+        let inputURL = URL(string: inputPath, relativeTo: URL(string: WordPressComRestApi.apiBaseURLString))
+        XCTAssertNotNil(inputURL)
+
+        var actualURLComponents = URLComponents(url: inputURL!, resolvingAgainstBaseURL: false)
+        XCTAssertNotNil(actualURLComponents)
+
+        let localeQueryItem = URLQueryItem(name: WordPressComRestApi.localeKey, value: expectedLocaleValue)
+        actualURLComponents!.queryItems = [ localeQueryItem ]
+
+        let actualPath = actualURLComponents?.path
+        XCTAssertNotNil(actualPath)
+
+        let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(actualPath!)
+
+        // Then
+        XCTAssertTrue(localeAppendedPath.contains(expectedLocaleValue))
+
+        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
+        XCTAssertFalse(localeAppendedPath.contains(preferredLanguageIdentifier))
     }
 }

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -7,34 +7,117 @@ import WordPressShared
 extension WordPressComRestApiTests {
 
     func testThatAppendingLocaleWorks() {
-
-        let path = "path/path"
-        let localeKey = "locale"
+        // Given
+        let path = "/path/path"
         let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        let expectedPath = "\(path)?\(localeKey)=\(preferredLanguageIdentifier)"
 
+        // When
         let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
-        XCTAssert(localeAppendedPath == expectedPath, "Expected the locale to be appended to the path as (\(expectedPath)) but instead encountered (\(localeAppendedPath)).")
+
+        // Then
+        let actualURL = URL(string: localeAppendedPath, relativeTo: URL(string: WordPressComRestApi.apiBaseURLString))
+        XCTAssertNotNil(actualURL)
+
+        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
+        XCTAssertNotNil(actualURLComponents)
+
+        let expectedPath = path
+        let actualPath = actualURLComponents!.path
+        XCTAssertEqual(expectedPath, actualPath)
+
+        let actualQueryItems = actualURLComponents!.queryItems
+        XCTAssertNotNil(actualQueryItems)
+
+        let expectedQueryItemCount = 1
+        let actualQueryItemCount = actualQueryItems!.count
+        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
+
+        let actualQueryItem = actualQueryItems!.first
+        XCTAssertNotNil(actualQueryItem!)
+
+        let actualQueryItemKey = actualQueryItem!.name
+        let expectedQueryItemKey = WordPressComRestApi.localeKey
+        XCTAssertEqual(expectedQueryItemKey, actualQueryItemKey)
+
+        let actualQueryItemValue = actualQueryItem!.value
+        XCTAssertNotNil(actualQueryItemValue)
+
+        let expectedQueryItemValue = preferredLanguageIdentifier
+        XCTAssertEqual(expectedQueryItemValue, actualQueryItemValue!)
     }
 
-    func testThatAppendingLocaleWorksWithExistingParams() {
+    func testThatAppendingLocalePreservesExistingParams() {
+        // Given
+        let path = "/path/path?someKey=value"
 
-        let path = "path/path?someKey=value"
-        let localeKey = "locale"
-        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        let expectedPath = "\(path)&\(localeKey)=\(preferredLanguageIdentifier)"
-
+        // When
         let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
-        XCTAssert(localeAppendedPath == expectedPath, "Expected the locale to be appended to the path as (\(expectedPath)) but instead encountered (\(localeAppendedPath)).")
+
+        // Then
+        let actualURL = URL(string: localeAppendedPath, relativeTo: URL(string: WordPressComRestApi.apiBaseURLString))
+        XCTAssertNotNil(actualURL)
+
+        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
+        XCTAssertNotNil(actualURLComponents)
+
+        let expectedPath = "/path/path"
+        let actualPath = actualURLComponents!.path
+        XCTAssertEqual(expectedPath, actualPath)
+
+        let actualQueryItems = actualURLComponents!.queryItems
+        XCTAssertNotNil(actualQueryItems)
+
+        let expectedQueryItemCount = 2
+        let actualQueryItemCount = actualQueryItems!.count
+        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
+
+        let actualQueryString = actualURLComponents?.query
+        XCTAssertNotNil(actualQueryString)
+
+        let queryStringIncludesLocale = actualQueryString!.contains(WordPressComRestApi.localeKey)
+        XCTAssertTrue(queryStringIncludesLocale)
+
+        let queryStringIncludesSomeKey = actualQueryString!.contains("someKey")
+        XCTAssertTrue(queryStringIncludesSomeKey)
     }
 
-    func testThatAppendingLocaleIgnoresIfAlreadyIncluded() {
+    func testThatAppendingLocaleIgnoresIfAlreadyIncludedInPath() {
+        // Given
+        let preferredLanguageIdentifier = "foo"
+        let path = "/path/path?locale=\(preferredLanguageIdentifier)"
 
-        let localeKey = "locale"
-        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        let path = "path/path?\(localeKey)=\(preferredLanguageIdentifier)&someKey=value"
-
+        // When
         let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
-        XCTAssert(localeAppendedPath == path, "Expected the locale to already be appended to the path as (\(path)) but instead encountered (\(localeAppendedPath)).")
+
+        // Then
+        let actualURL = URL(string: localeAppendedPath, relativeTo: URL(string: WordPressComRestApi.apiBaseURLString))
+        XCTAssertNotNil(actualURL)
+
+        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
+        XCTAssertNotNil(actualURLComponents)
+
+        let expectedPath = "/path/path"
+        let actualPath = actualURLComponents!.path
+        XCTAssertEqual(expectedPath, actualPath)
+
+        let actualQueryItems = actualURLComponents!.queryItems
+        XCTAssertNotNil(actualQueryItems)
+
+        let expectedQueryItemCount = 1
+        let actualQueryItemCount = actualQueryItems!.count
+        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
+
+        let actualQueryItem = actualQueryItems!.first
+        XCTAssertNotNil(actualQueryItem!)
+
+        let actualQueryItemKey = actualQueryItem!.name
+        let expectedQueryItemKey = WordPressComRestApi.localeKey
+        XCTAssertEqual(expectedQueryItemKey, actualQueryItemKey)
+
+        let actualQueryItemValue = actualQueryItem!.value
+        XCTAssertNotNil(actualQueryItemValue)
+
+        let expectedQueryItemValue = preferredLanguageIdentifier
+        XCTAssertEqual(expectedQueryItemValue, actualQueryItemValue!)
     }
 }

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -161,38 +161,6 @@ class WordPressComRestApiTests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testThatAppendingLocaleWorks() {
-
-        let path = "path/path"
-        let localeKey = "locale"
-        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        let expectedPath = "\(path)?\(localeKey)=\(preferredLanguageIdentifier)"
-
-        let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
-        XCTAssert(localeAppendedPath == expectedPath, "Expected the locale to be appended to the path as (\(expectedPath)) but instead encountered (\(localeAppendedPath)).")
-    }
-
-    func testThatAppendingLocaleWorksWithExistingParams() {
-
-        let path = "path/path?someKey=value"
-        let localeKey = "locale"
-        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        let expectedPath = "\(path)&\(localeKey)=\(preferredLanguageIdentifier)"
-
-        let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
-        XCTAssert(localeAppendedPath == expectedPath, "Expected the locale to be appended to the path as (\(expectedPath)) but instead encountered (\(localeAppendedPath)).")
-    }
-
-    func testThatAppendingLocaleIgnoresIfAlreadyIncluded() {
-
-        let localeKey = "locale"
-        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        let path = "path/path?\(localeKey)=\(preferredLanguageIdentifier)&someKey=value"
-
-        let localeAppendedPath = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(path)
-        XCTAssert(localeAppendedPath == path, "Expected the locale to already be appended to the path as (\(path)) but instead encountered (\(localeAppendedPath)).")
-    }
-
     func testStreamMethodCallWithInvalidFile() {
         stub(condition: isRestAPIMediaNewRequest()) { request in
             let stubPath = OHPathForFile("WordPressComRestApiMedia.json", type(of: self))

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -6,9 +6,10 @@ import WordPressShared
 
 class WordPressComRestApiTests: XCTestCase {
 
-    let wordPressComRestApi = "https://public-api.wordpress.com/"
-    let wordPressMediaRoute = "rest/v1.1/sites/0/media/"
-    let wordPressMediaNewEndpoint = "rest/v1.1/sites/0/media/new"
+    let scheme                          = "https"
+    let host                            = "public-api.wordpress.com"
+    let wordPressMediaRoutePath         = "/rest/v1.1/sites/0/media/"
+    let wordPressMediaNewEndpointPath   = "/rest/v1.1/sites/0/media/new"
 
     override func setUp() {
         super.setUp()
@@ -19,17 +20,43 @@ class WordPressComRestApiTests: XCTestCase {
         OHHTTPStubs.removeAllStubs()
     }
 
-    fileprivate func isRestAPIRequest() -> OHHTTPStubsTestBlock {
+    private func isRestAPIRequest() -> OHHTTPStubsTestBlock {
         return { request in
-            let pathWithLocale = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(self.wordPressMediaRoute)
-            return request.url?.absoluteString == self.wordPressComRestApi + pathWithLocale
+            guard let requestURL = request.url, let components = URLComponents(string: requestURL.absoluteString) else {
+                return false
+            }
+
+            let expectedScheme = self.scheme
+            let actualScheme = components.scheme
+
+            let expectedHost = self.host
+            let actualHost = components.host
+
+            let expectedPath = self.wordPressMediaRoutePath
+            let actualPath = components.path
+
+            let result = expectedScheme == actualScheme && expectedHost == actualHost && expectedPath == actualPath
+            return result
         }
     }
 
-    fileprivate func isRestAPIMediaNewRequest() -> OHHTTPStubsTestBlock {
+    private func isRestAPIMediaNewRequest() -> OHHTTPStubsTestBlock {
         return { request in
-            let pathWithLocale = WordPressComRestApi.pathByAppendingPreferredLanguageLocale(self.wordPressMediaNewEndpoint)
-            return request.url?.absoluteString == self.wordPressComRestApi + pathWithLocale
+            guard let requestURL = request.url, let components = URLComponents(string: requestURL.absoluteString) else {
+                return false
+            }
+
+            let expectedScheme = self.scheme
+            let actualScheme = components.scheme
+
+            let expectedHost = self.host
+            let actualHost = components.host
+
+            let expectedPath = self.wordPressMediaNewEndpointPath
+            let actualPath = components.path
+
+            let result = expectedScheme == actualScheme && expectedHost == actualHost && expectedPath == actualPath
+            return result
         }
     }
 
@@ -41,7 +68,7 @@ class WordPressComRestApiTests: XCTestCase {
 
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.GET(wordPressMediaRoute, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTAssert(responseObject is [String: AnyObject], "The response should be a dictionary")
             }, failure: { (error, httpResponse) in
@@ -60,7 +87,7 @@ class WordPressComRestApiTests: XCTestCase {
 
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.GET(wordPressMediaRoute, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
@@ -78,7 +105,7 @@ class WordPressComRestApiTests: XCTestCase {
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.GET(wordPressMediaRoute, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
@@ -96,7 +123,7 @@ class WordPressComRestApiTests: XCTestCase {
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.POST(wordPressMediaNewEndpoint, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
@@ -114,7 +141,7 @@ class WordPressComRestApiTests: XCTestCase {
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.POST(wordPressMediaNewEndpoint, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
@@ -132,7 +159,7 @@ class WordPressComRestApiTests: XCTestCase {
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.POST(wordPressMediaNewEndpoint, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
@@ -150,7 +177,7 @@ class WordPressComRestApiTests: XCTestCase {
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.multipartPOST(wordPressMediaNewEndpoint, parameters: nil, fileParts: [], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
         }, failure: { (error, httpResponse) in
@@ -170,7 +197,7 @@ class WordPressComRestApiTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
         let filePart = FilePart(parameterName: "file", url: URL(fileURLWithPath: "/a.txt") as URL, filename: "a.txt", mimeType: "image/jpeg")
-        api.multipartPOST(wordPressMediaNewEndpoint, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
@@ -194,7 +221,7 @@ class WordPressComRestApiTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
         let filePart = FilePart(parameterName: "media[]", url: mediaURL as URL, filename: "test-image.jpg", mimeType: "image/jpeg")
-        let progress1 = api.multipartPOST(wordPressMediaNewEndpoint, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        let progress1 = api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
                 XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
                 print(error)
@@ -203,7 +230,7 @@ class WordPressComRestApiTests: XCTestCase {
             }
         )
         progress1?.cancel()
-        api.multipartPOST(wordPressMediaNewEndpoint, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
 
             }, failure: { (error, httpResponse) in


### PR DESCRIPTION
### Description

Fixes #72, which observed that the existing framework behavior inspected a request's path for locale, and by default, appended it if missing. This change ensures that request parameters are also inspected for the presence of the parameter.

_From the standpoint of semantic versioning, I view this as a breaking change._

### Testing Details

- Checkout the branch and confirm that existing tests pass.
- Review the code and documentation for additional context.
- From [`WordPressAuthenticator`](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/), checkout the branch `try/wordpresskit-72-validation` and confirm that it compiles & tests pass.
- From [`WPiOS`](https://github.com/wordpress-mobile/WordPress-iOS/), checkout the branch `try/wordpresskit-72-validation` and confirm that it compiles & tests pass. Also launch the app and exercise requests to confirm that there are no regressions.

- [X] Please check here if your pull request includes additional test coverage.