### PR TITLE
EditorServiceRemote: Adding `me/gutenberg` post request.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.3.0"
+  s.version       = "4.3.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/EditorServiceRemote.swift
+++ b/WordPressKit/EditorServiceRemote.swift
@@ -18,6 +18,22 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         }
     }
 
+    public func postDesignateMobileEditorForAllSites(_ editor: EditorSettings.Mobile, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        let endpoint = "me/gutenberg"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
+
+        let parameters = [
+            "platform": "mobile",
+            "editor": editor.rawValue,
+        ] as [String: AnyObject]
+
+        wordPressComRestApi.POST(path, parameters: parameters, success: { (responseObject, httpResponse) in
+            success()
+        }) { (error, httpError) in
+            failure(error)
+        }
+    }
+
     public func getEditorSettings(_ siteID: Int, success: @escaping (EditorSettings) -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "sites/\(siteID)/gutenberg"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)

--- a/WordPressKit/EditorServiceRemote.swift
+++ b/WordPressKit/EditorServiceRemote.swift
@@ -18,7 +18,7 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         }
     }
 
-    public func postDesignateMobileEditorForAllSites(_ editor: EditorSettings.Mobile, setOnlyIfEmptu: Bool = true, success: @escaping ([Int: EditorSettings.Mobile]) -> Void, failure: @escaping (Error) -> Void) {
+    public func postDesignateMobileEditorForAllSites(_ editor: EditorSettings.Mobile, setOnlyIfEmpty: Bool = true, success: @escaping ([Int: EditorSettings.Mobile]) -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "me/gutenberg"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 

--- a/WordPressKit/EditorServiceRemote.swift
+++ b/WordPressKit/EditorServiceRemote.swift
@@ -25,7 +25,7 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         let parameters = [
             "platform": "mobile",
             "editor": editor.rawValue,
-            "set_only_if_empty": setOnlyIfEmptu,
+            "set_only_if_empty": setOnlyIfEmpty,
         ] as [String: AnyObject]
 
         wordPressComRestApi.POST(path, parameters: parameters, success: { (responseObject, httpResponse) in

--- a/WordPressKit/EditorServiceRemote.swift
+++ b/WordPressKit/EditorServiceRemote.swift
@@ -29,13 +29,18 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         ] as [String: AnyObject]
 
         wordPressComRestApi.POST(path, parameters: parameters, success: { (responseObject, httpResponse) in
-            guard let response = responseObject as? [Int: String] else {
+            guard let response = responseObject as? [String: String] else {
                 if let boolResponse = responseObject as? Bool, boolResponse == false {
                     return failure(EditorSettings.Error.badRequest)
                 }
                 return failure(EditorSettings.Error.badResponse)
             }
-            let mappedResponse = response.compactMapValues(EditorSettings.Mobile.init)
+
+            let mappedResponse = response.reduce(into: [Int: EditorSettings.Mobile](), { (result, response) in
+                if let id = Int(response.key), let editor = EditorSettings.Mobile(rawValue: response.value) {
+                    result[id] = editor
+                }
+            })
             success(mappedResponse)
         }) { (error, httpError) in
             failure(error)

--- a/WordPressKit/EditorSettings.swift
+++ b/WordPressKit/EditorSettings.swift
@@ -6,6 +6,9 @@ private struct RemoteEditorSettings: Codable {
 public struct EditorSettings {
     public enum Error: Swift.Error {
         case decodingFailed
+        case unknownEditor(String)
+        case badRequest
+        case badResponse
     }
 
     /// Editor choosen by the user to be used on Mobile

--- a/WordPressKitTests/EditorServiceRemoteTests.swift
+++ b/WordPressKitTests/EditorServiceRemoteTests.swift
@@ -180,13 +180,52 @@ class EditorServiceRemoteTests: XCTestCase {
         wait(for: [expec], timeout: 0.1)
     }
 
-    func testPostDesignateMobileEditorForAllSites() {
+    func testPostDesignateGutenbergMobileEditorForAllSites() {
         let expec = expectation(description: "success")
+        let editor = EditorSettings.Mobile.gutenberg
 
         //TODO: Response not yet clear
-        let response = [String: AnyObject]()
+        let response: [Int: String] = [
+            1: editor.rawValue,
+            2: editor.rawValue,
+        ]
 
-        editorServiceRemote.postDesignateMobileEditorForAllSites(.gutenberg, success: {
+        let expected: [Int: EditorSettings.Mobile] = [
+            1: editor,
+            2: editor
+        ]
+
+        editorServiceRemote.postDesignateMobileEditorForAllSites(editor, success: {
+            XCTAssertEqual($0, expected)
+            expec.fulfill()
+        }) { (error) in
+            XCTFail("This call should error")
+            expec.fulfill()
+        }
+
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+        XCTAssertTrue(mockRemoteApi.postMethodCalled)
+
+        wait(for: [expec], timeout: 0.1)
+    }
+
+    func testPostDesignateAztecMobileEditorForAllSites() {
+        let expec = expectation(description: "success")
+        let editor = EditorSettings.Mobile.aztec
+
+        //TODO: Response not yet clear
+        let response: [Int: String] = [
+            1: editor.rawValue,
+            2: editor.rawValue,
+        ]
+
+        let expected: [Int: EditorSettings.Mobile] = [
+            1: editor,
+            2: editor
+        ]
+
+        editorServiceRemote.postDesignateMobileEditorForAllSites(editor, success: {
+            XCTAssertEqual($0, expected)
             expec.fulfill()
         }) { (error) in
             XCTFail("This call should error")

--- a/WordPressKitTests/EditorServiceRemoteTests.swift
+++ b/WordPressKitTests/EditorServiceRemoteTests.swift
@@ -179,6 +179,25 @@ class EditorServiceRemoteTests: XCTestCase {
 
         wait(for: [expec], timeout: 0.1)
     }
+
+    func testPostDesignateMobileEditorForAllSites() {
+        let expec = expectation(description: "success")
+
+        //TODO: Response not yet clear
+        let response = [String: AnyObject]()
+
+        editorServiceRemote.postDesignateMobileEditorForAllSites(.gutenberg, success: {
+            expec.fulfill()
+        }) { (error) in
+            XCTFail("This call should error")
+            expec.fulfill()
+        }
+
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+        XCTAssertTrue(mockRemoteApi.postMethodCalled)
+
+        wait(for: [expec], timeout: 0.1)
+    }
 }
 
 extension EditorServiceRemoteTests {

--- a/WordPressKitTests/EditorServiceRemoteTests.swift
+++ b/WordPressKitTests/EditorServiceRemoteTests.swift
@@ -184,10 +184,9 @@ class EditorServiceRemoteTests: XCTestCase {
         let expec = expectation(description: "success")
         let editor = EditorSettings.Mobile.gutenberg
 
-        //TODO: Response not yet clear
-        let response: [Int: String] = [
-            1: editor.rawValue,
-            2: editor.rawValue,
+        let response: [String: String] = [
+            "1": editor.rawValue,
+            "2": editor.rawValue,
         ]
 
         let expected: [Int: EditorSettings.Mobile] = [
@@ -199,7 +198,7 @@ class EditorServiceRemoteTests: XCTestCase {
             XCTAssertEqual($0, expected)
             expec.fulfill()
         }) { (error) in
-            XCTFail("This call should error")
+            XCTFail("This call should NOT error")
             expec.fulfill()
         }
 
@@ -213,10 +212,9 @@ class EditorServiceRemoteTests: XCTestCase {
         let expec = expectation(description: "success")
         let editor = EditorSettings.Mobile.aztec
 
-        //TODO: Response not yet clear
-        let response: [Int: String] = [
-            1: editor.rawValue,
-            2: editor.rawValue,
+        let response: [String: String] = [
+            "1": editor.rawValue,
+            "2": editor.rawValue,
         ]
 
         let expected: [Int: EditorSettings.Mobile] = [
@@ -228,7 +226,7 @@ class EditorServiceRemoteTests: XCTestCase {
             XCTAssertEqual($0, expected)
             expec.fulfill()
         }) { (error) in
-            XCTFail("This call should error")
+            XCTFail("This call should NOT error")
             expec.fulfill()
         }
 


### PR DESCRIPTION
iOS side of https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/1332

This PR adds the ability to bulk set the mobile editor preference on all sites with just one network call to a new WordPress.com REST API Endpoint (`https://public-api.wordpress.com/wpcom/v2/me/gutenberg/`). 

The endpoint is not deployed yet, and the response format is still in brainstorming, but we can start coding the request/response flow.

Test via: https://github.com/wordpress-mobile/WordPress-iOS/pull/12276

- [x] Please check here if your pull request includes additional test coverage.

cc @hypest @daniloercoli 
