### PR TITLE
[Stats Refresh] Get all years for Annual insights

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.3"
+  s.version       = "4.1.4-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.1.4-beta.1"
+  s.version       = "4.2.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -420,6 +420,7 @@
 		93F50A441F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F50A431F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift */; };
 		93F50A471F227F3600B5BEBA /* xmlrpc-response-getprofile.xml in Resources */ = {isa = PBXBuildFile; fileRef = 93F50A451F227F3600B5BEBA /* xmlrpc-response-getprofile.xml */; };
 		93F50A481F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml in Resources */ = {isa = PBXBuildFile; fileRef = 93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */; };
+		98DC787522BAEBF200267279 /* StatsAllAnnualInsight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DC787422BAEBF100267279 /* StatsAllAnnualInsight.swift */; };
 		9A2D0B28225E0119009E585F /* JetpackServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D0B27225E0119009E585F /* JetpackServiceRemote.swift */; };
 		9A2D0B2B225E0E22009E585F /* JetpackServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D0B2A225E0E22009E585F /* JetpackServiceRemoteTests.swift */; };
 		9A2D0B2F225E1245009E585F /* jetpack-service-check-site-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 9A2D0B2C225E1038009E585F /* jetpack-service-check-site-success.json */; };
@@ -938,6 +939,7 @@
 		93F50A431F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersServiceRemoteXMLRPCTests.swift; sourceTree = "<group>"; };
 		93F50A451F227F3600B5BEBA /* xmlrpc-response-getprofile.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-response-getprofile.xml"; sourceTree = "<group>"; };
 		93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-response-valid-but-unexpected-dictionary.xml"; sourceTree = "<group>"; };
+		98DC787422BAEBF100267279 /* StatsAllAnnualInsight.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsAllAnnualInsight.swift; sourceTree = "<group>"; };
 		9A2D0B27225E0119009E585F /* JetpackServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackServiceRemote.swift; sourceTree = "<group>"; };
 		9A2D0B2A225E0E22009E585F /* JetpackServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackServiceRemoteTests.swift; sourceTree = "<group>"; };
 		9A2D0B2C225E1038009E585F /* jetpack-service-check-site-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "jetpack-service-check-site-success.json"; sourceTree = "<group>"; };
@@ -1092,6 +1094,7 @@
 				4041405F220F9F1F00CF7C5B /* StatsAllTimesInsight.swift */,
 				40E7FEAD220FAEA10032834E /* StatsPublicizeInsight.swift */,
 				40E7FEB0220FB3B60032834E /* StatsAnnualAndMostPopularTimeInsight.swift */,
+				98DC787422BAEBF100267279 /* StatsAllAnnualInsight.swift */,
 				40E7FEB3221063480032834E /* StatsTodayInsight.swift */,
 				40E7FEB622106A8D0032834E /* StatsCommentsInsight.swift */,
 				40E7FEB92210894B0032834E /* StatsTagsAndCategoriesInsight.swift */,
@@ -2459,6 +2462,7 @@
 				17CE77F120C6EB41001DEA5A /* ReaderFeed.swift in Sources */,
 				93C674F21EE8351E00BFAF05 /* NSMutableDictionary+Helpers.m in Sources */,
 				74D67F061F1528470010C5ED /* PeopleServiceRemote.swift in Sources */,
+				98DC787522BAEBF200267279 /* StatsAllAnnualInsight.swift in Sources */,
 				740B23C31F17EE8000067A2A /* RemotePostCategory.m in Sources */,
 				74B5F0E71EF8699C00B411E7 /* RemotePostType.m in Sources */,
 				93188D1F1F2262BF0028ED4D /* RemotePostTag.m in Sources */,

