### PR TITLE
Stats: Streaks improvements

### DIFF
--- a/WordPressKit/Insights/StatsPostingStreakInsight.swift
+++ b/WordPressKit/Insights/StatsPostingStreakInsight.swift
@@ -26,6 +26,32 @@ extension StatsPostingStreakInsight: InsightProtocol {
         return "stats/streak"
     }
 
+    // Some heavy-traffic sites can have A LOT of posts and the default query parameters wouldn't
+    // return all the relevant streak data, so we manualy override the `max` and `startDate``/endDate`
+    // parameters to hopefully get all.
+    public static var queryProperties: [String: String] {
+        let today = Date()
+
+        let numberOfDaysInCurrentMonth = Calendar.autoupdatingCurrent.range(of: .day, in: .month, for: today)
+
+        guard
+            let firstDayIndex = numberOfDaysInCurrentMonth?.first,
+            let lastDayIndex = numberOfDaysInCurrentMonth?.last,
+            let lastDayOfMonth = Calendar.autoupdatingCurrent.date(bySetting: .day, value: lastDayIndex, of: today),
+            let firstDayOfMonth = Calendar.autoupdatingCurrent.date(bySetting: .day, value: firstDayIndex, of: today),
+            let yearAgo = Calendar.autoupdatingCurrent.date(byAdding: .year, value: -1, to: firstDayOfMonth)
+            else {
+                return [:]
+        }
+
+        let firstDayString = self.dateFormatter.string(from: yearAgo)
+        let lastDayString = self.dateFormatter.string(from: lastDayOfMonth)
+
+        return ["startDate": "\(firstDayString)",
+                "endDate": "\(lastDayString)",
+                "max": "5000"]
+    }
+
     public init?(jsonDictionary: [String: AnyObject]) {
         guard
             let postsData = jsonDictionary["data"] as? [String: AnyObject],

--- a/WordPressKit/Insights/StatsPostingStreakInsight.swift
+++ b/WordPressKit/Insights/StatsPostingStreakInsight.swift
@@ -12,6 +12,11 @@ public struct StatsPostingStreakInsight {
 public struct PostingStreakEvent {
     public let date: Date
     public let postCount: Int
+
+    public init(date: Date, postCount: Int) {
+        self.date = date
+        self.postCount = postCount
+    }
 }
 
 extension StatsPostingStreakInsight: InsightProtocol {


### PR DESCRIPTION
### Description

Fixes #104 and changes the external API to make https://github.com/wordpress-mobile/WordPress-iOS/pull/11129 possible

### Testing Details

Verify the lib builds
Verify the tests pass
Check out corresponding WPiOS build and verify that the Streak data for the past year for Hogwarts P2 shows up correctly
