### PR TITLE
Update how we handle domain privacy

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.2.0-beta.1"
+  s.version       = "3.2.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/TransactionsServiceRemote.swift
+++ b/WordPressKit/TransactionsServiceRemote.swift
@@ -9,7 +9,6 @@ import CocoaLumberjack
     }
 
     private enum Constants {
-        static let privateRegistrationProductID = 16
         static let freeDomainPaymentMethod = "WPCOM_Billing_WPCOM"
     }
 
@@ -47,22 +46,15 @@ import CocoaLumberjack
         let endPoint = "me/shopping-cart/\(siteID)"
         let urlPath = path(forEndpoint: endPoint, withVersion: ._1_1)
 
-        let productsArray: [[String: AnyObject]]
-
-        let productDictionary: [String: AnyObject] = ["product_id": domainSuggestion.productID as AnyObject,
+        var productDictionary: [String: AnyObject] = ["product_id": domainSuggestion.productID as AnyObject,
                                                       "meta": domainSuggestion.domainName as AnyObject]
 
         if privacyProtectionEnabled {
-            let privacyProduct: [String: AnyObject] = ["product_id": Constants.privateRegistrationProductID as AnyObject,
-                                                       "meta": domainSuggestion.domainName as AnyObject]
-
-            productsArray = [productDictionary, privacyProduct]
-        } else {
-            productsArray = [productDictionary]
+            productDictionary["extra"] = ["privacy": true] as AnyObject
         }
 
         let parameters: [String: AnyObject] = ["temporary": "true" as AnyObject,
-                                               "products": productsArray as AnyObject]
+                                               "products": [productDictionary] as AnyObject]
 
         wordPressComRestApi.POST(urlPath,
                                  parameters: parameters,
@@ -108,25 +100,31 @@ import CocoaLumberjack
     }
 }
 
-public struct CartResponse: Codable {
+public struct CartResponse {
     let blogID: Int
     let cartKey: String
     let products: [Product]
 
     init?(jsonDictionary: [String: AnyObject]) {
-        guard let cartKey = jsonDictionary["cart_key"] as? String,
-                let blogID = jsonDictionary["blog_id"] as? Int,
-                let products = jsonDictionary["products"] as? [[String: AnyObject]] else {
+        guard
+            let cartKey = jsonDictionary["cart_key"] as? String,
+            let blogID = jsonDictionary["blog_id"] as? Int,
+            let products = jsonDictionary["products"] as? [[String: AnyObject]]
+            else {
                 return nil
         }
 
         let mappedProducts = products.compactMap { (product) -> Product? in
-            guard let productID = product["product_id"] as? Int,
-                let meta = product["meta"] as? String else {
+            guard
+                let productID = product["product_id"] as? Int,
+                let meta = product["meta"] as? String
+                else {
                     return nil
             }
 
-            return Product(productID: productID, meta: meta)
+            let extra = product["extra"] as? [String: AnyObject]
+
+            return Product(productID: productID, meta: meta, extra: extra)
         }
 
         guard mappedProducts.count == products.count else {
@@ -141,11 +139,28 @@ public struct CartResponse: Codable {
     fileprivate func jsonRepresentation() -> [String: AnyObject] {
         return ["blog_id": blogID as AnyObject,
                 "cart_key": cartKey as AnyObject,
-                "products": products.map { return ["product_id": $0.productID, "meta": $0.meta] } as AnyObject ]
+                "products": products.map { $0.jsonRepresentation() } as AnyObject]
+
     }
 }
 
-public struct Product: Codable {
+public struct Product {
     let productID: Int
     let meta: String
+    let extra: [String: AnyObject]?
+
+    fileprivate func jsonRepresentation() -> [String: AnyObject] {
+        var returnDict: [String: AnyObject] = [:]
+
+        returnDict["product_id"] = productID as AnyObject
+        returnDict["meta"] = meta as AnyObject
+
+
+        if let extra = extra {
+            returnDict["extra"] = extra as AnyObject
+        }
+
+        return returnDict
+    }
 }
+


### PR DESCRIPTION
This fixes this WPiOS bug: https://github.com/wordpress-mobile/WordPress-iOS/issues/11304

Apparently, because we no longer bill people separately for private registration, we also changed how we handle it on Calypso. This PR brings WPKit/WPiOS in-line with those changes.

To test:
Pretty much standard Custom Domains flow, which is why I chose you, @aerych  ;P

Point to this branch in Podfile in WPiOS
Have a WPCom site with no custom domain, and biz plan
Go trough the custom domain flows
Make sure to select private registration
Verify everything still works
Verify in Calypso that the domain was actually registered as private