### PR TITLE
Stats Insights: don't fail parsing unless critical data is missing.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.2.0"
+  s.version       = "4.2.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/Insights/StatsAllTimesInsight.swift
+++ b/WordPressKit/Insights/StatsAllTimesInsight.swift
@@ -25,20 +25,16 @@ extension StatsAllTimesInsight: StatsInsightData {
     public init?(jsonDictionary: [String: AnyObject]) {
         guard
             let statsDict = jsonDictionary["stats"] as? [String: AnyObject],
-            let postsCount = statsDict["posts"] as? Int,
-            let viewsCount = statsDict["views"] as? Int,
-            let visitorsCount = statsDict["visitors"] as? Int,
-            let bestViewsPerDayCount = statsDict["views_best_day_total"] as? Int,
             let bestViewsDayString = statsDict["views_best_day"] as? String,
             let bestViewsDay = StatsAllTimesInsight.dateFormatter.date(from: bestViewsDayString)
             else {
                 return nil
         }
 
-        self.postsCount = postsCount
-        self.bestViewsPerDayCount = bestViewsPerDayCount
-        self.visitorsCount = visitorsCount
-        self.viewsCount = viewsCount
+        self.postsCount = statsDict["posts"] as? Int ?? 0
+        self.bestViewsPerDayCount = statsDict["views_best_day_total"] as? Int ?? 0
+        self.visitorsCount = statsDict["visitors"] as? Int ?? 0
+        self.viewsCount = statsDict["views"] as? Int ?? 0
         self.bestViewsDay = bestViewsDay
     }
 

--- a/WordPressKit/Insights/StatsAnnualAndMostPopularTimeInsight.swift
+++ b/WordPressKit/Insights/StatsAnnualAndMostPopularTimeInsight.swift
@@ -74,16 +74,7 @@ extension StatsAnnualAndMostPopularTimeInsight: StatsInsightData {
             let yearlyInsights = jsonDictionary["years"] as? [[String: AnyObject]],
             let latestYearlyInsight = yearlyInsights.last,
             let yearString = latestYearlyInsight["year"] as? String,
-            let currentYear = Int(yearString),
-            let postCount = latestYearlyInsight["total_posts"] as? Int,
-            let wordsCount = latestYearlyInsight["total_words"] as? Int,
-            let wordsAverage = latestYearlyInsight["avg_words"] as? Double,
-            let likesCount = latestYearlyInsight["total_likes"] as? Int,
-            let likesAverage = latestYearlyInsight["avg_likes"] as? Double,
-            let commentsCount = latestYearlyInsight["total_comments"] as? Int,
-            let commentsAverage = latestYearlyInsight["avg_comments"] as? Double,
-            let imagesCount = latestYearlyInsight["total_images"] as? Int,
-            let imagesAverage = latestYearlyInsight["avg_images"] as? Double
+            let currentYear = Int(yearString)
             else {
                 return nil
         }
@@ -105,17 +96,17 @@ extension StatsAnnualAndMostPopularTimeInsight: StatsInsightData {
 
         self.annualInsightsYear = currentYear
 
-        self.annualInsightsTotalPostsCount = postCount
-        self.annualInsightsTotalWordsCount = wordsCount
-        self.annualInsightsAverageWordsCount = wordsAverage
+        self.annualInsightsTotalPostsCount = latestYearlyInsight["total_posts"] as? Int ?? 0
+        self.annualInsightsTotalWordsCount = latestYearlyInsight["total_words"] as? Int ?? 0
+        self.annualInsightsAverageWordsCount = latestYearlyInsight["avg_words"] as? Double ?? 0
 
-        self.annualInsightsTotalLikesCount = likesCount
-        self.annualInsightsAverageLikesCount = likesAverage
+        self.annualInsightsTotalLikesCount = latestYearlyInsight["total_likes"] as? Int ?? 0
+        self.annualInsightsAverageLikesCount = latestYearlyInsight["avg_likes"] as? Double ?? 0
 
-        self.annualInsightsTotalCommentsCount = commentsCount
-        self.annualInsightsAverageCommentsCount = commentsAverage
+        self.annualInsightsTotalCommentsCount = latestYearlyInsight["total_comments"] as? Int ?? 0
+        self.annualInsightsAverageCommentsCount = latestYearlyInsight["avg_comments"] as? Double ?? 0
 
-        self.annualInsightsTotalImagesCount = imagesCount
-        self.annualInsightsAverageImagesCount = imagesAverage
+        self.annualInsightsTotalImagesCount = latestYearlyInsight["total_images"] as? Int ?? 0
+        self.annualInsightsAverageImagesCount = latestYearlyInsight["avg_images"] as? Double ?? 0
     }
 }

--- a/WordPressKit/Insights/StatsLastPostInsight.swift
+++ b/WordPressKit/Insights/StatsLastPostInsight.swift
@@ -51,18 +51,13 @@ extension StatsLastPostInsight: StatsInsightData {
         guard
             let title = jsonDictionary["title"] as? String,
             let dateString = jsonDictionary["date"] as? String,
+            let date = StatsLastPostInsight.dateFormatter.date(from: dateString),
             let urlString = jsonDictionary["URL"] as? String,
+            let url = URL(string: urlString),
             let likesCount = jsonDictionary["like_count"] as? Int,
             let postID = jsonDictionary["ID"] as? Int,
             let discussionDict = jsonDictionary["discussion"] as? [String: Any],
             let commentsCount = discussionDict["comment_count"] as? Int
-            else {
-                return nil
-        }
-
-        guard
-            let url = URL(string: urlString),
-            let date = StatsLastPostInsight.dateFormatter.date(from: dateString)
             else {
                 return nil
         }

--- a/WordPressKit/Insights/StatsPostingStreakInsight.swift
+++ b/WordPressKit/Insights/StatsPostingStreakInsight.swift
@@ -76,11 +76,6 @@ extension StatsPostingStreakInsight: StatsInsightData {
             let streaks = jsonDictionary["streak"] as? [String: AnyObject],
             let longestData = streaks["long"] as? [String: AnyObject],
             let currentData = streaks["current"] as? [String: AnyObject],
-            let longestStart = longestData["start"] as? String,
-            let longestStartDate = StatsPostingStreakInsight.dateFormatter.date(from: longestStart),
-            let longestEnd = longestData["end"] as? String,
-            let longestEndDate = StatsPostingStreakInsight.dateFormatter.date(from: longestEnd),
-            let longestLength = longestData["length"] as? Int,
             let currentStart = currentData["start"] as? String,
             let currentStartDate = StatsPostingStreakInsight.dateFormatter.date(from: currentStart),
             let currentEnd = currentData["end"] as? String,
@@ -101,13 +96,25 @@ extension StatsPostingStreakInsight: StatsInsightData {
             PostingStreakEvent(date: $0 as! Date, postCount: countedPosts.count(for: $0))
         }
 
+        self.postingEvents = postingEvents
         self.currentStreakStart = currentStartDate
         self.currentStreakEnd = currentEndDate
         self.currentStreakLength = currentLength
-        self.longestStreakStart = longestStartDate
-        self.longestStreakEnd = longestEndDate
-        self.longestStreakLength = longestLength
-        self.postingEvents = postingEvents
+
+        // If there is no longest streak, use the current.
+        if let longestStart = longestData["start"] as? String,
+            let longestStartDate = StatsPostingStreakInsight.dateFormatter.date(from: longestStart),
+            let longestEnd = longestData["end"] as? String,
+            let longestEndDate = StatsPostingStreakInsight.dateFormatter.date(from: longestEnd),
+            let longestLength = longestData["length"] as? Int {
+            self.longestStreakStart = longestStartDate
+            self.longestStreakEnd = longestEndDate
+            self.longestStreakLength = longestLength
+        } else {
+            self.longestStreakStart = currentStartDate
+            self.longestStreakEnd = currentEndDate
+            self.longestStreakLength = currentLength
+        }
     }
 
     private static var dateFormatter: DateFormatter {
@@ -116,6 +123,4 @@ extension StatsPostingStreakInsight: StatsInsightData {
         return formatter
     }
 
-
-    
 }

--- a/WordPressKit/Insights/StatsTodayInsight.swift
+++ b/WordPressKit/Insights/StatsTodayInsight.swift
@@ -23,18 +23,9 @@ extension StatsTodayInsight: StatsInsightData {
     }
 
     public init?(jsonDictionary: [String: AnyObject]) {
-        guard
-            let viewsCount = jsonDictionary["views"] as? Int,
-            let visitorsCount = jsonDictionary["visitors"] as? Int,
-            let likesCount = jsonDictionary["likes"] as? Int,
-            let commentsCount = jsonDictionary["comments"] as? Int
-            else {
-                return nil
-        }
-
-        self.visitorsCount = visitorsCount
-        self.viewsCount = viewsCount
-        self.likesCount = likesCount
-        self.commentsCount = commentsCount
+        self.visitorsCount = jsonDictionary["visitors"] as? Int ?? 0
+        self.viewsCount = jsonDictionary["views"] as? Int ?? 0
+        self.likesCount = jsonDictionary["likes"] as? Int ?? 0
+        self.commentsCount = jsonDictionary["comments"] as? Int ?? 0
     }
 }


### PR DESCRIPTION
### Description
This fixes issues where parsing Insights json would fail if any piece of data was missing. This was overkill, and resulted in some stats not showing when they should.

Fixes #n/a

### Testing Details
Can be tested with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/12137.


- [ ] Please check here if your pull request includes additional test coverage.
