### PR TITLE
Stats: separate out fetching "likes" from "Summary" for performance speedup.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.2-beta.1"
+  s.version       = "4.1.2-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/Time Interval/StatsSummaryTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsSummaryTimeIntervalData.swift
@@ -44,7 +44,8 @@ extension StatsSummaryTimeIntervalData: StatsTimeIntervalData {
 
     public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String : String] {
         return ["unit": period.stringValue,
-                "quantity": String(maxCount)]
+                "quantity": String(maxCount),
+                "stat_fields": "views,visitors,comments"]
     }
 
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
@@ -69,7 +70,6 @@ extension StatsSummaryTimeIntervalData: StatsTimeIntervalData {
             let periodIndex = fieldsArray.firstIndex(of: "period"),
             let viewsIndex = fieldsArray.firstIndex(of: "views"),
             let visitorsIndex = fieldsArray.firstIndex(of: "visitors"),
-            let likesIndex = fieldsArray.firstIndex(of: "likes"),
             let commentsIndex = fieldsArray.firstIndex(of: "comments")
             else {
                 return nil
@@ -82,7 +82,7 @@ extension StatsSummaryTimeIntervalData: StatsTimeIntervalData {
                                                               periodIndex: periodIndex,
                                                               viewsIndex: viewsIndex,
                                                               visitorsIndex: visitorsIndex,
-                                                              likesIndex: likesIndex,
+                                                              likesIndex: nil,
                                                               commentsIndex: commentsIndex) }
     }
 }
@@ -91,23 +91,61 @@ private extension StatsSummaryData {
     init?(dataArray: [Any],
           period: StatsPeriodUnit,
           periodIndex: Int,
-          viewsIndex: Int,
-          visitorsIndex: Int,
-          likesIndex: Int,
-          commentsIndex: Int) {
+          viewsIndex: Int?,
+          visitorsIndex: Int?,
+          likesIndex: Int?,
+          commentsIndex: Int?) {
+
         guard
             let periodString = dataArray[periodIndex] as? String,
-            let periodStart = type(of: self).parsedDate(from: periodString, for: period),
-            let viewsCount = dataArray[viewsIndex] as? Int,
-            let visitorsCount = dataArray[visitorsIndex] as? Int,
-            let likesCount = dataArray[likesIndex] as? Int,
-            let commentsCount = dataArray[commentsIndex] as? Int
-            else {
+            let periodStart = type(of: self).parsedDate(from: periodString, for: period) else {
                 return nil
+        }
+
+        let viewsCount: Int
+        let visitorsCount: Int
+        let likesCount: Int
+        let commentsCount: Int
+
+        if let viewsIndex = viewsIndex {
+            guard let count = dataArray[viewsIndex] as? Int else {
+                return nil
+            }
+            viewsCount = count
+        } else {
+            viewsCount = 0
+        }
+
+        if let visitorsIndex = visitorsIndex {
+            guard let count = dataArray[visitorsIndex] as? Int else {
+                return nil
+            }
+            visitorsCount = count
+        } else {
+            visitorsCount = 0
+        }
+
+        if let likesIndex = likesIndex {
+            guard let count = dataArray[likesIndex] as? Int else {
+                return nil
+            }
+            likesCount = count
+        } else {
+            likesCount = 0
+        }
+
+        if let commentsIndex = commentsIndex {
+            guard let count = dataArray[commentsIndex] as? Int else {
+                return nil
+            }
+            commentsCount = count
+        } else {
+            commentsCount = 0
         }
 
         self.period = period
         self.periodStartDate = periodStart
+
         self.viewsCount = viewsCount
         self.visitorsCount = visitorsCount
         self.likesCount = likesCount
@@ -146,3 +184,63 @@ private extension StatsSummaryData {
         return df
     }
 }
+
+
+/// So this is very awkward and neccessiated by our API. Turns out, calculating likes
+/// for long periods of times (months/years) on large sites takes _ages_ (up to a minute sometimes).
+/// Thankfully, calculating views/visitors/comments takes a much shorter time. (~2s, which is still suuuuuper long, but acceptable.)
+/// We don't want to wait a whole minute to display the rest of the data, so we fetch the likes separately.
+public struct StatsLikesSummaryTimeIntervalData {
+
+    public let period: StatsPeriodUnit
+    public let periodEndDate: Date
+
+    public let summaryData: [StatsSummaryData]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                summaryData: [StatsSummaryData]) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.summaryData = summaryData
+    }
+}
+
+extension StatsLikesSummaryTimeIntervalData: StatsTimeIntervalData {
+
+    public static var pathComponent: String {
+        return "stats/visits"
+    }
+
+    public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String : String] {
+        return ["unit": period.stringValue,
+                "quantity": String(maxCount),
+                "stat_fields": "likes"]
+    }
+
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+        guard
+            let fieldsArray = jsonDictionary["fields"] as? [String],
+            let data = jsonDictionary["data"] as? [[Any]]
+            else {
+                return nil
+        }
+
+        guard
+            let periodIndex = fieldsArray.firstIndex(of: "period"),
+            let likesIndex = fieldsArray.firstIndex(of: "likes") else {
+                return nil
+        }
+
+        self.period = period
+        self.periodEndDate = date
+        self.summaryData = data.compactMap { StatsSummaryData(dataArray: $0,
+                                                              period: period,
+                                                              periodIndex: periodIndex,
+                                                              viewsIndex: nil,
+                                                              visitorsIndex: nil,
+                                                              likesIndex: likesIndex,
+                                                              commentsIndex: nil) }
+    }
+}
+

