### PR TITLE
Implemented savePost (calling autoSave endpoint)

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.0-beta.3"
+  s.version       = "4.1.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemote.h
+++ b/WordPressKit/PostServiceRemote.h
@@ -63,6 +63,17 @@
            failure:(void (^)(NSError *error))failure;
 
 /**
+ *  @brief      Saves a post.
+ *
+ *  @param      post        The post to update.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)savePost:(RemotePost *)post
+           success:(void (^)(RemotePost *post, NSString *previewURL))success
+           failure:(void (^)(NSError *error))failure;
+
+/**
  *  @brief      Deletes a post.
  *
  *  @param      post        The post to delete.  Cannot be nil.

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -183,6 +183,33 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
            }];
 }
 
+- (void)savePost:(RemotePost *)post
+           success:(void (^)(RemotePost *, NSString *))success
+           failure:(void (^)(NSError *))failure
+{
+    NSParameterAssert([post isKindOfClass:[RemotePost class]]);
+    
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/autosave", self.siteID, post.postID];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    
+    NSDictionary *parameters = [self parametersWithRemotePost:post];
+    
+    [self.wordPressComRestApi POST:requestUrl
+                        parameters:parameters
+                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                               RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
+                               NSString *previewURL = responseObject[@"preview_URL"];
+                               if (success) {
+                                   success(post, previewURL);
+                               }
+                           } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                               if (failure) {
+                                   failure(error);
+                               }
+                           }];
+}
+
 - (void)deletePost:(RemotePost *)post
            success:(void (^)(void))success
            failure:(void (^)(NSError *))failure


### PR DESCRIPTION

In order to preview published posts with their current updates, we need to call the autoSave endpoint. 
This PR adds that call.
The successful response to this call contains a previewURL which we returning in the success block so that the caller can use it to preview correctly. 

Addresses:  https://github.com/wordpress-mobile/WordPress-iOS/issues/9287

This branch is used in this WPiOS PR

- [ ] Please check here if your pull request includes additional test coverage.
