### PR TITLE
Added call to connect/site-info in BlogServiceRemote

### DIFF
--- a/WordPressKit/BlogServiceRemoteREST.h
+++ b/WordPressKit/BlogServiceRemoteREST.h
@@ -54,4 +54,16 @@ typedef void (^SettingsHandler)(RemoteBlogSettings *settings);
                         success:(void(^)(NSDictionary *siteInfoDict))success
                         failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Fetch site info (does not require authentication) for the specified site address with no authentication.
+ *
+ *  @note       Uses anonymous API
+ *
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)fetchUnauthenticatedSiteInfoForAddress:(NSString *)siteAddress
+                        success:(void(^)(NSDictionary *siteInfoDict))success
+                        failure:(void (^)(NSError *error))failure;
+
 @end

--- a/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/BlogServiceRemoteREST.m
@@ -287,6 +287,24 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
                           }];
 }
 
+- (void)fetchUnauthenticatedSiteInfoForAddress:(NSString *)siteAddress
+                        success:(void(^)(NSDictionary *siteInfoDict))success
+                        failure:(void (^)(NSError *error))failure
+{
+    NSString *path = [self pathForEndpoint:@"connect/site-info" withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    NSURL *siteURL = [NSURL URLWithString:siteAddress];
+    [self.wordPressComRestApi GET:path
+                       parameters:@{ @"url": siteURL.absoluteString }
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                              if (success) {
+                                  success((NSDictionary *)responseObject);
+                                  return;
+                              }
+                          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                              failure(error);
+                          }];
+}
+
 #pragma mark - API paths
 
 - (NSString *)pathForUsers

--- a/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/BlogServiceRemoteREST.m
@@ -293,6 +293,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 {
     NSString *path = [self pathForEndpoint:@"connect/site-info" withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     NSURL *siteURL = [NSURL URLWithString:siteAddress];
+
     [self.wordPressComRestApi GET:path
                        parameters:@{ @"url": siteURL.absoluteString }
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {

--- a/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/BlogServiceRemoteREST.m
@@ -299,10 +299,11 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               if (success) {
                                   success((NSDictionary *)responseObject);
-                                  return;
                               }
                           } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-                              failure(error);
+                              if(failure) {
+                                  failure(error);
+                              }
                           }];
 }
 


### PR DESCRIPTION
related issue: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/52

Purpose: Getting site info without authentication.

### Description

Fixes https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/52

- [ ] Please check here if your pull request includes additional test coverage.