### PR TITLE
Fix bug that prevented the `limit` parameter being respected by the `StatsSummaryTimeIntervalData` fetches

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.1"
+  s.version       = "4.2-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -69,10 +69,9 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: "sites/\(siteID)/\(pathComponent)/", withVersion: ._1_1)
 
         let staticProperties = ["period": period.stringValue,
-                                "date": periodDataQueryDateFormatter.string(from: endingOn),
-                                "max": limit as AnyObject] as [String: AnyObject]
+                                "date": periodDataQueryDateFormatter.string(from: endingOn)] as [String: AnyObject]
 
-        let classProperties = TimeStatsType.queryProperties(with: endingOn, period: period) as [String: AnyObject]
+        let classProperties = TimeStatsType.queryProperties(with: endingOn, period: period, maxCount: limit) as [String: AnyObject]
 
         let properties = staticProperties.merging(classProperties) { val1, _ in
             return val1
@@ -263,13 +262,13 @@ public protocol StatsTimeIntervalData {
 
     init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject])
 
-    static func queryProperties(with date: Date, period: StatsPeriodUnit) -> [String: String]
+    static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String: String]
 }
 
 extension StatsTimeIntervalData {
 
-    public static func queryProperties(with date: Date, period: StatsPeriodUnit) -> [String: String] {
-        return [:]
+    public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String: String] {
+        return ["max": String(maxCount)]
     }
 
     // Most of the responses for time data come in a unwieldy format, that requires awkwkard unwrapping

--- a/WordPressKit/Time Interval/StatsSummaryTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsSummaryTimeIntervalData.swift
@@ -42,10 +42,9 @@ extension StatsSummaryTimeIntervalData: StatsTimeIntervalData {
         return "stats/visits"
     }
 
-    public static func queryProperties(with date: Date, period: StatsPeriodUnit) -> [String: String] {
-        return ["quantity": "10",
-                "stat_fields": "views,visitors,likes,comments",
-                "unit": period.stringValue]
+    public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String : String] {
+        return ["unit": period.stringValue,
+                "quantity": String(maxCount)]
     }
 
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {


### PR DESCRIPTION
### Description

There was a bug in the implementation of `StatsTimeIntervalData`-based Stats entities that made the library ignore the `limit` parameter for `StatsSummaryTimeIntervalData`.

This fixes that.

### Testing Details

Check out related WPiOS PR (link to come shortly) and verify that the library now respects the `limit` parameter`.