### PR TITLE
add a way to ask for `DomainSuggestions` that belong to a specific whitelist of TLDs

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.2.0"
+  s.version       = "4.2.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -39,6 +39,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         case includeWordPressDotCom
         case onlyWordPressDotCom
         case wordPressDotComAndDotBlogSubdomains
+        case whitelistedTopLevelDomains([String])
         
         fileprivate func parameters() -> [String: AnyObject] {
             switch self {
@@ -54,6 +55,8 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
                         "vendor": "dot" as AnyObject,
                         "only_wordpressdotcom": true as AnyObject,
                         "include_wordpressdotcom": true as AnyObject]
+            case .whitelistedTopLevelDomains(let whitelistedTLDs):
+                return ["tlds": whitelistedTLDs.joined(separator: ",") as AnyObject]
             }
         }
     }


### PR DESCRIPTION
This is the WPKit part of fixes for https://github.com/wordpress-mobile/WordPress-iOS/issues/12063.

There's also a corresponding WPiOS PR, here: https://github.com/wordpress-mobile/WordPress-iOS/pull/12135