### PR TITLE
Adds invalidTokenHandler

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "2.1.0.1"
+  s.version       = "2.1.0.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -60,6 +60,8 @@ open class WordPressComRestApi: NSObject {
 
     private let localeKey: String
 
+    private var invalidTokenHandler: (() -> Void)? = nil
+
     /**
      Configure whether or not the user's preferred language locale should be appended. Defaults to true.
      */
@@ -152,6 +154,14 @@ open class WordPressComRestApi: NSObject {
     @objc open func invalidateAndCancelTasks() {
         sessionManager.session.invalidateAndCancel()
         uploadSessionManager.session.invalidateAndCancel()
+    }
+
+    public func authTokenEquals(token: String) -> Bool {
+        return token == oAuthToken
+    }
+
+    @objc func setInvalidTokenHandler(_ handler: @escaping () -> Void) {
+        invalidTokenHandler = handler
     }
 
     // MARK: Network requests
@@ -443,6 +453,9 @@ extension WordPressComRestApi {
         ]
 
         let mappedError = errorsMap[errorCode] ?? WordPressComRestApiError.unknown
+        if mappedError == .invalidToken {
+            invalidTokenHandler?()
+        }
         userInfo[WordPressComRestApi.ErrorKeyErrorCode] = errorCode
         userInfo[WordPressComRestApi.ErrorKeyErrorMessage] = errorDescription
         userInfo[NSLocalizedDescriptionKey] =  errorDescription

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -156,10 +156,6 @@ open class WordPressComRestApi: NSObject {
         uploadSessionManager.session.invalidateAndCancel()
     }
 
-    public func authTokenEquals(token: String) -> Bool {
-        return token == oAuthToken
-    }
-
     @objc func setInvalidTokenHandler(_ handler: @escaping () -> Void) {
         invalidTokenHandler = handler
     }


### PR DESCRIPTION
### Description

Exposes a way to 

For https://github.com/wordpress-mobile/WordPress-iOS/pull/11245

**Note:** I created a `release/2.1.0` branch just for this since we'll want to do a hotfix, we should make sure this gets merged to develop afterwards.

### Testing Details

See https://github.com/wordpress-mobile/WordPress-iOS/pull/11245

- [ ] Please check here if your pull request includes additional test coverage.