### PR TITLE
Reverts the get post API call to use version 1.1 of the endpoint.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.0.0"
+  s.version       = "4.0.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -34,7 +34,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
     NSDictionary *parameters = @{ @"context": @"edit" };
     

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -38,7 +38,7 @@
     NSNumber *postID = @1;
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@", dotComID, postID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
     OCMStub([api GET:[OCMArg isEqual:url]
           parameters:[OCMArg isNotNil]


### PR DESCRIPTION
This PR simple reverts the get post REST API call to version 1.1 because version 1.2 is not implemented.

To test:
 - Make sure unit tests still working
 - Test on the main app using this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/11606