--- a/WordPressKitTests/StatsRemoteV2Tests.swift
+++ b/WordPressKitTests/StatsRemoteV2Tests.swift
@@ -381,7 +381,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
             XCTAssertEqual(summary?.summaryData[0].viewsCount, 5140)
             XCTAssertEqual(summary?.summaryData[0].visitorsCount, 3560)
-            XCTAssertEqual(summary?.summaryData[0].likesCount, 70)
+            XCTAssertEqual(summary?.summaryData[0].likesCount, 0)
             XCTAssertEqual(summary?.summaryData[0].commentsCount, 1)
 
             let nineDaysAgo = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -9, to: date)!
@@ -389,7 +389,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
             XCTAssertEqual(summary?.summaryData[9].viewsCount, 3244)
             XCTAssertEqual(summary?.summaryData[9].visitorsCount, 2127)
-            XCTAssertEqual(summary?.summaryData[9].likesCount, 25)
+            XCTAssertEqual(summary?.summaryData[9].likesCount, 0)
             XCTAssertEqual(summary?.summaryData[9].commentsCount, 0)
             XCTAssertEqual(summary?.summaryData[9].periodStartDate, date)
 
@@ -490,7 +490,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
             XCTAssertEqual(summary?.summaryData[0].viewsCount, 32603)
             XCTAssertEqual(summary?.summaryData[0].visitorsCount, 23205)
-            XCTAssertEqual(summary?.summaryData[0].likesCount, 855)
+            XCTAssertEqual(summary?.summaryData[0].likesCount, 0)
             XCTAssertEqual(summary?.summaryData[0].commentsCount, 44)
 
             let dec17 = DateComponents(year: 2018, month: 12, day: 17)
@@ -499,7 +499,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
             XCTAssertEqual(summary?.summaryData[9].viewsCount, 17162)
             XCTAssertEqual(summary?.summaryData[9].visitorsCount, 11490)
