### PR TITLE
TimeInterval-data types initializers

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.2.0-beta.3"
+  s.version       = "3.2.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.2.0-beta.2"
+  s.version       = "3.2.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/Time Interval/StatsPublishedPostsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsPublishedPostsTimeIntervalData.swift
@@ -3,6 +3,14 @@ public struct StatsPublishedPostsTimeIntervalData {
     public let period: StatsPeriodUnit
 
     public let publishedPosts: [StatsTopPost]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                publishedPosts: [StatsTopPost]) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.publishedPosts = publishedPosts
+    }
 }
 
 extension StatsPublishedPostsTimeIntervalData: StatsTimeIntervalData {

--- a/WordPressKit/Time Interval/StatsSearchTermTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsSearchTermTimeIntervalData.swift
@@ -5,12 +5,32 @@ public struct StatsSearchTermTimeIntervalData {
     public let totalSearchTermsCount: Int
     public let hiddenSearchTermsCount: Int
     public let otherSearchTermsCount: Int
-    public let searchTerms: [SearchTerm]
+    public let searchTerms: [StatsSearchTerm]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                searchTerms: [StatsSearchTerm],
+                totalSearchTermsCount: Int,
+                hiddenSearchTermsCount: Int,
+                otherSearchTermsCount: Int) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.searchTerms = searchTerms
+        self.totalSearchTermsCount = totalSearchTermsCount
+        self.hiddenSearchTermsCount = hiddenSearchTermsCount
+        self.otherSearchTermsCount = otherSearchTermsCount
+    }
 }
 
