### PR TITLE
fix parsing stats data for empty data sets

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.2.2.beta-2"
+  s.version       = "3.2.2.beta-1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "3.2.1"
+  s.version       = "3.2.2.beta-2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/Time Interval/StatsTopClicksTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopClicksTimeIntervalData.swift
@@ -49,14 +49,13 @@ extension StatsTopClicksTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let totalClicks = unwrappedDays["total_clicks"] as? Int,
-            let otherClicks = unwrappedDays["other_clicks"] as? Int,
             let clicks = unwrappedDays["clicks"] as? [[String: AnyObject]]
             else {
                 return nil
         }
 
-
+        let totalClicks = unwrappedDays["total_clicks"] as? Int ?? 0
+        let otherClicks = unwrappedDays["other_clicks"] as? Int ?? 0
 
         self.period = period
         self.periodEndDate = date

--- a/WordPressKit/Time Interval/StatsTopCountryTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopCountryTimeIntervalData.swift
@@ -41,14 +41,15 @@ extension StatsTopCountryTimeIntervalData: StatsTimeIntervalData {
 
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
         guard
-            let countryInfo = jsonDictionary["country-info"] as? [String: AnyObject],
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let totalViews = unwrappedDays["total_views"] as? Int,
-            let otherViews = unwrappedDays["other_views"] as? Int,
             let countriesViews = unwrappedDays["views"] as? [[String: AnyObject]]
             else {
                 return nil
         }
+
+        let countryInfo = jsonDictionary["country-info"] as? [String: AnyObject] ?? [:]
+        let totalViews = unwrappedDays["total_views"] as? Int ?? 0
+        let otherViews = unwrappedDays["other_views"] as? Int ?? 0
 
         self.periodEndDate = date
         self.period = period

--- a/WordPressKit/Time Interval/StatsTopPostsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopPostsTimeIntervalData.swift
@@ -27,12 +27,13 @@ extension StatsTopPostsTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let posts = unwrappedDays["postviews"] as? [[String: AnyObject]],
-            let totalViews = unwrappedDays["total_views"] as? Int,
-            let otherViews = unwrappedDays["other_views"] as? Int
+            let posts = unwrappedDays["postviews"] as? [[String: AnyObject]]
             else {
                 return nil
         }
+
+        let totalViews = unwrappedDays["total_views"] as? Int ?? 0
+        let otherViews = unwrappedDays["other_views"] as? Int ?? 0
 
         self.periodEndDate = date
         self.period = period

--- a/WordPressKit/Time Interval/StatsTopReferrersTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopReferrersTimeIntervalData.swift
@@ -49,12 +49,13 @@ extension StatsTopReferrersTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let totalClicks = unwrappedDays["total_views"] as? Int,
-            let otherClicks = unwrappedDays["other_views"] as? Int,
             let referrers = unwrappedDays["groups"] as? [[String: AnyObject]]
             else {
                 return nil
         }
+
+        let totalClicks = unwrappedDays["total_views"] as? Int ?? 0
+        let otherClicks = unwrappedDays["other_views"] as? Int ?? 0
 
         self.period = period
         self.periodEndDate = date


### PR DESCRIPTION
During testing the new API in WPiOS (https://github.com/wordpress-mobile/WordPress-iOS/pull/11342 ), we found situation where parsing failed for some types where it shouldn't and didn't before. This makes the code somewhat uglier, but c'est la vie ¯\_(ツ)_/¯ 

(I included this branch in the above PR, but just realised I forgot to open a WPKit PR until now. Sorry!)