### PR TITLE
Removes some no-longer-used code.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.0-beta.1"
+  s.version       = "4.1.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -41,8 +41,6 @@ import CocoaLumberjack
 /// WordPress XMLRPC sites.
 open class WordPressOrgXMLRPCValidator: NSObject {
 
-    @objc public static let UserInfoHasJetpackKey = "UserInfoHasJetpackKey"
-
     // The documentation for NSURLErrorHTTPTooManyRedirects says that 16
     // is the default threshold for allowable redirects.
     private let redirectLimit = 16
@@ -133,20 +131,8 @@ open class WordPressOrgXMLRPCValidator: NSObject {
                 // Fetch the original url and look for the RSD link
                 self.guessXMLRPCURLFromHTMLURL(originalXMLRPCURL, success: success, failure: { (error) in
                     DDLogError(error.localizedDescription)
-                    // See if this is a Jetpack site that's having problems.
-                    let service = JetpackServiceRemote(wordPressComRestApi: WordPressComRestApi.anonymousApi(userAgent: userAgent))
-                    service.checkSiteHasJetpack(originalXMLRPCURL, success: { (hasJetpack) in
-                        var err = error
-                        if hasJetpack {
-                            var userInfo = err.userInfo
-                            userInfo[WordPressOrgXMLRPCValidator.UserInfoHasJetpackKey] = true
-                            err = NSError(domain: err.domain, code: err.code, userInfo: userInfo)
-                        }
-                        errorHandler(err)
-                    }, failure: { (_) in
-                        // Return the previous error, not an error when checking for jp.
-                        errorHandler(error)
-                    })
+                    
+                    errorHandler(error)
                 })
             })
         })


### PR DESCRIPTION
### Description

This PR is related to: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/90

Since that PR no longer uses this code, and no other of our repos does either, I'm removing it.

### Testing Details

You can test this PR through WPiOS branch: `issue/11505-remove-jetpack-error`.

Just make sure it builds.

- [ ] Please check here if your pull request includes additional test coverage.