### PR TITLE
Fix endpoint used to get Post Stats data

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.0.0-beta.3"
+  s.version       = "4.0.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.0.0-beta.4"
+  s.version       = "4.1.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -108,7 +108,7 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
     }
 
     public func getDetails(forPostID postID: Int, completion: @escaping ((StatsPostDetails?, Error?) -> Void)) {
-        let path = self.path(forEndpoint: "sites/\(siteID)/post/\(postID)/", withVersion: ._1_1)
+        let path = self.path(forEndpoint: "sites/\(siteID)/stats/post/\(postID)/", withVersion: ._1_1)
 
         wordPressComRestApi.GET(path, parameters: [:], success: { (response, _) in
             guard

--- a/WordPressKitTests/StatsRemoteV2Tests.swift
+++ b/WordPressKitTests/StatsRemoteV2Tests.swift
@@ -34,7 +34,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     var siteVisitsDataEndpoint: String { return "sites/\(siteID)/stats/visits/" }
     var sitePostsDataEndpoint: String { return "sites/\(siteID)/stats/top-posts/" }
     var sitePublishedPostsEndpoint: String { return "sites/\(siteID)/posts/" }
-    var sitePostDetailsEndpoint: String { return "sites/\(siteID)/post/9001" }
+    var sitePostDetailsEndpoint: String { return "sites/\(siteID)/stats/post/9001" }
 
 
     var remote: StatsServiceRemoteV2!


### PR DESCRIPTION
### Description

Fixes #n/a

This fixes the endpoint used to fetch data for Post Stats.

It can be tested with WPiOS https://github.com/wordpress-mobile/WordPress-iOS/pull/11504.
