### PR TITLE
Implement POST editor settings

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.3.0-beta.4"
+  s.version       = "4.3.0-beta.5"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.3.0-beta.1"
+  s.version       = "4.3.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -277,10 +277,13 @@
 		74FC6F411F191C1D00112505 /* notifications-last-seen.json in Resources */ = {isa = PBXBuildFile; fileRef = 74FC6F3D1F191C1D00112505 /* notifications-last-seen.json */; };
 		74FC6F421F191C1D00112505 /* notifications-load-hash.json in Resources */ = {isa = PBXBuildFile; fileRef = 74FC6F3E1F191C1D00112505 /* notifications-load-hash.json */; };
 		74FC6F431F191C1D00112505 /* notifications-load-all.json in Resources */ = {isa = PBXBuildFile; fileRef = 74FC6F3F1F191C1D00112505 /* notifications-load-all.json */; };
+		7E0D64FF22D855700092AD10 /* EditorServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E0D64FE22D855700092AD10 /* EditorServiceRemote.swift */; };
 		7E3E7A4520E443060075D159 /* NSAttributedString+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A4420E443050075D159 /* NSAttributedString+extensions.swift */; };
 		7E3E7A4820E443370075D159 /* NSMutableAttributedString+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A4720E443370075D159 /* NSMutableAttributedString+extensions.swift */; };
 		7E3E7A4A20E443890075D159 /* Scanner+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A4920E443890075D159 /* Scanner+extensions.swift */; };
 		7E3E7A4C20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A4B20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift */; };
+		7EC60EBE22DC4F9000FB0336 /* EditorServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC60EBD22DC4F9000FB0336 /* EditorServiceRemoteTests.swift */; };
+		7EC60EC022DC5D7C00FB0336 /* EditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC60EBF22DC5D7C00FB0336 /* EditorSettings.swift */; };
 		8236EB4D2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8236EB4C2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift */; };
 		826016F11F9FA13A00533B6C /* ActivityServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */; };
 		826016F31F9FA17B00533B6C /* Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F21F9FA17B00533B6C /* Activity.swift */; };
