### PR TITLE
Update podspec author

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressKit-iOS"
   s.license       = "GPLv2"
-  s.author        = { "Jorge Leandro Perez" => "jorge.perez@automattic.com" }
+  s.author        = { "WordPress" => "mobile@automattic.com" }
   s.platform      = :ios, "10.0"
   s.swift_version = '4.2'
   s.source        = { :git => "https://github.com/wordpress-mobile/WordPressKit-iOS.git", :tag => s.version.to_s }


### PR DESCRIPTION
Updates the podspec author to be "WordPress" => "mobile@automattic.com" for consistency with our other pods.

Since there's no functionality changes we can probably skip adding a new tag or version for this one. 