-            XCTAssertEqual(summary?.summaryData[9].likesCount, 126)
+            XCTAssertEqual(summary?.summaryData[9].likesCount, 0)
             XCTAssertEqual(summary?.summaryData[9].commentsCount, 0)
 
             XCTAssertEqual(summary?.summaryData[9].periodStartDate, Calendar.autoupdatingCurrent.date(byAdding: .day,
@@ -529,7 +529,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
             XCTAssertEqual(summary?.summaryData[0].viewsCount, 3496)
             XCTAssertEqual(summary?.summaryData[0].visitorsCount, 398)
-            XCTAssertEqual(summary?.summaryData[0].likesCount, 72)
+            XCTAssertEqual(summary?.summaryData[0].likesCount, 0)
             XCTAssertEqual(summary?.summaryData[0].commentsCount, 0)
 
             let may1 = DateComponents(year: 2018, month: 5, day: 1)
@@ -538,13 +538,52 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
             XCTAssertEqual(summary?.summaryData[9].viewsCount, 2569)
             XCTAssertEqual(summary?.summaryData[9].visitorsCount, 334)
-            XCTAssertEqual(summary?.summaryData[9].likesCount, 116)
+            XCTAssertEqual(summary?.summaryData[9].likesCount, 0)
             XCTAssertEqual(summary?.summaryData[9].commentsCount, 0)
 
             let nineMonthsFromMay1 = Calendar.autoupdatingCurrent.date(byAdding: .month, value: 9, to: may1Date)!
 
             XCTAssertEqual(summary?.summaryData[9].periodStartDate, nineMonthsFromMay1)
             
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testLikesForMonth() {
+        let expect = expectation(description: "It should return likes data for a month")
+
+        stubRemoteResponse(siteVisitsDataEndpoint, filename: getVisitsMonthMockFilename, contentType: .ApplicationJSON)
+
+        let feb21 = DateComponents(year: 2019, month: 2, day: 21)
+        let date = Calendar.autoupdatingCurrent.date(from: feb21)!
+
+
+        remote.getData(for: .month, endingOn: date) { (summary: StatsLikesSummaryTimeIntervalData?, error: Error?) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(summary)
+
+            XCTAssertEqual(summary?.summaryData.count, 10)
+
+            XCTAssertEqual(summary?.summaryData[0].viewsCount, 0)
+            XCTAssertEqual(summary?.summaryData[0].visitorsCount, 0)
+            XCTAssertEqual(summary?.summaryData[0].likesCount, 72)
+            XCTAssertEqual(summary?.summaryData[0].commentsCount, 0)
+
+            let may1 = DateComponents(year: 2018, month: 5, day: 1)
+            let may1Date = Calendar.autoupdatingCurrent.date(from: may1)!
+            XCTAssertEqual(summary?.summaryData[0].periodStartDate, may1Date)
+
+            XCTAssertEqual(summary?.summaryData[9].viewsCount, 0)
+            XCTAssertEqual(summary?.summaryData[9].visitorsCount, 0)
+            XCTAssertEqual(summary?.summaryData[9].likesCount, 116)
+            XCTAssertEqual(summary?.summaryData[9].commentsCount, 0)
+
+            let nineMonthsFromMay1 = Calendar.autoupdatingCurrent.date(byAdding: .month, value: 9, to: may1Date)!
+
+            XCTAssertEqual(summary?.summaryData[9].periodStartDate, nineMonthsFromMay1)
+
             expect.fulfill()
         }
 


### PR DESCRIPTION
### Description
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11657, ish.

The comments should explain it — but I was able to figure out that only fetching `likes` slows those requests down so much — fetching just `views`/`visitors`/`comments` is (relatively, still takes like ~1.5s of wall-clock time for a `year`) fast. 

I tried bajilllion different things to work-around this in a nicer way — splitting data by a smaller chunk (i.e. instead of fetching by `.year`, fetch 14 times by `.month`) and add data up ended up... much slower — not even because of the added complexity and additional parsing step, just the smaller requests sometimes were _slower_ than the ones with bigger granularity. 

Adding to the fact that mobile networks aren't exactly friendly to firing multiple requests like that and it ended up being a _very, very long and windy_ road to nowhere.

AFAICT, Calypso does the same thing — when I look at the request made in the network inspector, there's one that doesn't ask for likes and takes ~2s, and a second one that loads likes that's taking up ~10x times that.

### Testing Details

- [ ] Check out the related WPKit PR (https://github.com/wordpress-mobile/WordPress-iOS/pull/11841) and verify that the tests pass.