### PR TITLE
Fix publishing private XML-RPC posts.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.2.0-beta.2"
+  s.version       = "4.2.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

Fixes this WPiOS issue — which prevented people from publishing private posts on XML-RPC posts: https://github.com/wordpress-mobile/WordPress-iOS/issues/12009

It seems like publishing _an existing draft_ that was set to private worked, but outright publishing a private posts didn't. Now it does!

---
### Testing Detail

Check out the related WPiOS branch: https://github.com/wordpress-mobile/WordPress-iOS/pull/12024
Create a new vanilla WP site ussing `jurassic.ninja`
Verify that publishing a new, private post works!