### PR TITLE
Removed obsolete BB postbuild script

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-
-bundle install
-bundle exec pod lib lint


### PR DESCRIPTION
As per `paaHJt-oq-p2`, this PR removes an apparently obsolete script from the project. 