@@ -792,10 +795,13 @@
 		74FC6F3D1F191C1D00112505 /* notifications-last-seen.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-last-seen.json"; sourceTree = "<group>"; };
 		74FC6F3E1F191C1D00112505 /* notifications-load-hash.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-load-hash.json"; sourceTree = "<group>"; };
 		74FC6F3F1F191C1D00112505 /* notifications-load-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-load-all.json"; sourceTree = "<group>"; };
+		7E0D64FE22D855700092AD10 /* EditorServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorServiceRemote.swift; sourceTree = "<group>"; };
 		7E3E7A4420E443050075D159 /* NSAttributedString+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+extensions.swift"; sourceTree = "<group>"; };
 		7E3E7A4720E443370075D159 /* NSMutableAttributedString+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+extensions.swift"; sourceTree = "<group>"; };
 		7E3E7A4920E443890075D159 /* Scanner+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Scanner+extensions.swift"; sourceTree = "<group>"; };
 		7E3E7A4B20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableParagraphStyle+extensions.swift"; sourceTree = "<group>"; };
+		7EC60EBD22DC4F9000FB0336 /* EditorServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorServiceRemoteTests.swift; sourceTree = "<group>"; };
+		7EC60EBF22DC5D7C00FB0336 /* EditorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSettings.swift; sourceTree = "<group>"; };
 		8236EB4C2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBlogJetpackModulesSettings.swift; sourceTree = "<group>"; };
 		826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceRemote.swift; sourceTree = "<group>"; };
 		826016F21F9FA17B00533B6C /* Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
@@ -1239,6 +1245,14 @@
 			name = Extensions;
 			sourceTree = "<group>";
 		};
+		7EC60EBC22DC4F5A00FB0336 /* Editor */ = {
+			isa = PBXGroup;
+			children = (
+				7EC60EBD22DC4F9000FB0336 /* EditorServiceRemoteTests.swift */,
+			);
+			name = Editor;
+			sourceTree = "<group>";
+		};
 		826016FE1F9FD59400533B6C /* Activity */ = {
 			isa = PBXGroup;
 			children = (
@@ -1293,6 +1307,7 @@
 				826016FE1F9FD59400533B6C /* Activity */,
 				74B5F0DF1EF82AAB00B411E7 /* Blog */,
 				74585B911F0D520700E7E667 /* Domains */,
+				7EC60EBC22DC4F5A00FB0336 /* Editor */,
 				9A2D0B29225E0DF7009E585F /* Jetpack */,
 				74FA25F81F1FDA240044BC54 /* Media */,
 				74D97CB91F1CF6E200AC49B7 /* Menu */,
@@ -1418,6 +1433,7 @@
 				74A44DC81F13C533006CD8F4 /* NotificationSettingsServiceRemote.swift */,
 				74A44DC91F13C533006CD8F4 /* NotificationSyncServiceRemote.swift */,
 				74D67F051F1528470010C5ED /* PeopleServiceRemote.swift */,
+				7E0D64FE22D855700092AD10 /* EditorServiceRemote.swift */,
 				7433BBFF1EFC4505002D9E92 /* PlanServiceRemote.swift */,
 				439A44D72107C85E00795ED7 /* PlanServiceRemote_ApiVersion1_3.swift */,
 				439A44D52107C66A00795ED7 /* JSONDecoderExtension.swift */,
@@ -1484,6 +1500,7 @@
 				9AF4F2FD2183345D00570E4B /* Revisions */,
 				930F52B91ECF8A44002F921B /* Stats */,
 				7403A3011EF0726E00DED7DC /* AccountSettings.swift */,
+				7EC60EBF22DC5D7C00FB0336 /* EditorSettings.swift */,
 				74E229591F1E77290085F7F2 /* KeyringConnection.swift */,
 				74E2295A1F1E77290085F7F2 /* KeyringConnectionExternalUser.swift */,
 				40247DFB2120E69600AE1C3C /* AutomatedTransferStatus.swift */,
@@ -2432,6 +2449,7 @@
 				93F50A381F226B9300B5BEBA /* WordPressComServiceRemote.m in Sources */,
 				9F4E52002088E38200424676 /* ObjectValidation.swift in Sources */,
 				7430C9B81F1927C50051B8E6 /* RemoteReaderTopic.m in Sources */,
+				7EC60EC022DC5D7C00FB0336 /* EditorSettings.swift in Sources */,
 				7403A3021EF0726E00DED7DC /* AccountSettings.swift in Sources */,
 				40E7FEA9220FA4060032834E /* StatsEmailFollowersInsight.swift in Sources */,
 				404057DA221C9D560060250C /* StatsTopReferrersTimeIntervalData.swift in Sources */,
@@ -2472,6 +2490,7 @@
 				436D56352118D85800CEAA33 /* Country.swift in Sources */,
 				74A44DCB1F13C533006CD8F4 /* NotificationSettingsServiceRemote.swift in Sources */,
 				404057CE221C38130060250C /* StatsTopVideosTimeIntervalData.swift in Sources */,
+				7E0D64FF22D855700092AD10 /* EditorServiceRemote.swift in Sources */,
 				E182BF6A1FD961810001D850 /* Endpoint.swift in Sources */,
 				9AF4F2FF2183346B00570E4B /* RemoteRevision.swift in Sources */,
 				74BA04F41F06DC0A00ED5CD8 /* CommentServiceRemoteREST.m in Sources */,
@@ -2581,6 +2600,7 @@
 				74C473AF1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift in Sources */,
 				74A44DD51F13C6D8006CD8F4 /* PushAuthenticationServiceRemoteTests.swift in Sources */,
 				731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */,
+				7EC60EBE22DC4F9000FB0336 /* EditorServiceRemoteTests.swift in Sources */,
 				931924241F1662FA0069CBCC /* JSONLoader.swift in Sources */,
 				93AC8EE21ED32FD000900F5A /* WPStatsServiceRemoteTests.m in Sources */,
 				E1787DB2200E5690004CB3AF /* TimeZoneServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/EditorServiceRemote.swift
+++ b/WordPressKit/EditorServiceRemote.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressShared
 
 public class EditorServiceRemote: ServiceRemoteWordPressComREST {
-    public func postDesignateMobileEditor(_ siteID: Int, editor: EditorSettings, success: @escaping (EditorSettings) -> Void, failure: @escaping (Error) -> Void) {
+    public func postDesignateMobileEditor(_ siteID: Int, editor: EditorSettings.Mobile, success: @escaping (EditorSettings) -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "sites/\(siteID)/gutenberg?platform=mobile&editor=\(editor.rawValue)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 

--- a/WordPressKit/EditorServiceRemote.swift
+++ b/WordPressKit/EditorServiceRemote.swift
@@ -17,4 +17,20 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
             failure(error)
         }
     }
+
+    public func getEditorSettings(_ siteID: Int, success: @escaping (EditorSettings) -> Void, failure: @escaping (Error) -> Void) {
+        let endpoint = "sites/\(siteID)/gutenberg"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
+
+        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, httpResponse) in
+            do {
+                let settings = try EditorSettings(with: responseObject)
+                success(settings)
+            } catch {
+                failure(error)
+            }
+        }) { (error, httpError) in
+            failure(error)
+        }
+    }
 }

--- a/WordPressKit/EditorServiceRemote.swift
+++ b/WordPressKit/EditorServiceRemote.swift
@@ -1,0 +1,20 @@
+import Foundation
+import WordPressShared
+
+public class EditorServiceRemote: ServiceRemoteWordPressComREST {
+    public func postDesignateMobileEditor(_ siteID: Int, editor: EditorSettings, success: @escaping (EditorSettings) -> Void, failure: @escaping (Error) -> Void) {
+        let endpoint = "sites/\(siteID)/gutenberg?platform=mobile&editor=\(editor.rawValue)"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
+
+        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, httpResponse) in
+            do {
+                let settings = try EditorSettings(with: responseObject)
+                success(settings)
+            } catch {
+                failure(error)
+            }
+        }) { (error, httpError) in
+            failure(error)
+        }
+    }
+}

--- a/WordPressKit/EditorSettings.swift
+++ b/WordPressKit/EditorSettings.swift
@@ -11,7 +11,7 @@ public enum EditorSettings: String {
 }
 
 extension EditorSettings {
-    init (with response: AnyObject) throws {
+    init(with response: AnyObject) throws {
         guard let response = response as? [String: AnyObject] else {
             throw NSError(domain: NSURLErrorDomain, code: NSURLErrorBadServerResponse, userInfo: nil)
         }

--- a/WordPressKit/EditorSettings.swift
+++ b/WordPressKit/EditorSettings.swift
@@ -1,0 +1,27 @@
+private struct RemoteEditorSettings: Codable {
+    let editor_mobile: String
+    let editor_web: String
+}
+
+public enum EditorSettings: String {
+    case gutenberg
+    case aztec
+
+    static let `default` = EditorSettings.aztec
+}
+
+extension EditorSettings {
+    init (with response: AnyObject) throws {
+        guard let response = response as? [String: AnyObject] else {
+            throw NSError(domain: NSURLErrorDomain, code: NSURLErrorBadServerResponse, userInfo: nil)
+        }
+
+        let data = try JSONSerialization.data(withJSONObject: response, options: .prettyPrinted)
+        let editorPreferenesRemote = try JSONDecoder().decode(RemoteEditorSettings.self, from: data)
+        self.init(with: editorPreferenesRemote)
+    }
+
+    private init(with remote: RemoteEditorSettings) {
+        self = EditorSettings(rawValue: remote.editor_mobile) ?? .default
+    }
+}

--- a/WordPressKit/EditorSettings.swift
+++ b/WordPressKit/EditorSettings.swift
@@ -3,11 +3,21 @@ private struct RemoteEditorSettings: Codable {
     let editorWeb: String
 }
 
-public enum EditorSettings: String {
-    case gutenberg
-    case aztec
+public struct EditorSettings {
+    public enum Mobile: String {
+        case gutenberg
+        case aztec
+        static let `default` = Mobile.aztec
+    }
 
-    static let `default` = EditorSettings.aztec
+    public enum Web: String {
+        case classic
+        case gutenberg
+        static let `default` = Web.classic
+    }
+
+    let mobile: Mobile
+    let web: Web
 }
 
 extension EditorSettings {
@@ -22,6 +32,8 @@ extension EditorSettings {
     }
 
     private init(with remote: RemoteEditorSettings) {
-        self = EditorSettings(rawValue: remote.editorMobile) ?? .default
+        let mobile = Mobile(rawValue: remote.editorMobile) ?? .default
+        let web = Web(rawValue: remote.editorWeb) ?? .default
+        self = EditorSettings(mobile: mobile, web: web)
     }
 }

--- a/WordPressKit/EditorSettings.swift
+++ b/WordPressKit/EditorSettings.swift
@@ -1,6 +1,6 @@
 private struct RemoteEditorSettings: Codable {
-    let editor_mobile: String
-    let editor_web: String
+    let editorMobile: String
+    let editorWeb: String
 }
 
 public enum EditorSettings: String {
@@ -17,11 +17,11 @@ extension EditorSettings {
         }
 
         let data = try JSONSerialization.data(withJSONObject: response, options: .prettyPrinted)
-        let editorPreferenesRemote = try JSONDecoder().decode(RemoteEditorSettings.self, from: data)
+        let editorPreferenesRemote = try JSONDecoder.apiDecoder.decode(RemoteEditorSettings.self, from: data)
         self.init(with: editorPreferenesRemote)
     }
 
     private init(with remote: RemoteEditorSettings) {
-        self = EditorSettings(rawValue: remote.editor_mobile) ?? .default
+        self = EditorSettings(rawValue: remote.editorMobile) ?? .default
     }
 }

--- a/WordPressKit/EditorSettings.swift
+++ b/WordPressKit/EditorSettings.swift
@@ -16,8 +16,8 @@ public struct EditorSettings {
         static let `default` = Web.classic
     }
 
-    let mobile: Mobile
-    let web: Web
+    public let mobile: Mobile
+    public let web: Web
 }
 
 extension EditorSettings {

--- a/WordPressKitTests/EditorServiceRemoteTests.swift
+++ b/WordPressKitTests/EditorServiceRemoteTests.swift
@@ -17,7 +17,7 @@ class EditorServiceRemoteTests: XCTestCase {
         XCTAssertTrue(mockRemoteApi.postMethodCalled)
     }
 
-    func testPostDesignateMobileEditorSuccess() {
+    func testPostDesignateMobileEditorSuccessSettingGutenberg() {
         let expec = expectation(description: "success")
         let response: [String: String] = [
             "editor_mobile": "gutenberg",
@@ -26,6 +26,25 @@ class EditorServiceRemoteTests: XCTestCase {
 
         editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { editor in
             XCTAssertEqual(editor, .gutenberg)
+            expec.fulfill()
+        }) { (error) in
+            XCTFail("This call should succeed. Error: \(error)")
+            expec.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+
+        wait(for: [expec], timeout: 0.1)
+    }
+
+    func testPostDesignateMobileEditorSuccessSettingAztec() {
+        let expec = expectation(description: "success")
+        let response: [String: String] = [
+            "editor_mobile": "aztec",
+            "editor_web": "gutenberg",
+        ]
+
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.aztec, success: { editor in
+            XCTAssertEqual(editor, .aztec)
             expec.fulfill()
         }) { (error) in
             XCTFail("This call should succeed. Error: \(error)")

--- a/WordPressKitTests/EditorServiceRemoteTests.swift
+++ b/WordPressKitTests/EditorServiceRemoteTests.swift
@@ -24,8 +24,9 @@ class EditorServiceRemoteTests: XCTestCase {
             "editor_web": "gutenberg",
         ]
 
-        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { editor in
-            XCTAssertEqual(editor, .gutenberg)
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { editor in
+            XCTAssertEqual(editor.mobile, .gutenberg)
+            XCTAssertEqual(editor.web, .gutenberg)
             expec.fulfill()
         }) { (error) in
             XCTFail("This call should succeed. Error: \(error)")
@@ -40,11 +41,12 @@ class EditorServiceRemoteTests: XCTestCase {
         let expec = expectation(description: "success")
         let response: [String: String] = [
             "editor_mobile": "aztec",
-            "editor_web": "gutenberg",
+            "editor_web": "classic",
         ]
 
-        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.aztec, success: { editor in
-            XCTAssertEqual(editor, .aztec)
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .aztec, success: { editor in
+            XCTAssertEqual(editor.mobile, .aztec)
+            XCTAssertEqual(editor.web, .classic)
             expec.fulfill()
         }) { (error) in
             XCTFail("This call should succeed. Error: \(error)")
@@ -62,7 +64,7 @@ class EditorServiceRemoteTests: XCTestCase {
             "editor_web": "gutenberg",
         ]
 
-        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { editor in
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { editor in
             XCTFail("This should fail")
             expec.fulfill()
         }) { (error) in
@@ -75,15 +77,16 @@ class EditorServiceRemoteTests: XCTestCase {
         wait(for: [expec], timeout: 0.1)
     }
 
-    func testPostDesignateMobileEditorDefaultsToAztecWithBadValueResponse() {
+    func testPostDesignateMobileEditorDefaultsWithBadValueResponse() {
         let expec = expectation(description: "success")
         let response: [String: String] = [
             "editor_mobile": "guten_BORG",
-            "editor_web": "gutenberg",
+            "editor_web": "guten_WRONG",
         ]
 
-        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { editor in
-            XCTAssertEqual(editor, .aztec)
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { editor in
+            XCTAssertEqual(editor.mobile, .aztec)
+            XCTAssertEqual(editor.web, .classic)
             expec.fulfill()
         }) { (error) in
             XCTFail("This should not error")
@@ -97,7 +100,7 @@ class EditorServiceRemoteTests: XCTestCase {
     func testPostDesignateMobileEditorError() {
         let expec = expectation(description: "success")
         let errorExpec = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
-        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { _ in
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { _ in
             XCTFail("This call should error")
             expec.fulfill()
         }) { (error) in
@@ -106,6 +109,7 @@ class EditorServiceRemoteTests: XCTestCase {
         }
         mockRemoteApi.failureBlockPassedIn?(errorExpec, nil)
         XCTAssertTrue(mockRemoteApi.postMethodCalled)
+
         wait(for: [expec], timeout: 0.1)
     }
 }

--- a/WordPressKitTests/EditorServiceRemoteTests.swift
+++ b/WordPressKitTests/EditorServiceRemoteTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+@testable import WordPressKit
+
+class EditorServiceRemoteTests: XCTestCase {
+
+    let mockRemoteApi = MockWordPressComRestApi()
+    var editorServiceRemote: EditorServiceRemote!
+    let siteID = 99999
+
+    override func setUp() {
+        super.setUp()
+        editorServiceRemote = EditorServiceRemote(wordPressComRestApi: mockRemoteApi)
+    }
+
+    func testPostDesignateMobileEditorPostMethodIsCalled() {
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { _ in }, failure: { _ in })
+        XCTAssertTrue(mockRemoteApi.postMethodCalled)
+    }
+
+    func testPostDesignateMobileEditorSuccess() {
+        let expec = expectation(description: "success")
+        let response: [String: String] = [
+            "editor_mobile": "gutenberg",
+            "editor_web": "gutenberg",
+        ]
+
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { editor in
+            XCTAssertEqual(editor, .gutenberg)
+            expec.fulfill()
+        }) { (error) in
+            XCTFail("This call should succeed. Error: \(error)")
+            expec.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+
+        wait(for: [expec], timeout: 0.1)
+    }
+
+    func testPostDesignateMobileEditorDoesNotCrashWithBadKeyResponse() {
+        let expec = expectation(description: "success")
+        let response: [String: String] = [
+            "editor_mobile_bad": "gutenberg",
+            "editor_web": "gutenberg",
+        ]
+
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { editor in
+            XCTFail("This should fail")
+            expec.fulfill()
+        }) { (error) in
+            let nsError = error as NSError
+            XCTAssertEqual(nsError.code, NSCoderValueNotFoundError)
+            expec.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+
+        wait(for: [expec], timeout: 0.1)
+    }
+
+    func testPostDesignateMobileEditorDefaultsToAztecWithBadValueResponse() {
+        let expec = expectation(description: "success")
+        let response: [String: String] = [
+            "editor_mobile": "guten_BORG",
+            "editor_web": "gutenberg",
+        ]
+
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { editor in
+            XCTAssertEqual(editor, .aztec)
+            expec.fulfill()
+        }) { (error) in
+            XCTFail("This should not error")
+            expec.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+
+        wait(for: [expec], timeout: 0.1)
+    }
+
+    func testPostDesignateMobileEditorError() {
+        let expec = expectation(description: "success")
+        let errorExpec = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: EditorSettings.gutenberg, success: { _ in
+            XCTFail("This call should error")
+            expec.fulfill()
+        }) { (error) in
+            XCTAssertEqual(error as NSError, errorExpec)
+            expec.fulfill()
+        }
+        mockRemoteApi.failureBlockPassedIn?(errorExpec, nil)
+        XCTAssertTrue(mockRemoteApi.postMethodCalled)
+        wait(for: [expec], timeout: 0.1)
+    }
+}


### PR DESCRIPTION
This PR adds the ability of setting the default mobile editor to Remote.
Fixes part of https://github.com/wordpress-mobile/WordPress-iOS/issues/10870

WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12123

### Testing Details

Follow the instructions from https://github.com/wordpress-mobile/WordPress-iOS/pull/12123


- [x] Please check here if your pull request includes additional test coverage.