### PR TITLE
Stats File Downloads: fix filename key

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.4.0-beta.1"
+  s.version       = "4.4.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/Time Interval/StatsFileDownloadsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsFileDownloadsTimeIntervalData.swift
@@ -49,8 +49,7 @@ extension StatsFileDownloadsTimeIntervalData: StatsTimeIntervalData {
         }
         
         let fileDownloads: [StatsFileDownload] = fileDownloadsDict.compactMap {
-            // TODO: these keys are a total guess. Verify/update when the endpoint is actually live.
-            guard let file = $0["file"] as? String, let downloads = $0["downloads"] as? Int else {
+            guard let file = $0["filename"] as? String, let downloads = $0["downloads"] as? Int else {
                 return nil
             }
             

--- a/WordPressKitTests/Mock Data/stats-file-downloads.json
+++ b/WordPressKitTests/Mock Data/stats-file-downloads.json
@@ -1,11 +1,20 @@
 {
-	"date": "2019-07-29",
-	"period": "month",
-	"days": {
-		"2019-07-01": {
-			"files": [],
-			"other_downloads": 0,
-			"total_downloads": 0
-		}
-	}
+    "date": "2019-07-29",
+    "period": "month",
+    "days": {
+        "2019-07-01": {
+            "files": [
+                {
+                    "filename": "/2019/07/test.pdf",
+                    "downloads": 11
+                },
+                {
+                    "filename": "/2019/07/sampleaudio.mp3",
+                    "downloads": 4
+                }
+            ],
+            "other_downloads": 0,
+            "total_downloads": 15
+        }
+    }
 }

--- a/WordPressKitTests/StatsRemoteV2Tests.swift
+++ b/WordPressKitTests/StatsRemoteV2Tests.swift
@@ -367,9 +367,6 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     }
 
     func testFetchDownloadsData() {
-
-        // TODO: update with real data once endpoint is live
-
         let expect = expectation(description: "It should return file download data for a month")
         
         let dateComponents = DateComponents(year: 2019, month: 7, day: 29)
@@ -382,13 +379,12 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertNotNil(fileDownloads)
 
             XCTAssertEqual(fileDownloads?.otherDownloadsCount, 0)
-            XCTAssertEqual(fileDownloads?.totalDownloadsCount, 0)
+            XCTAssertEqual(fileDownloads?.totalDownloadsCount, 15)
 
-            XCTAssertEqual(fileDownloads?.fileDownloads.count, 0)
+            XCTAssertEqual(fileDownloads?.fileDownloads.count, 2)
             
-            // TODO: enable these (with valid tests) when endpoint is live
-            // XCTAssertEqual(fileDownloads?.fileDownloads.first!.file, "")
-            // XCTAssertEqual(fileDownloads?.fileDownloads.first!.downloadCount, 666)
+            XCTAssertEqual(fileDownloads?.fileDownloads.first!.file, "/2019/07/test.pdf")
+            XCTAssertEqual(fileDownloads?.fileDownloads.first!.downloadCount, 11)
 
             expect.fulfill()
         }


### PR DESCRIPTION
This corrects the key for a downloaded file.

Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/11963


### Testing Details
1. Verify the `testFetchDownloadsData` test passes.
2. Test with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12275


- [x] Please check here if your pull request includes additional test coverage.