-public struct SearchTerm {
+public struct StatsSearchTerm {
     public let term: String
     public let viewsCount: Int
+
+    public init(term: String,
+                viewsCount: Int) {
+        self.term = term
+        self.viewsCount = viewsCount
+    }
 }
 
 extension StatsSearchTermTimeIntervalData: StatsTimeIntervalData {
@@ -29,12 +49,12 @@ extension StatsSearchTermTimeIntervalData: StatsTimeIntervalData {
                 return nil
         }
 
-        let searchTerms: [SearchTerm] = searchTermsDict.compactMap {
+        let searchTerms: [StatsSearchTerm] = searchTermsDict.compactMap {
             guard let term = $0["term"] as? String, let views = $0["views"] as? Int else {
                 return nil
             }
 
-            return SearchTerm(term: term, viewsCount: views)
+            return StatsSearchTerm(term: term, viewsCount: views)
         }
 
 

--- a/WordPressKit/Time Interval/StatsSummaryTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsSummaryTimeIntervalData.swift
@@ -3,6 +3,14 @@ public struct StatsSummaryTimeIntervalData {
     public let periodEndDate: Date
 
     public let summaryData: [StatsSummaryData]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                summaryData: [StatsSummaryData]) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.summaryData = summaryData
+    }
 }
 
 public struct StatsSummaryData {
@@ -13,6 +21,20 @@ public struct StatsSummaryData {
     public let visitorsCount: Int
     public let likesCount: Int
     public let commentsCount: Int
+
+    public init(period: StatsPeriodUnit,
+                periodStartDate: Date,
+                viewsCount: Int,
+                visitorsCount: Int,
+                likesCount: Int,
+                commentsCount: Int) {
+        self.period = period
+        self.periodStartDate = periodStartDate
+        self.viewsCount = viewsCount
+        self.visitorsCount = visitorsCount
+        self.likesCount = likesCount
+        self.commentsCount = commentsCount
+    }
 }
 
 extension StatsSummaryTimeIntervalData: StatsTimeIntervalData {

--- a/WordPressKit/Time Interval/StatsTopAuthorsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopAuthorsTimeIntervalData.swift
@@ -3,6 +3,14 @@ public struct StatsTopAuthorsTimeIntervalData {
     public let periodEndDate: Date
 
     public let topAuthors: [StatsTopAuthor]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                topAuthors: [StatsTopAuthor]) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.topAuthors = topAuthors
+    }
 }
 
 public struct StatsTopAuthor {
@@ -10,6 +18,16 @@ public struct StatsTopAuthor {
     public let iconURL: URL?
     public let viewsCount: Int
     public let posts: [StatsTopPost]
+
+    public init(name: String,
+                iconURL: URL?,
+                viewsCount: Int,
+                posts: [StatsTopPost]) {
+        self.name = name
+        self.iconURL = iconURL
+        self.viewsCount = viewsCount
+        self.posts = posts
+    }
 }
 
 public struct StatsTopPost {
@@ -28,6 +46,17 @@ public struct StatsTopPost {
     public let viewsCount: Int
     public let kind: Kind
 
+    public init(title: String,
+                postID: Int,
+                postURL: URL?,
+                viewsCount: Int,
+                kind: Kind) {
+        self.title = title
+        self.postID = postID
+        self.postURL = postURL
+        self.viewsCount = viewsCount
+        self.kind = kind
+    }
 }
 
 extension StatsTopAuthorsTimeIntervalData: StatsTimeIntervalData {

--- a/WordPressKit/Time Interval/StatsTopClicksTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopClicksTimeIntervalData.swift
@@ -6,6 +6,18 @@ public struct StatsTopClicksTimeIntervalData {
     public let otherClicksCount: Int
 
     public let clicks: [StatsClick]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                clicks: [StatsClick],
+                totalClicksCount: Int,
+                otherClicksCount: Int) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.clicks = clicks
+        self.totalClicksCount = totalClicksCount
+        self.otherClicksCount = otherClicksCount
+    }
 }
 
 public struct StatsClick {
@@ -15,6 +27,18 @@ public struct StatsClick {
     public let iconURL: URL?
 
     public let children: [StatsClick]
+
+    public init(title: String,
+                clicksCount: Int,
+                clickedURL: URL?,
+                iconURL: URL?,
+                children: [StatsClick]) {
+        self.title = title
+        self.clicksCount = clicksCount
+        self.clickedURL = clickedURL
+        self.iconURL = iconURL
+        self.children = children
+    }
 }
 
 extension StatsTopClicksTimeIntervalData: StatsTimeIntervalData {

--- a/WordPressKit/Time Interval/StatsTopCountryTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopCountryTimeIntervalData.swift
@@ -6,12 +6,32 @@ public struct StatsTopCountryTimeIntervalData {
     public let otherViewsCount: Int
 
     public let countries: [StatsCountry]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                countries: [StatsCountry],
+                totalViewsCount: Int,
+                otherViewsCount: Int) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.countries = countries
+        self.totalViewsCount = totalViewsCount
+        self.otherViewsCount = otherViewsCount
+    }
 }
 
 public struct StatsCountry {
-    let name: String
-    let code: String
-    let viewsCount: Int
+    public let name: String
+    public let code: String
+    public let viewsCount: Int
+
+    public init(name: String,
+                code: String,
+                viewsCount: Int){
+        self.name = name
+        self.code = code
+        self.viewsCount = viewsCount
+    }
 }
 
 extension StatsTopCountryTimeIntervalData: StatsTimeIntervalData {

--- a/WordPressKit/Time Interval/StatsTopPostsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopPostsTimeIntervalData.swift
@@ -5,6 +5,18 @@ public struct StatsTopPostsTimeIntervalData {
     public let totalViewsCount: Int
     public let otherViewsCount: Int
     public let topPosts: [StatsTopPost]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                topPosts: [StatsTopPost],
+                totalViewsCount: Int,
+                otherViewsCount: Int) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.topPosts = topPosts
+        self.totalViewsCount = totalViewsCount
+        self.otherViewsCount = otherViewsCount
+    }
 }
 
 extension StatsTopPostsTimeIntervalData: StatsTimeIntervalData {

--- a/WordPressKit/Time Interval/StatsTopReferrersTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopReferrersTimeIntervalData.swift
@@ -6,6 +6,18 @@ public struct StatsTopReferrersTimeIntervalData {
     public let otherReferrerViewsCount: Int
 
     public let referrers: [StatsReferrer]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                referrers: [StatsReferrer],
+                totalReferrerViewsCount: Int,
+                otherReferrerViewsCount: Int) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.referrers = referrers
+        self.totalReferrerViewsCount = totalReferrerViewsCount
+        self.otherReferrerViewsCount = otherReferrerViewsCount
+    }
 }
 
 public struct StatsReferrer {
@@ -15,6 +27,18 @@ public struct StatsReferrer {
     public let iconURL: URL?
 
     public let children: [StatsReferrer]
+
+    public init(title: String,
+                viewsCount: Int,
+                url: URL?,
+                iconURL: URL?,
+                children: [StatsReferrer]) {
+        self.title = title
+        self.viewsCount = viewsCount
+        self.url = url
+        self.iconURL = iconURL
+        self.children = children
+    }
 }
 
 extension StatsTopReferrersTimeIntervalData: StatsTimeIntervalData {

--- a/WordPressKit/Time Interval/StatsTopVideosTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopVideosTimeIntervalData.swift
@@ -5,15 +5,35 @@ public struct StatsTopVideosTimeIntervalData {
     public let totalPlaysCount: Int
     public let otherPlayCount: Int
     public let videos: [StatsVideo]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                videos: [StatsVideo],
+                totalPlaysCount: Int,
+                otherPlayCount: Int) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.videos = videos
+        self.totalPlaysCount = totalPlaysCount
+        self.otherPlayCount = otherPlayCount
+    }
 }
 
 public struct StatsVideo {
-    let postID: Int
-    let title: String
-    let playsCount: Int
-    let videoURL: URL?
+    public let postID: Int
+    public let title: String
+    public let playsCount: Int
+    public let videoURL: URL?
 
-
+    public init(postID: Int,
+                title: String,
+                playsCount: Int,
+                videoURL: URL?) {
+        self.postID = postID
+        self.title = title
+        self.playsCount = playsCount
+        self.videoURL = videoURL
+    }
 }
 
 extension StatsTopVideosTimeIntervalData: StatsTimeIntervalData {


### PR DESCRIPTION
This is TimeInterval counterpart to https://github.com/wordpress-mobile/WordPressKit-iOS/pull/125 — exposing public inits for the Stats data types, so we can make use of them in the WPiOS land.

Nothing really to test here — just make sure the tests still pass :)