### PR TITLE
Podfile: Reference 'WordPressKit' as a development pod

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,23 +6,23 @@ use_frameworks!
 platform :ios, '10.0'
 plugin 'cocoapods-repo-update'
 
+def wordpress_kit
+  pod 'WordPressKit', :path => './'
+end
+
 ## WordPress Kit
 ## =============
 ##
 target 'WordPressKit' do
-  pod 'Alamofire', '~> 4.7.3'
-  pod 'CocoaLumberjack', '3.4.2'
-  pod 'WordPressShared', '~> 1.4'
-  pod 'NSObject-SafeExpectations', '~> 0.0.3'
-  pod 'wpxmlrpc', '0.8.4'
-  pod 'UIDeviceIdentifier', '~> 1.1.4'
+  wordpress_kit
+end
 
-  target 'WordPressKitTests' do
-    inherit! :search_paths
-
-    pod 'OHHTTPStubs', '6.1.0'
-    pod 'OHHTTPStubs/Swift', '6.1.0'
-    pod 'OCMock', '~> 3.4.2'
-    pod 'WordPressShared', '~> 1.4'
-  end
+## WordPress Kit Tests
+## ===================
+##
+target 'WordPressKitTests' do
+  wordpress_kit
+  pod 'OHHTTPStubs', '6.1.0'
+  pod 'OHHTTPStubs/Swift', '6.1.0'
+  pod 'OCMock', '~> 3.4.2'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,11 +1,8 @@
 PODS:
   - Alamofire (4.7.3)
-  - CocoaLumberjack (3.4.2):
-    - CocoaLumberjack/Default (= 3.4.2)
-    - CocoaLumberjack/Extensions (= 3.4.2)
-  - CocoaLumberjack/Default (3.4.2)
-  - CocoaLumberjack/Extensions (3.4.2):
-    - CocoaLumberjack/Default
+  - CocoaLumberjack (3.5.2):
+    - CocoaLumberjack/Core (= 3.5.2)
+  - CocoaLumberjack/Core (3.5.2)
   - FormatterKit/Resources (1.8.2)
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
@@ -27,21 +24,23 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (1.1.4)
+  - WordPressKit (3.2.2.beta-1):
+    - Alamofire (~> 4.7.3)
+    - CocoaLumberjack (~> 3.4)
+    - NSObject-SafeExpectations (= 0.0.3)
+    - UIDeviceIdentifier (~> 1.1.4)
+    - WordPressShared (~> 1.4)
+    - wpxmlrpc (= 0.8.4)
   - WordPressShared (1.7.2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - wpxmlrpc (0.8.4)
 
 DEPENDENCIES:
-  - Alamofire (~> 4.7.3)
-  - CocoaLumberjack (= 3.4.2)
-  - NSObject-SafeExpectations (~> 0.0.3)
   - OCMock (~> 3.4.2)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
-  - UIDeviceIdentifier (~> 1.1.4)
-  - WordPressShared (~> 1.4)
-  - wpxmlrpc (= 0.8.4)
+  - WordPressKit (from `./`)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -55,17 +54,22 @@ SPEC REPOS:
     - WordPressShared
     - wpxmlrpc
 
+EXTERNAL SOURCES:
+  WordPressKit:
+    :path: "./"
+
 SPEC CHECKSUMS:
   Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
-  CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
+  CocoaLumberjack: 118bf4a820efc641f79fa487b75ed928dccfae23
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
   NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
+  WordPressKit: dadf13474bdea9178e068cfe5c5295ed98f7c097
   WordPressShared: 63d57a4a07ad9f9a1ee5e8a7162e48fbb5192014
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 34d4f957f37c097c360d2863370ce2e5e06511cc
+PODFILE CHECKSUM: 098746198fa4e4daac2858ccb7b0edddd489f6c7
 
 COCOAPODS: 1.5.3

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -2309,27 +2309,29 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/FormatterKit/FormatterKit.framework",
-				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
-				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
-				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
 				"${BUILT_PRODUCTS_DIR}/NSObject-SafeExpectations/NSObject_SafeExpectations.framework",
 				"${BUILT_PRODUCTS_DIR}/UIDeviceIdentifier/UIDeviceIdentifier.framework",
+				"${BUILT_PRODUCTS_DIR}/WordPressKit/WordPressKit.framework",
+				"${BUILT_PRODUCTS_DIR}/WordPressShared/WordPressShared.framework",
 				"${BUILT_PRODUCTS_DIR}/wpxmlrpc/wpxmlrpc.framework",
+				"${BUILT_PRODUCTS_DIR}/OCMock/OCMock.framework",
+				"${BUILT_PRODUCTS_DIR}/OHHTTPStubs/OHHTTPStubs.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/FormatterKit.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressShared.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NSObject_SafeExpectations.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/UIDeviceIdentifier.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressKit.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WordPressShared.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/wpxmlrpc.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OCMock.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/OHHTTPStubs.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;


### PR DESCRIPTION
### Description

This reverts the changes from https://github.com/wordpress-mobile/WordPressKit-iOS/pull/99 so that we once again use the recommended way of integrating pods being developed.

This will catch any issues with the podspec in CI and the Xcode project more closely resembles how WordPressKit is integrated into other projects. It also removes duplication of dependencies.

### Testing Details

- Run `bundle exec pod install` and run the tests.

- [x] Please check here if your pull request includes additional test coverage.
