### PR TITLE
Check attachments for displayable image.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.2.0"
+  s.version       = "4.2.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -438,8 +438,9 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
         post.pathForDisplayImage = post.postThumbnailPath;
     } else {
         // parse contents for a suitable image
-        if (!post.pathForDisplayImage) {
-            post.pathForDisplayImage = [DisplayableImageHelper searchPostContentForImageToDisplay:post.content];
+        post.pathForDisplayImage = [DisplayableImageHelper searchPostContentForImageToDisplay:post.content];
+        if ([post.pathForDisplayImage length] == 0) {
+            post.pathForDisplayImage = [DisplayableImageHelper searchPostAttachmentsForImageToDisplay:[jsonPost dictionaryForKey:@"attachments"] existingInContent:post.content];
         }
     }
 


### PR DESCRIPTION
### Description
I've noticed that the post cards in WPiOS are not showing images for posts created with the block editor unless an image is defined as the post's featured image.  The expectation is when a post does not have a featured image, that another prominent image will be displayed in the post list. 

Digging into this it looks like the image tag HTML for post created with the block editor is missing the sizing information that accompanies posts created in the classic editor. You can test this by querying my recent posts on mobilemanger.wordpress.com (be sure to use an "edit" context for the REST query since that's how posts are fetched by WPiOS).

Since we want to show images, where we can, this PR checks the post's attachments for an image to show. 

### Testing Details
- Confirm the issue by viewing posts on mobilemanger.wordpress.com in the WPiOS app.  Note that posts created with the block editor do not display images in the post list while others do.
- Point the WPiOS podfile to use this branch for WordPress-Kit. 
- Run `bundle exec pod install`
- Clean the build folder.
- Build and run the app. 
- Confirm you now see images for posts made with the block editor. 

### Before:

![Simulator Screen Shot - iPhone X - 2019-07-15 at 14 22 16](https://user-images.githubusercontent.com/1435271/61242695-019ca500-a70c-11e9-819d-24bb747cbfe2.png)


### After:

![Simulator Screen Shot - iPhone X - 2019-07-15 at 14 16 34](https://user-images.githubusercontent.com/1435271/61242503-7cb18b80-a70b-11e9-876d-1ebb9658911b.png)


@nheagy could I trouble you with this one since you've recently been wrangling post list things? 