### PR TITLE
Apply some Swift 4 cleanup

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "2.1.0"
+  s.version       = "2.1.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -2663,7 +2663,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -2689,7 +2688,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -2710,7 +2708,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressKitTests/WordPressKitTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -2730,7 +2727,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressKitTests/WordPressKitTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -2812,7 +2808,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = "Release-Internal";
 		};
@@ -2832,7 +2827,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressKitTests/WordPressKitTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.2;
 			};
 			name = "Release-Internal";
 		};
@@ -2914,7 +2908,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
 			};
 			name = "Release-Alpha";
 		};
@@ -2934,7 +2927,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.WordPressKitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "WordPressKitTests/WordPressKitTests-Bridging-Header.h";
-				SWIFT_VERSION = 4.2;
 			};
 			name = "Release-Alpha";
 		};

--- a/WordPressKit/AccountSettingsRemote.swift
+++ b/WordPressKit/AccountSettingsRemote.swift
@@ -123,7 +123,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         })
     }
     
-    fileprivate func settingsFromResponse(_ responseObject: AnyObject) throws -> AccountSettings {
+    private func settingsFromResponse(_ responseObject: AnyObject) throws -> AccountSettings {
         guard let
             response = responseObject as? [String: AnyObject],
             let firstName = response["first_name"] as? String,
@@ -158,7 +158,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
                                tracksOptOut: tracksOptOut)
     }
 
