### PR TITLE
Compatibility with both CocoaPods dynamic and static frameworks

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		17CD0CC320C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CD0CC220C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift */; };
 		17CE77F120C6EB41001DEA5A /* ReaderFeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77F020C6EB41001DEA5A /* ReaderFeed.swift */; };
 		17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */; };
+		1A4F98672279A87D00D86E8E /* WPKit-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4F98662279A87D00D86E8E /* WPKit-Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		240315B0A1D6C2B981572B5B /* Pods_WordPressKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED05C8FF3E61D93CE5BA527E /* Pods_WordPressKitTests.framework */; };
 		40247DFA2120D8E100AE1C3C /* AutomatedTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40247DF92120D8E100AE1C3C /* AutomatedTransferService.swift */; };
 		40247DFC2120E69600AE1C3C /* AutomatedTransferStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40247DFB2120E69600AE1C3C /* AutomatedTransferStatus.swift */; };
@@ -525,6 +526,7 @@
 		17CD0CC220C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchServiceRemote.swift; sourceTree = "<group>"; };
 		17CE77F020C6EB41001DEA5A /* ReaderFeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderFeed.swift; sourceTree = "<group>"; };
 		17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchServiceRemoteTests.swift; sourceTree = "<group>"; };
+		1A4F98662279A87D00D86E8E /* WPKit-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPKit-Swift.h"; sourceTree = "<group>"; };
 		264F5C834541BBF2018F4964 /* Pods-WordPressKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		40247DF92120D8E100AE1C3C /* AutomatedTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomatedTransferService.swift; sourceTree = "<group>"; };
 		40247DFB2120E69600AE1C3C /* AutomatedTransferStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomatedTransferStatus.swift; sourceTree = "<group>"; };
@@ -1850,6 +1852,7 @@
 				B5A4822C20AC6C19009D95F6 /* WPKitLogging.m */,
 				B5A4822620AC6BA8009D95F6 /* WPKitLoggingPrivate.h */,
 				B5A4822720AC6BA9009D95F6 /* WPKitLoggingPrivate.m */,
+				1A4F98662279A87D00D86E8E /* WPKit-Swift.h */,
 			);
 			path = Private;
 			sourceTree = "<group>";
@@ -1954,6 +1957,7 @@
 				740B23C41F17EE8000067A2A /* RemotePost.h in Headers */,
 				740B23C21F17EE8000067A2A /* RemotePostCategory.h in Headers */,
 				9309995B1F16616A00F006A1 /* RemoteTheme.h in Headers */,
+				1A4F98672279A87D00D86E8E /* WPKit-Swift.h in Headers */,
 				93F50A371F226B9300B5BEBA /* WordPressComServiceRemote.h in Headers */,
 				93C674EB1EE8348F00BFAF05 /* RemoteBlogOptionsHelper.h in Headers */,
 				9368C7B91EC630270092CE8E /* StatsSummary.h in Headers */,

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -2,7 +2,7 @@
 #import "RemoteBlog.h"
 #import "RemoteBlogOptionsHelper.h"
 #import "WPKitLoggingPrivate.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/BlogServiceRemoteREST.m
@@ -3,7 +3,7 @@
 #import "NSMutableDictionary+Helpers.h"
 #import "RemotePostType.h"
 #import "WPKitLoggingPrivate.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKit/BlogServiceRemoteXMLRPC.m
+++ b/WordPressKit/BlogServiceRemoteXMLRPC.m
@@ -2,7 +2,7 @@
 #import "NSMutableDictionary+Helpers.h"
 #import "RemotePostType.h"
 #import "WPKitLoggingPrivate.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -1,5 +1,5 @@
 #import "CommentServiceRemoteREST.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 #import "RemoteComment.h"
 
 @import NSObject_SafeExpectations;

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -1,5 +1,5 @@
 #import "CommentServiceRemoteXMLRPC.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 #import "RemoteComment.h"
 
 @import wpxmlrpc;

--- a/WordPressKit/MediaServiceRemoteREST.m
+++ b/WordPressKit/MediaServiceRemoteREST.m
@@ -1,7 +1,7 @@
 #import "MediaServiceRemoteREST.h"
 #import "RemoteMedia.h"
 #import "WPKitLoggingPrivate.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import WordPressShared;
 @import NSObject_SafeExpectations;
 

--- a/WordPressKit/MediaServiceRemoteXMLRPC.m
+++ b/WordPressKit/MediaServiceRemoteXMLRPC.m
@@ -1,6 +1,6 @@
 #import "MediaServiceRemoteXMLRPC.h"
 #import "RemoteMedia.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 
 @import WordPressShared;
 @import NSObject_SafeExpectations;

--- a/WordPressKit/MenusServiceRemote.m
+++ b/WordPressKit/MenusServiceRemote.m
@@ -2,7 +2,7 @@
 #import "RemoteMenu.h"
 #import "RemoteMenuItem.h"
 #import "RemoteMenuLocation.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 #import "WPKitLoggingPrivate.h"
 @import WordPressShared;
 @import NSObject_SafeExpectations;

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -1,7 +1,7 @@
 #import "PostServiceRemoteREST.h"
 #import "RemotePost.h"
 #import "RemotePostCategory.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import WordPressShared;
 @import NSObject_SafeExpectations;
 

--- a/WordPressKit/PostServiceRemoteXMLRPC.m
+++ b/WordPressKit/PostServiceRemoteXMLRPC.m
@@ -2,7 +2,7 @@
 #import "RemotePost.h"
 #import "RemotePostCategory.h"
 #import "NSMutableDictionary+Helpers.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKit/Private/WPKit-Swift.h
