### PR TITLE
Fix category update

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.1.1"
+  s.version       = "3.1.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -426,8 +426,9 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     }
 
     if (post.categories) {
-        parameters[@"categories"] = [post.categories valueForKey:@"categoryID"];
+        parameters[@"categories_by_id"] = [post.categories valueForKey:@"categoryID"];
     }
+
     if (post.tags) {
         NSArray *tags = post.tags;
         NSDictionary *postTags = @{@"post_tag":tags};


### PR DESCRIPTION
### Description

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11302

This PR updates the new/update post parameters to use `categories_by_id` parameter.

### Testing Details

Use this PR in the main app to test this fix: https://github.com/wordpress-mobile/WordPress-iOS/pull/11308

- [ ] Please check here if your pull request includes additional test coverage.
