### PR TITLE
 Ensure that nil parameters don't defeat locale handling

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "2.1.0.1-beta.1"
+  s.version       = "2.1.0.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "2.1.0"
+  s.version       = "2.1.0.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -351,9 +351,11 @@ open class WordPressComRestApi: NSObject {
 
         var componentsWithLocale = urlComponents
         var existingQueryItems = componentsWithLocale.queryItems ?? []
-
         let existingLocaleQueryItems = existingQueryItems.filter { $0.name == localeKey }
-        if let parameters = parameters, parameters[localeKey] == nil, existingLocaleQueryItems.isEmpty {
+
+        let inputParameters = parameters ?? [:]
+
+        if inputParameters[localeKey] == nil, existingLocaleQueryItems.isEmpty {
             let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
             let localeQueryItem = URLQueryItem(name: localeKey, value: preferredLanguageIdentifier)
 

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -199,4 +199,70 @@ extension WordPressComRestApiTests {
         let actualQueryItemKey = actualQueryItem!.name
         XCTAssertEqual(expectedKey, actualQueryItemKey)
     }
+
+    func testThatAppendingLocaleWorksWhenPassingNilParameters() {
+        // Given
+        let path = "/path/path"
+        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
+
+        // When
+        let localeAppendedPath = WordPressComRestApi().buildRequestURLFor(path: path, parameters: nil)
+
+        // Then
+        XCTAssertNotNil(localeAppendedPath)
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: WordPressComRestApi.apiBaseURLString))
+        XCTAssertNotNil(actualURL)
+
+        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
+        XCTAssertNotNil(actualURLComponents)
+
+        let expectedPath = path
+        let actualPath = actualURLComponents!.path
+        XCTAssertEqual(expectedPath, actualPath)
+
+        let actualQueryItems = actualURLComponents!.queryItems
+        XCTAssertNotNil(actualQueryItems)
+
+        let expectedQueryItemCount = 1
+        let actualQueryItemCount = actualQueryItems!.count
+        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
+
+        let actualQueryItem = actualQueryItems!.first
+        XCTAssertNotNil(actualQueryItem!)
+
+        let actualQueryItemKey = actualQueryItem!.name
+        let expectedQueryItemKey = WordPressComRestApi.LocaleKeyDefault
+        XCTAssertEqual(expectedQueryItemKey, actualQueryItemKey)
+
+        let actualQueryItemValue = actualQueryItem!.value
+        XCTAssertNotNil(actualQueryItemValue)
+
+        let expectedQueryItemValue = preferredLanguageIdentifier
+        XCTAssertEqual(expectedQueryItemValue, actualQueryItemValue!)
+    }
+
+    func testThatLocaleIsNotAppendedWhenDisabledAndParametersAreNil() {
+        // Given
+        let path = "/path/path"
+
+        // When
+        let api = WordPressComRestApi()
+        api.appendsPreferredLanguageLocale = false
+        let localeAppendedPath = api.buildRequestURLFor(path: path, parameters: nil)
+
+        // Then
+        XCTAssertNotNil(localeAppendedPath)
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: WordPressComRestApi.apiBaseURLString))
+        XCTAssertNotNil(actualURL)
+
+        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
+        XCTAssertNotNil(actualURLComponents)
+
+        let expectedPath = path
+        let actualPath = actualURLComponents!.path
+        XCTAssertEqual(expectedPath, actualPath)
+
+        let actualQueryItems = actualURLComponents!.queryItems
+        XCTAssertNil(actualQueryItems)
+    }
 }


### PR DESCRIPTION
### Description

Fixes #109, where it was observed that `nil` parameters could prevent the automatic insertion of a locale parameter.

The work is the same as in #111, but it is based off (& expressed against) `master` to reflect that this is a change to a pod post-code-freeze.

### Testing Details

- Checkout the branch and confirm that tests pass.
- Smoke test the changes with `issue/wpkit-109-validation`

- [X] Please check here if your pull request includes additional test coverage.