+++ b/WordPressKit/Private/WPKit-Swift.h
@@ -1,0 +1,8 @@
+// Import this header instead of <WordPressKit/WordPressKit-Swift.h>
+// This allows the pod to be built as a static or dynamic framework
+// See https://github.com/CocoaPods/CocoaPods/issues/7594
+#if __has_include("WordPressKit-Swift.h")
+    #import "WordPressKit-Swift.h"
+#else
+    #import <WordPressKit/WordPressKit-Swift.h>
+#endif

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -2,7 +2,7 @@
 #import "RemoteReaderPost.h"
 #import "RemoteSourcePostAttribution.h"
 #import "ReaderTopicServiceRemote.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKit/ReaderSiteServiceRemote.m
+++ b/WordPressKit/ReaderSiteServiceRemote.m
@@ -1,6 +1,6 @@
 #import "ReaderSiteServiceRemote.h"
 #import "RemoteReaderSite.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 #import "WPKitLoggingPrivate.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;

--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -1,7 +1,7 @@
 #import "ReaderTopicServiceRemote.h"
 #import "RemoteReaderTopic.h"
 #import "RemoteReaderSiteInfo.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKit/RemoteBlogOptionsHelper.m
+++ b/WordPressKit/RemoteBlogOptionsHelper.m
@@ -1,6 +1,6 @@
 #import "RemoteBlogOptionsHelper.h"
 #import "NSMutableDictionary+Helpers.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -1,6 +1,6 @@
 #import "RemoteReaderPost.h"
 #import "RemoteSourcePostAttribution.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 
 @implementation RemoteReaderPost
 

--- a/WordPressKit/ServiceRemoteWordPressComREST.m
+++ b/WordPressKit/ServiceRemoteWordPressComREST.m
@@ -1,5 +1,5 @@
 #import "ServiceRemoteWordPressComREST.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 
 ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_0 = 1000;
 ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_1 = 1001;

--- a/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -3,7 +3,7 @@
 #import "RemoteTaxonomyPaging.h"
 #import "RemotePostCategory.h"
 #import "WPKitLoggingPrivate.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
+++ b/WordPressKit/TaxonomyServiceRemoteXMLRPC.m
@@ -1,7 +1,7 @@
 #import "TaxonomyServiceRemoteXMLRPC.h"
 #import "RemotePostTag.h"
 #import "RemoteTaxonomyPaging.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 #import "WPKitLoggingPrivate.h"
 @import WordPressShared;
 @import NSObject_SafeExpectations;

--- a/WordPressKit/ThemeServiceRemote.m
+++ b/WordPressKit/ThemeServiceRemote.m
@@ -1,7 +1,7 @@
 #import "ThemeServiceRemote.h"
 
 #import "RemoteTheme.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 
 // Service dictionary keys

--- a/WordPressKit/WPStatsServiceRemote.m
+++ b/WordPressKit/WPStatsServiceRemote.m
@@ -8,7 +8,7 @@
 #import <WordPressShared/NSString+XMLExtensions.h>
 #import <WordPressShared/WPAnalytics.h>
 @import NSObject_SafeExpectations;
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 
 static NSString *const WordPressComApiClientVersionPrefix = @"rest/v1.1";
 static NSInteger const NumberOfDays = 12;

--- a/WordPressKit/WordPressComServiceRemote.m
+++ b/WordPressKit/WordPressComServiceRemote.m
@@ -1,5 +1,5 @@
 #import "WordPressComServiceRemote.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import NSObject_SafeExpectations;
 @import WordPressShared;
 

--- a/WordPressKitTests/MenusServiceRemoteTests.m
+++ b/WordPressKitTests/MenusServiceRemoteTests.m
@@ -2,7 +2,7 @@
 #import <XCTest/XCTest.h>
 #import "MenusServiceRemote.h"
 #import "RemoteMenu.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 
 @interface MenusServicRemoteTests : XCTestCase
 

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -3,7 +3,7 @@
 #import <XCTest/XCTest.h>
 #import "PostServiceRemoteREST.h"
 #import "RemotePost.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 
 @interface PostServiceRemoteRESTTests : XCTestCase
 @end

--- a/WordPressKitTests/ReaderPostServiceRemoteTests.m
+++ b/WordPressKitTests/ReaderPostServiceRemoteTests.m
@@ -3,7 +3,7 @@
 #import "RemoteReaderTopic.h"
 #import "ReaderPostServiceRemote.h"
 #import "RemoteReaderPost.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 @import WordPressShared;
 
 @interface ReaderPostServiceRemote ()

--- a/WordPressKitTests/ReaderTopicServiceRemoteTests.m
+++ b/WordPressKitTests/ReaderTopicServiceRemoteTests.m
@@ -2,7 +2,7 @@
 
 #import "ReaderTopicServiceRemote.h"
 #import "RemoteReaderTopic.h"
-#import <WordPressKit/WordPressKit-Swift.h>
+#import "WPKit-Swift.h"
 
 @interface ReaderTopicServiceRemote()
 - (RemoteReaderTopic *)normalizeTopicDictionary:(NSDictionary *)topicDict subscribed:(BOOL)subscribed recommended:(BOOL)recommended;


### PR DESCRIPTION
### Description

This makes the changes needed for the WordPressKit pod to be installed as a static or dynamic framework (with or without `use_frameworks!`). Currently, it does not work correctly when installed statically.

The changes are as follows:

- Use `#import "WPKit-Swift.h` instead of `#import <WordPressKit/WordPressKit-Swift.h>` to avoid the issue described in https://github.com/CocoaPods/CocoaPods/issues/7594.

Related to https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/203.

### Testing Details

You can see that the tests still build and pass with the changes I've made.

- [ ] Please check here if your pull request includes additional test coverage.
