### PR TITLE
Fixes a small typo in an error message.

### DIFF
--- a/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -30,7 +30,7 @@ import CocoaLumberjack
         case .blocked:
             return NSLocalizedString("Couldn't connect. Your host is blocking POST requests, and the app needs that in order to communicate with your site. Contact your host to solve this problem.", comment: "Message to show to user when he tries to add a self-hosted site but the host returned a 405 error, meaning that the host is blocking POST requests on /xmlrpc.php file.")
         case .forbidden:
-            return NSLocalizedString("Couldn't connect. We received a 403 error when trying to access your site XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve this problem.", comment: "Message to show to user when he tries to add a self-hosted site but the host returned a 403 error, meaning that the access to the /xmlrpc.php file is forbidden.")
+            return NSLocalizedString("Couldn't connect. We received a 403 error when trying to access your site's XMLRPC endpoint. The app needs that in order to communicate with your site. Contact your host to solve this problem.", comment: "Message to show to user when he tries to add a self-hosted site but the host returned a 403 error, meaning that the access to the /xmlrpc.php file is forbidden.")
         case .xmlrpc_missing:
             return NSLocalizedString("Couldn't connect. Required XML-RPC methods are missing on the server.", comment: "Message to show to user when he tries to add a self-hosted site with RSD link present, but xmlrpc is missing.")
         }


### PR DESCRIPTION
This PR fixes a small typo in an XML-RPC error message. 

@diegoreymendez would you mind a quick review?  If its convenient maybe we could include this fix when tagging the new release with the update in #152? 

