### PR TITLE
Update `WordPressShared` pod version

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -9,7 +9,7 @@ plugin 'cocoapods-repo-update'
 def wordpresskit_pods
   pod 'Alamofire', '~> 4.7.3'
   pod 'CocoaLumberjack', '3.4.2'
-  pod 'WordPressShared', '~> 1.4'
+  pod 'WordPressShared', '~> 1.8.0-beta'
   pod 'NSObject-SafeExpectations', '~> 0.0.3'
   pod 'wpxmlrpc', '0.8.4'
   pod 'UIDeviceIdentifier', '~> 1.1.4'
@@ -30,5 +30,5 @@ target 'WordPressKitTests' do
   pod 'OHHTTPStubs', '6.1.0'
   pod 'OHHTTPStubs/Swift', '6.1.0'
   pod 'OCMock', '~> 3.4.2'
-  pod 'WordPressShared', '~> 1.4'
+  pod 'WordPressShared', '~> 1.8.0-beta'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (1.1.4)
-  - WordPressShared (1.7.3):
+  - WordPressShared (1.8.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - wpxmlrpc (0.8.4)
@@ -40,7 +40,7 @@ DEPENDENCIES:
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
   - UIDeviceIdentifier (~> 1.1.4)
-  - WordPressShared (~> 1.4)
+  - WordPressShared (~> 1.8.0-beta)
   - wpxmlrpc (= 0.8.4)
 
 SPEC REPOS:
@@ -63,9 +63,9 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: 8f8a24b257a4d978c8d40ad1e7355b944ffbfa8c
-  WordPressShared: 0853172642668b0fbf5c8d56e743896ebf9aae01
+  WordPressShared: c77c0fc4840d5694a1a684f8c541224dfdb147f2
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
-PODFILE CHECKSUM: 2d40a9a3484ab5030d6ddd135b604a0be90271c8
+PODFILE CHECKSUM: db3bdf0c001097977876ad82d356303ac06e4c81
 
 COCOAPODS: 1.6.1

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.1-beta.1"
+  s.version       = "4.1.1-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.7.3'
   s.dependency 'CocoaLumberjack', '~> 3.4'
-  s.dependency 'WordPressShared', '~> 1.4'
+  s.dependency 'WordPressShared', '~> 1.8.0-beta'
   s.dependency 'NSObject-SafeExpectations', '0.0.3'
   s.dependency 'wpxmlrpc', '0.8.4'
   s.dependency 'UIDeviceIdentifier', '~> 1.1.4'


### PR DESCRIPTION
### Description

Updated `WordPressShared` dependency to `1.8.0-beta` and its own version to `4.1.1-beta.2`.
Related PRs:
https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/204
https://github.com/wordpress-mobile/WordPress-iOS/pull/11673

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

- [ ] Please check here if your pull request includes additional test coverage.
