### PR TITLE
Removed support for client-side .blog subdomain handling

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "2.0.0-beta.1"
+  s.version       = "2.0.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComServiceRemote+SiteSegments.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteSegments.swift
@@ -17,10 +17,6 @@ public struct SiteSegment {
     }
 }
 
-extension SiteSegment {
-    public static let blogSegmentIdentifier = Int64(1)
-}
-
 extension SiteSegment: Equatable {
     public static func ==(lhs: SiteSegment, rhs: SiteSegment) -> Bool {
         return lhs.identifier == rhs.identifier


### PR DESCRIPTION
### Description

Fixes a portion of [#10919](
https://github.com/wordpress-mobile/WordPress-iOS/issues/10919).

### Testing Details

- Checkout the branch and confirm that existing tests pass.
- Note that while tests pass locally, CircleCI is currently reporting a build error. I inquired about that Friday when other errors were observed, and was advised that the CircleCI transition is in progress for this repo, and CircleCI doesn’t have a config file for it just yet.

- [ ] Please check here if your pull request includes additional test coverage.