### PR TITLE
[Jetpack] Update Jetpack Remote Install Error

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.3.0-beta.1"
+  s.version       = "4.3.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/JetpackServiceRemote.swift
+++ b/WordPressKit/JetpackServiceRemote.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct JetpackInstallError: LocalizedError {
+public struct JetpackInstallError: LocalizedError, Equatable {
     public enum ErrorType: String {
         case invalidCredentials = "INVALID_CREDENTIALS"
         case forbidden = "FORBIDDEN"

--- a/WordPressKit/JetpackServiceRemote.swift
+++ b/WordPressKit/JetpackServiceRemote.swift
@@ -26,8 +26,8 @@ public struct JetpackInstallError: LocalizedError, Equatable {
         return JetpackInstallError(type: .unknown)
     }
 
-    public init(title: String? = nil, code: Int = 0, key: String) {
-        self.init(title: title, code: code, type: ErrorType(error: key))
+    public init(title: String? = nil, code: Int = 0, key: String? = nil) {
+        self.init(title: title, code: code, type: ErrorType(error: key ?? ""))
     }
 
     public init(title: String? = nil, code: Int = 0, type: ErrorType = .unknown) {
@@ -84,11 +84,11 @@ public class JetpackServiceRemote: ServiceRemoteWordPressComREST {
                                         completion(false, JetpackInstallError(type: .installResponseError))
                                     }
         }) { (error: NSError, httpResponse: HTTPURLResponse?) in
-            if let key = error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String {
-                completion(false, JetpackInstallError(title: error.localizedDescription, code: error.code, key: key))
-            } else {
-                completion(false, .unknown)
-            }
+            let key = error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
+            let jetpackError = JetpackInstallError(title: error.localizedDescription,
+                                                   code: error.code,
+                                                   key: key)
+            completion(false, jetpackError)
         }
     }
 

--- a/WordPressKit/JetpackServiceRemote.swift
+++ b/WordPressKit/JetpackServiceRemote.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public struct JetpackInstallError: LocalizedError {
-    enum ErrorType: String {
+    public enum ErrorType: String {
         case invalidCredentials = "INVALID_CREDENTIALS"
         case forbidden = "FORBIDDEN"
         case installFailure = "INSTALL_FAILURE"
@@ -18,19 +18,19 @@ public struct JetpackInstallError: LocalizedError {
         }
     }
 
-    var title: String?
-    var code: Int
-    var type: ErrorType
+    public var title: String?
+    public var code: Int
+    public var type: ErrorType
 
-    static var unknown: JetpackInstallError {
+    public static var unknown: JetpackInstallError {
         return JetpackInstallError(type: .unknown)
     }
 
-    init(title: String? = nil, code: Int = 0, key: String) {
+    public init(title: String? = nil, code: Int = 0, key: String) {
         self.init(title: title, code: code, type: ErrorType(error: key))
     }
 
-    init(title: String? = nil, code: Int = 0, type: ErrorType = .unknown) {
+    public init(title: String? = nil, code: Int = 0, type: ErrorType = .unknown) {
         self.title = title
         self.code = code
         self.type = type

--- a/WordPressKitTests/JetpackServiceRemoteTests.swift
+++ b/WordPressKitTests/JetpackServiceRemoteTests.swift
@@ -134,7 +134,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorInvalidCredentialsMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .invalidCredentials)
+            XCTAssertEqual(error?.type, .invalidCredentials)
             expect.fulfill()
         }
         
@@ -147,7 +147,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorUnknownMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .unknown)
+            XCTAssertEqual(error?.type, .unknown)
             expect.fulfill()
         }
         
@@ -160,7 +160,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorForbiddenMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .forbidden)
+            XCTAssertEqual(error?.type, .forbidden)
             expect.fulfill()
         }
         
@@ -173,7 +173,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorInstallFailureMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .installFailure)
+            XCTAssertEqual(error?.type, .installFailure)
             expect.fulfill()
         }
         
@@ -186,7 +186,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorInstallResponseMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .installResponseError)
+            XCTAssertEqual(error?.type, .installResponseError)
             expect.fulfill()
         }
         
@@ -199,7 +199,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorLoginFailureMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .loginFailure)
+            XCTAssertEqual(error?.type, .loginFailure)
             expect.fulfill()
         }
         
@@ -212,7 +212,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorSiteIsJetpackMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .siteIsJetpack)
+            XCTAssertEqual(error?.type, .siteIsJetpack)
             expect.fulfill()
         }
         
@@ -225,7 +225,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorActivationInstallMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .activationOnInstallFailure)
+            XCTAssertEqual(error?.type, .activationOnInstallFailure)
             expect.fulfill()
         }
         
@@ -238,7 +238,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorActivationResponseMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .activationResponseError)
+            XCTAssertEqual(error?.type, .activationResponseError)
             expect.fulfill()
         }
         
@@ -251,7 +251,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorActivationFailureMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
-            XCTAssertEqual(error, .activationFailure)
+            XCTAssertEqual(error?.type, .activationFailure)
             expect.fulfill()
         }
         


### PR DESCRIPTION
### Description
This is part of [#12138](https://github.com/wordpress-mobile/WordPress-iOS/issues/12138).
I refactored the `JetpackInstallError` to be able to store the Error code and description.

### Testing Details
• On WPKit run the `JetpackServiceRemoteTests`
• Run [#12195](https://github.com/wordpress-mobile/WordPress-iOS/pull/12195)