### PR TITLE
Add support for specifying custom limit of objects to fetch in stats insights

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.0.0-beta.2"
+  s.version       = "4.0.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/Insights/StatsDotComFollowersInsight.swift
+++ b/WordPressKit/Insights/StatsDotComFollowersInsight.swift
@@ -12,9 +12,9 @@ public struct StatsDotComFollowersInsight {
 extension StatsDotComFollowersInsight: StatsInsightData {
 
     //MARK: - StatsInsightData Conformance
-    public static var queryProperties: [String: String] {
+    public static func queryProperties(with maxCount: Int) -> [String: String] {
         return ["type": "wpcom",
-                "max": "7"]
+                "max": String(maxCount)]
     }
 
     public static var pathComponent: String {

--- a/WordPressKit/Insights/StatsEmailFollowersInsight.swift
+++ b/WordPressKit/Insights/StatsEmailFollowersInsight.swift
@@ -12,9 +12,9 @@ public struct StatsEmailFollowersInsight {
 extension StatsEmailFollowersInsight: StatsInsightData {
 
     //MARK: - StatsInsightData Conformance
-    public static var queryProperties: [String: String] {
+    public static func queryProperties(with maxCount: Int) -> [String: String] {
         return ["type": "email",
-                "max": "7"]
+                "max": String(maxCount)]
     }
 
     public static var pathComponent: String {

--- a/WordPressKit/Insights/StatsLastPostInsight.swift
+++ b/WordPressKit/Insights/StatsLastPostInsight.swift
@@ -27,7 +27,7 @@ public struct StatsLastPostInsight {
 extension StatsLastPostInsight: StatsInsightData {
 
     //MARK: - StatsInsightData Conformance
-    public static var queryProperties: [String: String] {
+    public static func queryProperties(with maxCount: Int) -> [String: String] {
         return ["order_by": "date",
                 "number": "1",
                 "type": "post",


### PR DESCRIPTION
### Description

This fixes the discrepancy in the API for Insights/TimeInterval-based stats objects, where you could provide a custom limit of how many objects you're interested in for the TimeInterval ones, but not for Insights. 

This helps closing https://github.com/wordpress-mobile/WordPress-iOS/issues/11238 and https://github.com/wordpress-mobile/WordPress-iOS/issues/11182.

### Testing Details

Check out corresponding WPiOS PR (https://github.com/wordpress-mobile/WordPress-iOS/pull/11473) and verify that the data shows up properly for 