--- a/WordPressKit/Insights/StatsAllAnnualInsight.swift
+++ b/WordPressKit/Insights/StatsAllAnnualInsight.swift
@@ -1,0 +1,74 @@
+public struct StatsAllAnnualInsight {
+    public let allAnnualInsights: [StatsAnnualInsight]
+    
+    public init(allAnnualInsights: [StatsAnnualInsight]) {
+        self.allAnnualInsights = allAnnualInsights
+    }
+}
+
+public struct StatsAnnualInsight {
+    public let year: Int
+    public let totalPostsCount: Int
+    public let totalWordsCount: Int
+    public let averageWordsCount: Double
+    public let totalLikesCount: Int
+    public let averageLikesCount: Double
+    public let totalCommentsCount: Int
+    public let averageCommentsCount: Double
+    public let totalImagesCount: Int
+    public let averageImagesCount: Double
+    
+    public init(year: Int,
+                totalPostsCount: Int,
+                totalWordsCount: Int,
+                averageWordsCount: Double,
+                totalLikesCount: Int,
+                averageLikesCount: Double,
+                totalCommentsCount: Int,
+                averageCommentsCount: Double,
+                totalImagesCount: Int,
+                averageImagesCount: Double) {
+        self.year = year
+        self.totalPostsCount = totalPostsCount
+        self.totalWordsCount = totalWordsCount
+        self.averageWordsCount = averageWordsCount
+        self.totalLikesCount = totalLikesCount
+        self.averageLikesCount = averageLikesCount
+        self.totalCommentsCount = totalCommentsCount
+        self.averageCommentsCount = averageCommentsCount
+        self.totalImagesCount = totalImagesCount
+        self.averageImagesCount = averageImagesCount
+    }
+}
+
+extension StatsAllAnnualInsight: StatsInsightData {
+    public static var pathComponent: String {
+        return "stats/insights"
+    }
+    
+    public init?(jsonDictionary: [String : AnyObject]) {
+        guard let yearlyInsights = jsonDictionary["years"] as? [[String: AnyObject]] else {
+            return nil
+        }
+        
+        let allAnnualInsights: [StatsAnnualInsight] = yearlyInsights.compactMap {
+            guard let yearString = $0["year"] as? String,
+                let year = Int(yearString) else {
+                    return nil
+            }
+            
+            return StatsAnnualInsight(year: year,
+                                      totalPostsCount: $0["total_posts"] as? Int ?? 0,
+                                      totalWordsCount: $0["total_words"] as? Int ?? 0,
+                                      averageWordsCount: $0["avg_words"] as? Double ?? 0,
+                                      totalLikesCount: $0["total_likes"] as? Int ?? 0,
+                                      averageLikesCount: $0["avg_likes"] as? Double ?? 0,
+                                      totalCommentsCount: $0["total_comments"] as? Int ?? 0,
+                                      averageCommentsCount: $0["avg_comments"] as? Double ?? 0,
+                                      totalImagesCount: $0["total_images"] as? Int ?? 0,
+                                      averageImagesCount: $0["avg_images"] as? Double ?? 0)
+        }
+        
+        self.allAnnualInsights = allAnnualInsights
+    }
+}

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -125,7 +125,8 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
     }
 }
 
-// MARK: - StatsLastPostInsight-specific hack
+// MARK: - StatsLastPostInsight Handling
+
 extension StatsServiceRemoteV2 {
     // "Last Post" Insights are "fun" in the way that they require multiple requests to actually create them,
     // so we do this "fun" dance in a separate method.
@@ -187,7 +188,8 @@ extension StatsServiceRemoteV2 {
     }
 }
 
-// MARK - StatsPublishedPostsTimeIntervalData-specific hack
+// MARK - StatsPublishedPostsTimeIntervalData Handling
+
 extension StatsServiceRemoteV2 {
 
     // StatsPublishedPostsTimeIntervalData hit a different endpoint and with different parameters


### PR DESCRIPTION
### Description
This adds a new `StatsInsightData` type, `StatsAllAnnualInsight`, that contains all years for a site's Annual insights.

Ref # https://github.com/wordpress-mobile/WordPress-iOS/issues/11908

### Testing Details

Can be testing with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/11962.

- [ ] Please check here if your pull request includes additional test coverage.
