### PR TITLE
Stats: Use site timezone for Published posts.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.2.1-beta.1"
+  s.version       = "4.3.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -15,7 +15,7 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
 
     private lazy var periodDataQueryDateFormatter: DateFormatter = {
         let df = DateFormatter()
-        df.timeZone = siteTimezone
+        df.locale = Locale(identifier: "en_US_POSIX")
         df.dateFormat = "yyyy-MM-dd"
         return df
     }()

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -15,7 +15,7 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
 
     private lazy var periodDataQueryDateFormatter: DateFormatter = {
         let df = DateFormatter()
-        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = siteTimezone
         df.dateFormat = "yyyy-MM-dd"
         return df
     }()

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -20,6 +20,12 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
         return df
     }()
 
+    private lazy var calendarForSite: Calendar = {
+        var cal = Calendar(identifier: .iso8601)
+        cal.timeZone = siteTimezone
+        return cal
+    }()
+    
     public init(wordPressComRestApi api: WordPressComRestApi, siteID: Int, siteTimezone: TimeZone) {
         self.siteID = siteID
         self.siteTimezone = siteTimezone
@@ -198,9 +204,7 @@ extension StatsServiceRemoteV2 {
                         endingOn: Date,
                         limit: Int = 10,
                         completion: @escaping ((StatsPublishedPostsTimeIntervalData?, Error?) -> Void)) {
-
         let pathComponent = StatsLastPostInsight.pathComponent
-
         let path = self.path(forEndpoint: "sites/\(siteID)/\(pathComponent)", withVersion: ._1_1)
 
         let properties = ["number": limit,
@@ -227,21 +231,19 @@ extension StatsServiceRemoteV2 {
     private func startDate(for period: StatsPeriodUnit, endDate: Date) -> Date {
         switch  period {
         case .day:
-            return Calendar.autoupdatingCurrent.startOfDay(for: endDate)
+            return calendarForSite.startOfDay(for: endDate)
         case .week:
-            let weekAgo = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -6, to: endDate)!
-            return Calendar.autoupdatingCurrent.startOfDay(for: weekAgo)
+            let weekAgo = calendarForSite.date(byAdding: .day, value: -6, to: endDate)!
+            return calendarForSite.startOfDay(for: weekAgo)
         case .month:
-            let monthAgo = Calendar.autoupdatingCurrent.date(byAdding: .month, value: -1, to: endDate)!
-            let firstOfMonth = Calendar.autoupdatingCurrent.date(bySetting: .day, value: 1, of: monthAgo)!
-
-            return Calendar.autoupdatingCurrent.startOfDay(for: firstOfMonth)
+            let monthAgo = calendarForSite.date(byAdding: .month, value: -1, to: endDate)!
+            let firstOfMonth = calendarForSite.date(bySetting: .day, value: 1, of: monthAgo)!
+            return calendarForSite.startOfDay(for: firstOfMonth)
         case .year:
-            let yearAgo = Calendar.autoupdatingCurrent.date(byAdding: .year, value: -1, to: endDate)!
-            let january = Calendar.autoupdatingCurrent.date(bySetting: .month, value: 1, of: yearAgo)!
-            let jan1 = Calendar.autoupdatingCurrent.date(bySetting: .day, value: 1, of: january)!
-
-            return Calendar.autoupdatingCurrent.startOfDay(for: jan1)
+            let yearAgo = calendarForSite.date(byAdding: .year, value: -1, to: endDate)!
+            let january = calendarForSite.date(bySetting: .month, value: 1, of: yearAgo)!
+            let jan1 = calendarForSite.date(bySetting: .day, value: 1, of: january)!
+            return calendarForSite.startOfDay(for: jan1)
         }
     }
 


### PR DESCRIPTION
### Description
This creates a calendar using the site's timezone, and uses that to determine dates for Published posts.

Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/12018

### Testing Details

Can be testing with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/12159.

- [ ] Please check here if your pull request includes additional test coverage.
