### PR TITLE
Implementing GET autosave endpoint

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.2.0-beta.2"
+  s.version       = "4.2.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemote.h
+++ b/WordPressKit/PostServiceRemote.h
@@ -41,6 +41,20 @@
                failure:(void (^)(NSError *error))failure;
 
 /**
+ *  @brief      Get autosave revision of a post.
+ *
+ *
+ *  @discussion retrieve the latest autosave revision of a post
+ 
+ *  @param      post        The post to save.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)getAutoSaveForPost:(RemotePost *)post
+                   success:(void (^)(RemotePost *))success
+                   failure:(void (^)(NSError *error))failure;
+
+/**
  *  @brief      Creates a post remotely for the specified blog.
  *
  *  @param      post        The post to create remotely.  Cannot be nil.

--- a/WordPressKit/PostServiceRemote.h
+++ b/WordPressKit/PostServiceRemote.h
@@ -41,20 +41,6 @@
                failure:(void (^)(NSError *error))failure;
 
 /**
- *  @brief      Get autosave revision of a post.
- *
- *
- *  @discussion retrieve the latest autosave revision of a post
- 
- *  @param      post        The post to save.  Cannot be nil.
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
- */
-- (void)getAutoSaveForPost:(RemotePost *)post
-                   success:(void (^)(RemotePost *))success
-                   failure:(void (^)(NSError *error))failure;
-
-/**
  *  @brief      Creates a post remotely for the specified blog.
  *
  *  @param      post        The post to create remotely.  Cannot be nil.

--- a/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/PostServiceRemoteREST.h
@@ -39,4 +39,18 @@
          success:(void (^)(RemotePost *post, NSString *previewURL))success
          failure:(void (^)(NSError *error))failure;
 
+/**
+ *  @brief      Get autosave revision of a post.
+ *
+ *
+ *  @discussion retrieve the latest autosave revision of a post
+ 
+ *  @param      post        The post to save.  Cannot be nil.
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)getAutoSaveForPost:(RemotePost *)post
+                   success:(void (^)(RemotePost *))success
+                   failure:(void (^)(NSError *error))failure;
+
 @end

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -93,6 +93,30 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
           }];
 }
 
+-(void)getAutoSaveForPost:(RemotePost *)post
+                  success:(void (^)(RemotePost *))success
+                  failure:(void (^)(NSError *error))failure
+{
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/autosave", self.siteID, post.postID];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    
+    NSDictionary *parameters = [self parametersWithRemotePost:post];
+    
+    [self.wordPressComRestApi GET:requestUrl
+                       parameters:parameters
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+                              RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
+                              if (success) {
+                                  success(post);
+                              }
+                          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+                              if (failure) {
+                                  failure(error);
+                              }
+                          }];
+}
+
 - (void)createPost:(RemotePost *)post
            success:(void (^)(RemotePost *))success
            failure:(void (^)(NSError *))failure

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -263,6 +263,40 @@
                                 failure:^(NSError *error) {}]);
 }
 
+- (void)testThatGetAutoSaveForPostWorks
+{
+    NSNumber *dotComID = @10;
+    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
+    PostServiceRemoteREST *service = nil;
+    
+    XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:dotComID]);
+    
+    RemotePost *post = OCMClassMock([RemotePost class]);
+    OCMStub([post postID]).andReturn(@1);
+    OCMStub([post title]).andReturn(@"Title");
+    OCMStub([post content]).andReturn(@"Content");
+    OCMStub([post status]).andReturn(@"Status");
+    OCMStub([post password]).andReturn(@"Password");
+    OCMStub([post type]).andReturn(@"Type");
+    OCMStub([post metadata]).andReturn(@[]);
+    OCMStub([post isStickyPost]).andReturn(@1);
+    OCMStub([post parentID]).andReturn(nil);
+    
+    NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/autosave", dotComID, post.postID];
+    NSString *url = [service pathForEndpoint:endpoint
+                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    
+    OCMStub([api GET:[OCMArg isEqual:url]
+          parameters:[OCMArg isNotNil]
+             success:[OCMArg isNotNil]
+             failure:[OCMArg isNotNil]]);
+    
+    [service getAutoSaveForPost:post
+                        success:^(RemotePost *post) {}
+                        failure:^(NSError *error) {}];
+}
+
+
 #pragma mark - Deleting posts
 
 - (void)testThatDeletePostWorks


### PR DESCRIPTION
Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/12003
### Description
Once we implement conflict resolution we would need to get the latest autosaved revision of a post.
This PR is in implementing the end point even though it's not used yet.  

- [ ] Please check here if your pull request includes additional test coverage.