-    fileprivate func fieldNameForChange(_ change: AccountSettingsChange) -> String {
+    private func fieldNameForChange(_ change: AccountSettingsChange) -> String {
         switch change {
         case .firstName:
             return "first_name"

--- a/WordPressKit/GravatarServiceRemote.swift
+++ b/WordPressKit/GravatarServiceRemote.swift
@@ -93,7 +93,7 @@ open class GravatarServiceRemote {
 
     /// Returns a new (randomized) Boundary String
     ///
-    fileprivate func boundaryForRequest() -> String {
+    private func boundaryForRequest() -> String {
         return "Boundary-" + UUID().uuidString
     }
 
@@ -107,7 +107,7 @@ open class GravatarServiceRemote {
     ///
     /// - Returns: A NSData instance, containing the Request's Payload.
     ///
-    fileprivate func bodyWithGravatarData(_ gravatarData: Data, account: String, boundary: String) -> Data {
+    private func bodyWithGravatarData(_ gravatarData: Data, account: String, boundary: String) -> Data {
         let body = NSMutableData()
 
         // Image Payload
@@ -131,7 +131,7 @@ open class GravatarServiceRemote {
 
 
     // MARK: - Private Structs
-    fileprivate struct UploadParameters {
+    private struct UploadParameters {
         static let endpointURL          = "https://api.gravatar.com/v1/upload-image"
         static let HTTPMethod           = "POST"
         static let contentType          = "application/octet-stream"

--- a/WordPressKit/HTTPAuthenticationAlertController.swift
+++ b/WordPressKit/HTTPAuthenticationAlertController.swift
@@ -7,7 +7,7 @@ open class HTTPAuthenticationAlertController {
 
     public typealias AuthenticationHandler = (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
 
-    fileprivate static var onGoingChallenges = [URLProtectionSpace: [AuthenticationHandler]]()
+    private static var onGoingChallenges = [URLProtectionSpace: [AuthenticationHandler]]()
 
     static public func controller(for challenge: URLAuthenticationChallenge, handler: @escaping AuthenticationHandler) -> UIAlertController? {
         if var handlers = onGoingChallenges[challenge.protectionSpace] {
@@ -35,7 +35,7 @@ open class HTTPAuthenticationAlertController {
         onGoingChallenges.removeValue(forKey: challenge.protectionSpace)
     }
 
-    static fileprivate func controllerForServerTrustChallenge(_ challenge: URLAuthenticationChallenge) -> UIAlertController {
+    private static func controllerForServerTrustChallenge(_ challenge: URLAuthenticationChallenge) -> UIAlertController {
         let title = NSLocalizedString("Certificate error", comment: "Popup title for wrong SSL certificate.")
         let message = String(format: NSLocalizedString("The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?", comment: ""), challenge.protectionSpace.host)
         let controller =  UIAlertController(title: title, message: message, preferredStyle: .alert)
@@ -58,7 +58,7 @@ open class HTTPAuthenticationAlertController {
         return controller
     }
 
-    static fileprivate func controllerForUserAuthenticationChallenge(_ challenge: URLAuthenticationChallenge) -> UIAlertController {
+    private static func controllerForUserAuthenticationChallenge(_ challenge: URLAuthenticationChallenge) -> UIAlertController {
         let title = String(format: NSLocalizedString("Authentication required for host: %@", comment: "Popup title to ask for user credentials."), challenge.protectionSpace.host)
         let message = NSLocalizedString("Please enter your credentials", comment: "Popup message to ask for user credentials (fields shown below).")
         let controller =  UIAlertController(title: title,

--- a/WordPressKit/NotificationSyncServiceRemote.swift
+++ b/WordPressKit/NotificationSyncServiceRemote.swift
@@ -5,7 +5,7 @@ import Foundation
 public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     // MARK: - Constants
     //
-    fileprivate let defaultPageSize = 100
+    private let defaultPageSize = 100
 
 
     // MARK: - Errors

--- a/WordPressKit/PluginServiceRemote.swift
+++ b/WordPressKit/PluginServiceRemote.swift
@@ -182,7 +182,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
     }
 }
 
-fileprivate extension PluginServiceRemote {
+private extension PluginServiceRemote {
     func encoded(pluginID: String) -> String? {
         let allowedCharacters = CharacterSet.urlPathAllowed.subtracting(CharacterSet(charactersIn: "/"))
         guard let escapedPluginID = pluginID.addingPercentEncoding(withAllowedCharacters: allowedCharacters) else {

--- a/WordPressKit/RemoteBlogSettings.swift
+++ b/WordPressKit/RemoteBlogSettings.swift
@@ -209,6 +209,6 @@ public class RemoteBlogSettings: NSObject {
 
     // MARK: - Private
 
-    fileprivate static let AscendingStringValue     = "asc"
-    fileprivate static let DescendingStringValue    = "desc"
+    private static let AscendingStringValue     = "asc"
+    private static let DescendingStringValue    = "desc"
 }

--- a/WordPressKit/RemoteNotificationSettings.swift
+++ b/WordPressKit/RemoteNotificationSettings.swift
@@ -67,7 +67,7 @@ open class RemoteNotificationSettings {
         ///
         /// - Returns: A native Swift dictionary, containing only the Boolean entries
         ///
-        fileprivate func filterNonBooleanEntries(_ dictionary: NSDictionary?) -> [String : Bool] {
+        private func filterNonBooleanEntries(_ dictionary: NSDictionary?) -> [String : Bool] {
             var filtered = [String: Bool]()
             if dictionary == nil {
                 return filtered
@@ -114,7 +114,7 @@ open class RemoteNotificationSettings {
     ///     - channel: The communications channel that uses the current settings
     ///     - settings: Raw dictionary containing the remote settings response
     ///
-    fileprivate init(channel: Channel, settings: NSDictionary?) {
+    private init(channel: Channel, settings: NSDictionary?) {
         self.channel = channel
         self.streams = Stream.fromDictionary(settings)
     }
@@ -124,7 +124,7 @@ open class RemoteNotificationSettings {
     ///
     /// - Parameter wpcomSettings: Dictionary containing the collection of WordPress.com Settings
     ///
-    fileprivate init(wpcomSettings: NSDictionary?) {
+    private init(wpcomSettings: NSDictionary?) {
         // WordPress.com is a special scenario: It contains just one (unspecified) stream: Email
         self.channel = Channel.wordPressCom
         self.streams = [ Stream(kind: .Email, preferences: wpcomSettings) ]
@@ -135,7 +135,7 @@ open class RemoteNotificationSettings {
     ///
     /// - Parameter blogSettings: Dictionary containing the collection of settings for a single blog
     ///
-    fileprivate convenience init(blogSettings: NSDictionary?) {
+    private convenience init(blogSettings: NSDictionary?) {
         let blogId = blogSettings?["blog_id"] as? Int ?? Int.max
         self.init(channel: Channel.blog(blogId: blogId), settings: blogSettings)
     }
@@ -145,7 +145,7 @@ open class RemoteNotificationSettings {
     ///
     /// - Parameter otherSettings: Dictionary containing the collection of "Other Settings"
     ///
-    fileprivate convenience init(otherSettings: NSDictionary?) {
+    private convenience init(otherSettings: NSDictionary?) {
         self.init(channel: Channel.other, settings: otherSettings)
     }
 

--- a/WordPressKit/SharingServiceRemote.swift
+++ b/WordPressKit/SharingServiceRemote.swift
@@ -154,7 +154,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///
     /// - Returns: An array of KeyringConnectionExternalUser instances.
     ///
-    fileprivate func externalUsersForKeyringConnection(_ externalUsers: NSArray) -> [KeyringConnectionExternalUser] {
+    private func externalUsersForKeyringConnection(_ externalUsers: NSArray) -> [KeyringConnectionExternalUser] {
         let arr: [KeyringConnectionExternalUser] = externalUsers.map { (dict) -> KeyringConnectionExternalUser in
             let externalUser = KeyringConnectionExternalUser()
             externalUser.externalID = (dict as AnyObject).string(forKey: ConnectionDictionaryKeys.externalID) ?? externalUser.externalID
@@ -364,7 +364,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///
     /// - Returns: A `RemotePublicizeConnection` object.
     ///
-    fileprivate func remotePublicizeConnectionFromDictionary(_ dict: NSDictionary) -> RemotePublicizeConnection? {
+    private func remotePublicizeConnectionFromDictionary(_ dict: NSDictionary) -> RemotePublicizeConnection? {
         guard let connectionID = dict.number(forKey: ConnectionDictionaryKeys.ID) else {
             return nil
         }
@@ -486,7 +486,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     ///
     /// - Returns: An array of `RemoteSharingButton` objects.
     ///
-    fileprivate func remoteSharingButtonsFromDictionary(_ buttons: NSArray) -> [RemoteSharingButton] {
+    private func remoteSharingButtonsFromDictionary(_ buttons: NSArray) -> [RemoteSharingButton] {
         var order = 0
         let sharingButtons: [RemoteSharingButton] = buttons.map { (dict) -> RemoteSharingButton in
             let btn = RemoteSharingButton()
@@ -510,7 +510,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     }
 
 
-    fileprivate func dictionariesFromRemoteSharingButtons(_ buttons: [RemoteSharingButton]) -> [NSDictionary] {
+    private func dictionariesFromRemoteSharingButtons(_ buttons: [RemoteSharingButton]) -> [NSDictionary] {
         return buttons.map({ (btn) -> NSDictionary in
 
             let dict = NSMutableDictionary()

--- a/WordPressKit/SiteManagementServiceRemote.swift
+++ b/WordPressKit/SiteManagementServiceRemote.swift
@@ -124,14 +124,14 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
 
     /// Keys found in API results
     ///
-    fileprivate struct ResultKey {
+    private struct ResultKey {
         static let Status = "status"
         static let Active = "active"
     }
 
     /// Values found in API results
     ///
-    fileprivate struct ResultValue {
+    private struct ResultValue {
         static let Deleted = "deleted"
         static let Running = "running"
     }

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -39,26 +39,26 @@ public final class WordPressComOAuthClient: NSObject {
 
     @objc public static let WordPressComSocialLoginEndpointVersion = 1.0
 
-    fileprivate let clientID: String
-    fileprivate let secret: String
+    private let clientID: String
+    private let secret: String
 
-    fileprivate let oauth2SessionManager: SessionManager = {
+    private let oauth2SessionManager: SessionManager = {
         return WordPressComOAuthClient.sessionManager()
     }()
 
-    fileprivate let socialSessionManager: SessionManager = {
+    private let socialSessionManager: SessionManager = {
         return WordPressComOAuthClient.sessionManager()
     }()
 
-    fileprivate let social2FASessionManager: SessionManager = {
+    private let social2FASessionManager: SessionManager = {
         return WordPressComOAuthClient.sessionManager()
     }()
 
-    fileprivate let socialNewSMS2FASessionManager: SessionManager = {
+    private let socialNewSMS2FASessionManager: SessionManager = {
         return WordPressComOAuthClient.sessionManager()
     }()
 
-    fileprivate class func sessionManager() -> SessionManager {
+    private class func sessionManager() -> SessionManager {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.httpAdditionalHeaders = ["Accept": "application/json"]
         let sessionManager = SessionManager(configuration: .ephemeral)
@@ -391,7 +391,7 @@ public final class WordPressComOAuthClient: NSObject {
             })
     }
 
-    fileprivate func cleanedUpResponseForLogging(_ response: AnyObject) -> AnyObject {
+    private func cleanedUpResponseForLogging(_ response: AnyObject) -> AnyObject {
         guard var responseDictionary = response as? [String: AnyObject],
             let _ = responseDictionary["access_token"]
             else {

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -7,10 +7,10 @@ open class WordPressOrgXMLRPCApi: NSObject {
     public typealias SuccessResponseBlock = (AnyObject, HTTPURLResponse?) -> ()
     public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> ()
 
-    fileprivate let endpoint: URL
-    fileprivate let userAgent: String?
-    fileprivate var backgroundUploads: Bool
-    fileprivate var backgroundSessionIdentifier: String
+    private let endpoint: URL
+    private let userAgent: String?
+    private var backgroundUploads: Bool
+    private var backgroundSessionIdentifier: String
     @objc public static let defaultBackgroundSessionIdentifier = "org.wordpress.wporgxmlrpcapi"
 
     /// onChallenge's Callback Closure Signature. Host Apps should call this method, whenever a proper AuthChallengeDisposition has been
@@ -22,19 +22,17 @@ open class WordPressOrgXMLRPCApi: NSObject {
     ///
     public static var onChallenge: ((URLAuthenticationChallenge, @escaping AuthenticationHandler) -> Void)?
 
-
     /// Minimum WordPress.org Supported Version.
     ///
     @objc public static let minimumSupportedVersion = "4.0"
 
-
-    fileprivate lazy var sessionManager: Alamofire.SessionManager = {
+    private lazy var sessionManager: Alamofire.SessionManager = {
         let sessionConfiguration = URLSessionConfiguration.default
         let sessionManager = self.makeSessionManager(configuration: sessionConfiguration)
         return sessionManager
     }()
 
-    fileprivate lazy var uploadSessionManager: Alamofire.SessionManager = {
+    private lazy var uploadSessionManager: Alamofire.SessionManager = {
         if self.backgroundUploads {
             let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: self.backgroundSessionIdentifier)
             let sessionManager = self.makeSessionManager(configuration: sessionConfiguration)
@@ -44,7 +42,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
         return self.sessionManager
     }()
 
-    fileprivate func makeSessionManager(configuration sessionConfiguration: URLSessionConfiguration) -> Alamofire.SessionManager {
+    private func makeSessionManager(configuration sessionConfiguration: URLSessionConfiguration) -> Alamofire.SessionManager {
         var additionalHeaders: [String : AnyObject] = ["Accept-Encoding": "gzip, deflate" as AnyObject]
         if let userAgent = self.userAgent {
             additionalHeaders["User-Agent"] = userAgent as AnyObject?
@@ -222,7 +220,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
     // MARK: - Request Building
 
-    fileprivate func requestWithMethod(_ method: String, parameters: [AnyObject]?) throws -> URLRequest {
+    private func requestWithMethod(_ method: String, parameters: [AnyObject]?) throws -> URLRequest {
         let mutableRequest = NSMutableURLRequest(url: endpoint)
         mutableRequest.httpMethod = "POST"
         mutableRequest.setValue("text/xml", forHTTPHeaderField: "Content-Type")
@@ -232,7 +230,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
         return mutableRequest as URLRequest
     }
 
-    fileprivate func streamingRequestWithMethod(_ method: String, parameters: [AnyObject]?, usingFileURLForCache fileURL: URL) throws -> URLRequest {
+    private func streamingRequestWithMethod(_ method: String, parameters: [AnyObject]?, usingFileURLForCache fileURL: URL) throws -> URLRequest {
         let mutableRequest = NSMutableURLRequest(url: endpoint)
         mutableRequest.httpMethod = "POST"
         mutableRequest.setValue("text/xml", forHTTPHeaderField: "Content-Type")
@@ -247,7 +245,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
         return mutableRequest as URLRequest
     }
 
-    fileprivate func URLForTemporaryFile() -> URL {
+    private func URLForTemporaryFile() -> URL {
         let fileName = "\(ProcessInfo.processInfo.globallyUniqueString)_file.xmlrpc"
         let fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
         return fileURL
@@ -255,7 +253,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
     // MARK: - Handling of data
 
-    fileprivate func handleResponseWithData(_ originalData: Data?, urlResponse: URLResponse?, error: NSError?) throws -> AnyObject {
+    private func handleResponseWithData(_ originalData: Data?, urlResponse: URLResponse?, error: NSError?) throws -> AnyObject {
         guard let data = originalData,
             let httpResponse = urlResponse as? HTTPURLResponse,
             let contentType = httpResponse.allHeaderFields["Content-Type"] as? String, error == nil else {
@@ -292,7 +290,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     @objc public static let WordPressOrgXMLRPCApiErrorKeyDataString: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyDataString"
     @objc public static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
 
-    fileprivate func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
+    private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data

--- a/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -152,7 +152,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
         })
     }
 
-    fileprivate func urlForXMLRPCFromURLString(_ urlString: String, addXMLRPC: Bool) throws -> URL {
+    private func urlForXMLRPCFromURLString(_ urlString: String, addXMLRPC: Bool) throws -> URL {
         var resultURLString = urlString
         // Is an empty url? Sorry, no psychic powers yet
         resultURLString = urlString.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
@@ -191,8 +191,8 @@ open class WordPressOrgXMLRPCValidator: NSObject {
         return url
     }
 
-    fileprivate func validateXMLRPCURL(_ url: URL,
-                                       redirectCount: Int = 0,
+    private func validateXMLRPCURL(_ url: URL,
+                                   redirectCount: Int = 0,
                                    success: @escaping (_ xmlrpcURL: URL) -> (),
                                    failure: @escaping (_ error: NSError) -> ()) {
             
@@ -247,7 +247,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
             })
     }
 
-    fileprivate func guessXMLRPCURLFromHTMLURL(_ htmlURL: URL,
+    private func guessXMLRPCURLFromHTMLURL(_ htmlURL: URL,
                                            success: @escaping (_ xmlrpcURL: URL) -> (),
                                            failure: @escaping (_ error: NSError) -> ()) {
         DDLogInfo("Fetch the original url and look for the RSD link by using RegExp")
@@ -295,7 +295,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
         dataTask.resume()
     }
 
-    fileprivate func extractRSDURLFromHTML(_ html: String) -> String? {
+    private func extractRSDURLFromHTML(_ html: String) -> String? {
         guard let rsdURLRegExp = try? NSRegularExpression(pattern: "<link\\s+rel=\"EditURI\"\\s+type=\"application/rsd\\+xml\"\\s+title=\"RSD\"\\s+href=\"([^\"]*)\"[^/]*/>",
                                                           options: [.caseInsensitive])
             else {
@@ -322,7 +322,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
         return rsdURL
     }
 
-    fileprivate func guessXMLRPCURLFromRSD(_ rsd: String,
+    private func guessXMLRPCURLFromRSD(_ rsd: String,
                                        success: @escaping (_ xmlrpcURL: URL) -> (),
                                        failure: @escaping (_ error: NSError) -> ()) {
         DDLogInfo("Parse the RSD document at the following URL: \(rsd)")

--- a/WordPressKit/WordPressRSDParser.swift
+++ b/WordPressKit/WordPressRSDParser.swift
@@ -4,8 +4,8 @@ import CocoaLumberjack
 /// An WordPressRSDParser is able to parse an RSD file and search for the XMLRPC WordPress url.
 open class WordPressRSDParser: NSObject, XMLParserDelegate {
 
-    fileprivate let parser: XMLParser
-    fileprivate var endpoint: String?
+    private let parser: XMLParser
+    private var endpoint: String?
 
     @objc init?(xmlString: String) {
         guard let data = xmlString.data(using: String.Encoding.utf8) else {

--- a/WordPressKitTests/JSONLoader.swift
+++ b/WordPressKitTests/JSONLoader.swift
@@ -38,7 +38,7 @@ import Foundation
         return nil
     }
 
-    fileprivate func parseData(_ data: Data) -> JSONDictionary? {
+    private func parseData(_ data: Data) -> JSONDictionary? {
         let options: JSONSerialization.ReadingOptions = [.mutableContainers , .mutableLeaves]
 
         do {

--- a/WordPressKitTests/WordPressComOAuthTests.swift
+++ b/WordPressKitTests/WordPressComOAuthTests.swift
@@ -22,7 +22,7 @@ class WordPressComOAuthTests: XCTestCase {
         OHHTTPStubs.removeAllStubs()
     }
 
-    fileprivate func isOauthTokenRequest(url: OAuthURL) -> OHHTTPStubsTestBlock {
+    private func isOauthTokenRequest(url: OAuthURL) -> OHHTTPStubsTestBlock {
         return { request in
             return request.url?.absoluteString == url.rawValue
         }

--- a/WordPressKitTests/WordPressComServiceRemoteRestTests.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteRestTests.swift
@@ -25,7 +25,7 @@ class WordPressComServiceRemoteRestTests: XCTestCase {
         OHHTTPStubs.removeAllStubs()
     }
 
-    fileprivate func isRestAPIUsersNewRequest() -> OHHTTPStubsTestBlock {
+    private func isRestAPIUsersNewRequest() -> OHHTTPStubsTestBlock {
         return { request in
             guard let url = request.url else {
                 return false
@@ -34,7 +34,7 @@ class WordPressComServiceRemoteRestTests: XCTestCase {
         }
     }
 
-    fileprivate func isRestAPISitesNewRequest() -> OHHTTPStubsTestBlock {
+    private func isRestAPISitesNewRequest() -> OHHTTPStubsTestBlock {
         return { request in
             guard let url = request.url else {
                 return false

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -16,7 +16,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         OHHTTPStubs.removeAllStubs()
     }
 
-    fileprivate func isXmlRpcAPIRequest() -> OHHTTPStubsTestBlock {
+    private func isXmlRpcAPIRequest() -> OHHTTPStubsTestBlock {
         return { request in
             return request.url?.absoluteString == self.xmlrpcEndpoint
         }


### PR DESCRIPTION
### Description

Refs #79. Before we create a branch to consider the transition to Swift 5, there is some low-hanging fruit related to Swift 4 that we could stand to tackle. This PR takes care of those:

- `SWIFT_VERSION` is set to 4.2 at both the project & target levels.
- Renamed some `fileprivate` members as `private` where applicable

### Testing Details

- Checkout the branch, confirm that it builds and existing tests pass.
- Evaluate the `issue/wpkit-79-integration` branch from WPiOS and confirm that it has no ill-effect.

- [ ] Please check here if your pull request includes additional test coverage.