### PR TITLE
Fetching a post on successful update (removes long time TODO)

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.2.0-beta.1"
+  s.version       = "4.2.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteXMLRPC.m
+++ b/WordPressKit/PostServiceRemoteXMLRPC.m
@@ -143,10 +143,16 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     [self.api callMethod:@"metaWeblog.editPost"
               parameters:parameters
                  success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-                     // TODO: fetch individual post
-                     if (success) {
-                         success(post);
-                     }
+                     [self getPostWithID:post.postID success:^(RemotePost *fetchedPost) {
+                         if (success) {
+                             success(fetchedPost);
+                         }
+                     } failure:^(NSError *error) {
+                         //We failed to fetch the post but the update was successful
+                         if (success) {
+                             success(post);
+                         }
+                     }];
                  } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
                      if (failure) {
                          failure(error);

--- a/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
@@ -259,7 +259,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
         let expect = expectation(description: "Update post success")
 
         stubRemoteResponse(XMLRPCTestableConstants.xmlRpcUrl,
-                           filename: updatePostSuccessMockFilename,
+                           files: [updatePostSuccessMockFilename, getPostSuccessMockFilename],
                            contentType: .XML)
 
         if let remoteInstance = remote as? PostServiceRemote {


### PR DESCRIPTION
### Description
currently in the success block returned from `wp.EditPost` we have TODO to fetch the updated post, ostensibly the same way we do in the create method, and return it rather than the captured post.
This PR implements fetching the post. 
On failure to fetch the post we do as we previously did and return the captured post.

Spun off of: https://github.com/wordpress-mobile/WordPress-iOS/issues/11952#issuecomment-504586218

- [ ] Please check here if your pull request includes additional test coverage.
