### PR TITLE
Issues/non localized plans for all sites

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.0-beta.2"
+  s.version       = "4.1.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.0-beta.1"
+  s.version       = "4.1.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -487,6 +487,7 @@
 		E1EF5D5D1F9F329900B6D53E /* SitePluginCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1EF5D5C1F9F329900B6D53E /* SitePluginCapabilities.swift */; };
 		E61A51A621B172A900A5F902 /* RemoteWpcomPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = E61A51A521B172A900A5F902 /* RemoteWpcomPlan.swift */; };
 		E632D7781F6E047400297F6D /* SocialLogin2FANonceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */; };
+		E670CD722277A85000E75735 /* plans-me-sites-success.json in Resources */ = {isa = PBXBuildFile; fileRef = E670CD712277A85000E75735 /* plans-me-sites-success.json */; };
 		E689431E21B0A1A800C5E4A7 /* plans-mobile-success.json in Resources */ = {isa = PBXBuildFile; fileRef = E689431D21B0A1A800C5E4A7 /* plans-mobile-success.json */; };
 		E6C1E8491EF21FC100D139D9 /* is-passwordless-account-no-account-found.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C1E8471EF21FC100D139D9 /* is-passwordless-account-no-account-found.json */; };
 		E6C1E84A1EF21FC100D139D9 /* is-passwordless-account-success.json in Resources */ = {isa = PBXBuildFile; fileRef = E6C1E8481EF21FC100D139D9 /* is-passwordless-account-success.json */; };
@@ -1009,6 +1010,7 @@
 		E33F1EA3284E0454909D1967 /* Pods-WordPressKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.release.xcconfig"; sourceTree = "<group>"; };
 		E61A51A521B172A900A5F902 /* RemoteWpcomPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteWpcomPlan.swift; sourceTree = "<group>"; };
 		E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocialLogin2FANonceInfo.swift; sourceTree = "<group>"; };
+		E670CD712277A85000E75735 /* plans-me-sites-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "plans-me-sites-success.json"; sourceTree = "<group>"; };
 		E689431D21B0A1A800C5E4A7 /* plans-mobile-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "plans-mobile-success.json"; sourceTree = "<group>"; };
 		E6C1E8471EF21FC100D139D9 /* is-passwordless-account-no-account-found.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "is-passwordless-account-no-account-found.json"; sourceTree = "<group>"; };
 		E6C1E8481EF21FC100D139D9 /* is-passwordless-account-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "is-passwordless-account-success.json"; sourceTree = "<group>"; };
@@ -1685,6 +1687,7 @@
 				74D67F1C1F15C3240010C5ED /* people-validate-invitation-failure.json */,
 				74D67F1D1F15C3240010C5ED /* people-validate-invitation-success.json */,
 				E689431D21B0A1A800C5E4A7 /* plans-mobile-success.json */,
+				E670CD712277A85000E75735 /* plans-me-sites-success.json */,
 				E1E89C671FD6B2E9006E7A33 /* plugin-directory-jetpack.json */,
 				40E4698C2017D2E30030DB5F /* plugin-directory-new.json */,
 				40E4698A2017C2840030DB5F /* plugin-directory-popular.json */,
@@ -2152,6 +2155,7 @@
 				404057D8221C986A0060250C /* stats-clicks-data.json in Resources */,
 				436D56532121F60500CEAA33 /* supported-states-empty.json in Resources */,
 				9ABE13EB223F8DA3006A8806 /* jetpack-service-error-invalid-credentials.json in Resources */,
+				E670CD722277A85000E75735 /* plans-me-sites-success.json in Resources */,
 				93AC8ED31ED32FD000900F5A /* stats-v1.1-streak.json in Resources */,
 				7403A2F91EF06FEB00DED7DC /* me-settings-change-email-success.json in Resources */,
 				439A44DC2107CE3C00795ED7 /* site-plans-v3-empty-failure.json in Resources */,

--- a/WordPressKit/RemoteWpcomPlan.swift
+++ b/WordPressKit/RemoteWpcomPlan.swift
@@ -36,3 +36,8 @@ public struct RemotePlanFeature {
     // Deprecated.  An icon associeated with the feature.
     public let iconURL: URL?
 }
+
+public struct RemotePlanSimpleDescription {
+    public let planID: Int
+    public let name: String
+}

--- a/WordPressKitTests/Mock Data/plans-me-sites-success.json
+++ b/WordPressKitTests/Mock Data/plans-me-sites-success.json
@@ -1,0 +1,44 @@
+{
+    "sites": [
+        {
+            "ID": 999999990,
+            "plan": {
+                "product_id": 2000,
+                "product_slug": "jetpack_premium",
+                "product_name_short": "Premium"
+            }
+        },
+        {
+            "ID": 999999991,
+            "plan": {
+                "product_id": 1010,
+                "product_slug": "blogger-bundle",
+                "product_name_short": "Blogger"
+            }
+        },
+        {
+            "ID": 999999992,
+            "plan": {
+                "product_id": 2002,
+                "product_slug": "jetpack_free",
+                "product_name_short": "Free"
+            }
+        },
+        {
+            "ID": 999999993,
+            "plan": {
+                "product_id": 1008,
+                "product_slug": "business-bundle",
+                "product_name_short": "Business"
+            }
+        },
+        {
+            "ID": 999999994,
+            "plan": {
+                "product_id": 1,
+                "product_slug": "free_plan",
+                "product_name_short": "Free"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
This PR adds a new method to fetch simple plan descriptions for the current user's sites.

We call the `me/sites` to fetch the list of the user's sites.  The call passes the `fields=siteID,plan` parameter to limit the response to just the desired information.  We also specify the `locale` in order to override WordPressKit's default locale behavior. For our use case in WPiOS, we want to specify an `en` locale in order to return plan descriptions in English on Zendesk tickets. 

To test:
Run the new tests.  Confirm that they pass. 

- [x] Please check here if your pull request includes additional test coverage.
