### PR TITLE
Provide memberwise initializers for Stats Insights objects.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.1.2-beta.1"
+  s.version       = "3.1.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.1.0"
+  s.version       = "3.1.2-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/Insights/StatsAllTimesInsight.swift
+++ b/WordPressKit/Insights/StatsAllTimesInsight.swift
@@ -4,6 +4,18 @@ public struct StatsAllTimesInsight {
     public let bestViewsDay: Date
     public let visitorsCount: Int
     public let bestViewsPerDayCount: Int
+
+    public init(postsCount: Int,
+                viewsCount: Int,
+                bestViewsDay: Date,
+                visitorsCount: Int,
+                bestViewsPerDayCount: Int) {
+        self.postsCount = postsCount
+        self.viewsCount = viewsCount
+        self.bestViewsDay = bestViewsDay
+        self.visitorsCount = visitorsCount
+        self.bestViewsPerDayCount = bestViewsPerDayCount
+    }
 }
 
 

--- a/WordPressKit/Insights/StatsAnnualAndMostPopularTimeInsight.swift
+++ b/WordPressKit/Insights/StatsAnnualAndMostPopularTimeInsight.swift
@@ -22,6 +22,42 @@ public struct StatsAnnualAndMostPopularTimeInsight {
 
     public let annualInsightsTotalImagesCount: Int
     public let annualInsightsAverageImagesCount: Double
+
+    public init(mostPopularDayOfWeek: DateComponents,
+                mostPopularDayOfWeekPercentage: Int,
+                mostPopularHour: DateComponents,
+                mostPopularHourPercentage: Int,
+                annualInsightsYear: Int,
+                annualInsightsTotalPostsCount: Int,
+                annualInsightsTotalWordsCount: Int,
+                annualInsightsAverageWordsCount: Double,
+                annualInsightsTotalLikesCount: Int,
+                annualInsightsAverageLikesCount: Double,
+                annualInsightsTotalCommentsCount: Int,
+                annualInsightsAverageCommentsCount: Double,
+                annualInsightsTotalImagesCount: Int,
+                annualInsightsAverageImagesCount: Double) {
+        self.mostPopularDayOfWeek = mostPopularDayOfWeek
+        self.mostPopularDayOfWeekPercentage = mostPopularDayOfWeekPercentage
+
+        self.mostPopularHour = mostPopularHour
+        self.mostPopularHourPercentage = mostPopularHourPercentage
+
+        self.annualInsightsYear = annualInsightsYear
+
+        self.annualInsightsTotalPostsCount = annualInsightsTotalPostsCount
+        self.annualInsightsTotalWordsCount = annualInsightsTotalWordsCount
+        self.annualInsightsAverageWordsCount = annualInsightsAverageWordsCount
+
+        self.annualInsightsTotalLikesCount = annualInsightsTotalLikesCount
+        self.annualInsightsAverageLikesCount = annualInsightsAverageLikesCount
+
+        self.annualInsightsTotalCommentsCount = annualInsightsTotalCommentsCount
+        self.annualInsightsAverageCommentsCount = annualInsightsAverageCommentsCount
+
+        self.annualInsightsTotalImagesCount = annualInsightsTotalImagesCount
+        self.annualInsightsAverageImagesCount = annualInsightsAverageImagesCount
+    }
 }
 
 extension StatsAnnualAndMostPopularTimeInsight: StatsInsightData {

--- a/WordPressKit/Insights/StatsCommentsInsight.swift
+++ b/WordPressKit/Insights/StatsCommentsInsight.swift
@@ -1,6 +1,12 @@
 public struct StatsCommentsInsight {
     public let topPosts: [StatsTopCommentsPost]
     public let topAuthors: [StatsTopCommentsAuthor]
+
+    public init(topPosts: [StatsTopCommentsPost],
+                topAuthors: [StatsTopCommentsAuthor]) {
+        self.topPosts = topPosts
+        self.topAuthors = topAuthors
+    }
 }
 
 extension StatsCommentsInsight: StatsInsightData {
@@ -31,6 +37,14 @@ public struct StatsTopCommentsAuthor {
     public let name: String
     public let commentCount: Int
     public let iconURL: URL?
+
+    public init(name: String,
+                commentCount: Int,
+                iconURL: URL?) {
+        self.name = name
+        self.commentCount = commentCount
+        self.iconURL = iconURL
+    }
 }
 
 public struct StatsTopCommentsPost {
@@ -38,6 +52,16 @@ public struct StatsTopCommentsPost {
     public let postID: String
     public let commentCount: Int
     public let postURL: URL?
+
+    public init(name: String,
+                postID: String,
+                commentCount: Int,
+                postURL: URL?) {
+        self.name = name
+        self.postID = postID
+        self.commentCount = commentCount
+        self.postURL = postURL
+    }
 }
 
 private extension StatsTopCommentsAuthor {

--- a/WordPressKit/Insights/StatsDotComFollowersInsight.swift
+++ b/WordPressKit/Insights/StatsDotComFollowersInsight.swift
@@ -1,6 +1,12 @@
 public struct StatsDotComFollowersInsight {
     public let dotComFollowersCount: Int
     public let topDotComFollowers: [StatsFollower]
+
+    public init (dotComFollowersCount: Int,
+                 topDotComFollowers: [StatsFollower]) {
+        self.dotComFollowersCount = dotComFollowersCount
+        self.topDotComFollowers = topDotComFollowers
+    }
 }
 
 extension StatsDotComFollowersInsight: StatsInsightData {
@@ -37,6 +43,14 @@ public struct StatsFollower {
     public let name: String
     public let subscribedDate: Date
     public let avatarURL: URL?
+
+    public init(name: String,
+                subscribedDate: Date,
+                avatarURL: URL?) {
+        self.name = name
+        self.subscribedDate = subscribedDate
+        self.avatarURL = avatarURL
+    }
 }
 
 extension StatsFollower {

--- a/WordPressKit/Insights/StatsEmailFollowersInsight.swift
+++ b/WordPressKit/Insights/StatsEmailFollowersInsight.swift
@@ -1,6 +1,12 @@
 public struct StatsEmailFollowersInsight {
     public let emailFollowersCount: Int
     public let topEmailFollowers: [StatsFollower]
+
+    public init(emailFollowersCount: Int,
+                topEmailFollowers: [StatsFollower]) {
+        self.emailFollowersCount = emailFollowersCount
+        self.topEmailFollowers = topEmailFollowers
+    }
 }
 
 extension StatsEmailFollowersInsight: StatsInsightData {

--- a/WordPressKit/Insights/StatsLastPostInsight.swift
+++ b/WordPressKit/Insights/StatsLastPostInsight.swift
@@ -6,6 +6,22 @@ public struct StatsLastPostInsight {
     public let commentsCount: Int
     public let viewsCount: Int
     public let postID: Int
+
+    public init(title: String,
+                url: URL,
+                publishedDate: Date,
+                likesCount: Int,
+                commentsCount: Int,
+                viewsCount: Int,
+                postID: Int) {
+        self.title = title
+        self.url = url
+        self.publishedDate = publishedDate
+        self.likesCount = likesCount
+        self.commentsCount = commentsCount
+        self.viewsCount = viewsCount
+        self.postID = postID
+    }
 }
 
 extension StatsLastPostInsight: StatsInsightData {

--- a/WordPressKit/Insights/StatsPostingStreakInsight.swift
+++ b/WordPressKit/Insights/StatsPostingStreakInsight.swift
@@ -7,6 +7,24 @@ public struct StatsPostingStreakInsight {
     public let longestStreakLength: Int
 
     public let postingEvents: [PostingStreakEvent]
+
+    public init(currentStreakStart: Date,
+                currentStreakEnd: Date,
+                currentStreakLength: Int,
+                longestStreakStart: Date,
+                longestStreakEnd: Date,
+                longestStreakLength: Int,
+                postingEvents: [PostingStreakEvent]) {
+        self.currentStreakStart = currentStreakStart
+        self.currentStreakEnd = currentStreakEnd
+        self.currentStreakLength = currentStreakLength
+
+        self.longestStreakStart = longestStreakStart
+        self.longestStreakEnd = longestStreakEnd
+        self.longestStreakLength = longestStreakLength
+
+        self.postingEvents = postingEvents
+    }
 }
 
 public struct PostingStreakEvent {

--- a/WordPressKit/Insights/StatsPublicizeInsight.swift
+++ b/WordPressKit/Insights/StatsPublicizeInsight.swift
@@ -1,5 +1,9 @@
 public struct StatsPublicizeInsight {
     public let publicizeServices: [StatsPublicizeService]
+
+    public init(publicizeServices: [StatsPublicizeService]) {
+        self.publicizeServices = publicizeServices
+    }
 }
 
 extension StatsPublicizeInsight: StatsInsightData {
@@ -27,6 +31,14 @@ public struct StatsPublicizeService {
     public let name: String
     public let followers: Int
     public let iconURL: URL?
+
+    public init(name: String,
+                followers: Int,
+                iconURL: URL?) {
+        self.name = name
+        self.followers = followers
+        self.iconURL = iconURL
+    }
 }
 
 private extension StatsPublicizeService {

--- a/WordPressKit/Insights/StatsTagsAndCategoriesInsight.swift
+++ b/WordPressKit/Insights/StatsTagsAndCategoriesInsight.swift
@@ -1,5 +1,9 @@
 public struct StatsTagsAndCategoriesInsight {
     public let topTagsAndCategories: [StatsTagAndCategory]
+
+    public init(topTagsAndCategories: [StatsTagAndCategory]) {
+        self.topTagsAndCategories = topTagsAndCategories
+    }
 }
 
 extension StatsTagsAndCategoriesInsight: StatsInsightData {
@@ -34,6 +38,15 @@ public struct StatsTagAndCategory {
     public let url: URL?
     public let viewsCount: Int?
     public let children: [StatsTagAndCategory]
+
+    public init(name: String, kind: Kind, url: URL?, viewsCount: Int?, children: [StatsTagAndCategory]) {
+        self.name = name
+        self.kind = kind
+        self.url = url
+        self.viewsCount = viewsCount
+        self.children = children
+    }
+
 }
 
 extension StatsTagAndCategory {
@@ -61,7 +74,7 @@ extension StatsTagAndCategory {
         let mappedChildren = innerTags.compactMap { StatsTagAndCategory(singleTag: $0) }
         let label = mappedChildren.map { $0.name }.joined(separator: ", ")
         
-        self.init(name: label, kind: .folder, url: "", viewsCount: views, children: mappedChildren)
+        self.init(name: label, kind: .folder, url: nil, viewsCount: views, children: mappedChildren)
     }
 
     init?(singleTag tag: [String: AnyObject], viewsCount: Int? = 0) {
@@ -84,16 +97,6 @@ extension StatsTagAndCategory {
             kind = .category
         }
 
-        self.init(name: name, kind: kind, url: url, viewsCount: viewsCount, children: [])
+        self.init(name: name, kind: kind, url: URL(string: url), viewsCount: viewsCount, children: [])
     }
-
-
-    init(name: String, kind: Kind, url: String, viewsCount: Int?, children: [StatsTagAndCategory]) {
-        self.name = name
-        self.kind = kind
-        self.url = URL(string: url)
-        self.viewsCount = viewsCount
-        self.children = children
-    }
-
 }

--- a/WordPressKit/Insights/StatsTodayInsight.swift
+++ b/WordPressKit/Insights/StatsTodayInsight.swift
@@ -3,6 +3,16 @@ public struct StatsTodayInsight {
     public let visitorsCount: Int
     public let likesCount: Int
     public let commentsCount: Int
+
+    public init(viewsCount: Int,
+                visitorsCount: Int,
+                likesCount: Int,
+                commentsCount: Int) {
+        self.viewsCount = viewsCount
+        self.visitorsCount = visitorsCount
+        self.likesCount = likesCount
+        self.commentsCount = commentsCount
+    }
 }
 
 extension StatsTodayInsight: StatsInsightData {


### PR DESCRIPTION
### Description

As part of Stats work in WPiOS, we need a way to map Stats object back and forth from Core Data to the format WPKit uses. 

Due to the fact that WPKit is in a separate module from WPiOS "proper", we need to manually provide memberwise initialisers for those objects. This accomplishes that!