### PR TITLE
Remove objc annotation from Plans service method with incompatible Obj-C types

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.2.0-beta.2"
+  s.version       = "3.2.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PlanServiceRemote_ApiVersion1_3.swift
+++ b/WordPressKit/PlanServiceRemote_ApiVersion1_3.swift
@@ -6,9 +6,9 @@ import CocoaLumberjack
 
     public typealias SitePlans = (activePlan: RemotePlan_ApiVersion1_3, availablePlans: [RemotePlan_ApiVersion1_3])
 
-    @objc public func getPlansForSite(_ siteID: Int,
-                                      success: @escaping (SitePlans) -> Void,
-                                      failure: @escaping (Error) -> Void) {
+    public func getPlansForSite(_ siteID: Int,
+                                success: @escaping (SitePlans) -> Void,
+                                failure: @escaping (Error) -> Void) {
         let endpoint = "sites/\(siteID)/plans"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_3)
 


### PR DESCRIPTION
### Description

Fixes #128.

### Testing Details

- On Xcode 10.2 (GM), checkout the branch and confirm that existing tests pass.
- With a prior version of Xcode, it should be possible to checkout `issue/wpkit-128-eval` from WPiOS and evaluate that the project successfully builds, runs, and interacts with this modified service method.

- [ ] Please check here if your pull request includes additional test coverage.