### PR TITLE
Add method to create WP account with Apple ID

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.4.0"
+  s.version       = "4.5.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComServiceRemote.h
+++ b/WordPressKit/WordPressComServiceRemote.h
@@ -53,7 +53,8 @@ typedef void(^WordPressComServiceFailureBlock)(NSError *error);
  *
  * @param token          Token provided by Apple.
  * @param email          Apple email to use for new account.
- * @param userName       The username for the new account. Formed from the Apple ID fullname.
+ * @param fullName       The user's full name for the new account. Formed from the fullname
+ *                       property in the Apple ID credential.
  * @param clientID       wpcom client ID.
  * @param clientSecret   wpcom secret.
  * @param success        success block.
@@ -61,7 +62,7 @@ typedef void(^WordPressComServiceFailureBlock)(NSError *error);
  */
 - (void)createWPComAccountWithApple:(NSString *)token
                            andEmail:(NSString *)email
-                        andUserName:(NSString *)userName
+                        andFullName:(NSString *)fullName
                         andClientID:(NSString *)clientID
                     andClientSecret:(NSString *)clientSecret
                             success:(WordPressComServiceSuccessBlock)success

--- a/WordPressKit/WordPressComServiceRemote.h
+++ b/WordPressKit/WordPressComServiceRemote.h
@@ -49,6 +49,25 @@ typedef void(^WordPressComServiceFailureBlock)(NSError *error);
                              failure:(WordPressComServiceFailureBlock)failure;
 
 /**
+ * @brief Create a new WordPress.com account from Apple ID credentials.
+ *
+ * @param token          Token provided by Apple.
+ * @param email          Apple email to use for new account.
+ * @param userName       The username for the new account. Formed from the Apple ID fullname.
+ * @param clientID       wpcom client ID.
+ * @param clientSecret   wpcom secret.
+ * @param success        success block.
+ * @param failure        failure block.
+ */
+- (void)createWPComAccountWithApple:(NSString *)token
+                           andEmail:(NSString *)email
+                        andUserName:(NSString *)userName
+                        andClientID:(NSString *)clientID
+                    andClientSecret:(NSString *)clientSecret
+                            success:(WordPressComServiceSuccessBlock)success
+                            failure:(WordPressComServiceFailureBlock)failure;
+
+/**
  *  @brief      Validates a WordPress.com blog with the specified parameters.
  *
  *  @param      blogUrl     The url of the blog to validate.  Cannot be nil.

--- a/WordPressKit/WordPressComServiceRemote.m
+++ b/WordPressKit/WordPressComServiceRemote.m
@@ -83,7 +83,7 @@
 
 - (void)createWPComAccountWithApple:(NSString *)token
                            andEmail:(NSString *)email
-                        andUserName:(NSString *)userName
+                        andFullName:(NSString *)fullName
                         andClientID:(NSString *)clientID
                     andClientSecret:(NSString *)clientSecret
                             success:(WordPressComServiceSuccessBlock)success
@@ -96,7 +96,7 @@
         @"service": @"apple",
         @"signup_flow_name": @"social",
         @"user_email": email,
-        @"user_name": userName,
+        @"user_name": fullName,
     };
 
     [self createSocialWPComAccountWithParams:params success:success failure:failure];

--- a/WordPressKit/WordPressComServiceRemote.m
+++ b/WordPressKit/WordPressComServiceRemote.m
@@ -64,12 +64,47 @@
     [self.wordPressComRestApi POST:requestUrl parameters:params success:successBlock failure:failureBlock];
 }
 
-// API v1 POST /users/social/new
 - (void)createWPComAccountWithGoogle:(NSString *)token
                          andClientID:(NSString *)clientID
                      andClientSecret:(NSString *)clientSecret
                              success:(WordPressComServiceSuccessBlock)success
                              failure:(WordPressComServiceFailureBlock)failure
+{
+    NSDictionary *params = @{
+        @"client_id": clientID,
+        @"client_secret": clientSecret,
+        @"id_token": token,
+        @"service": @"google",
+        @"signup_flow_name": @"social",
+    };
+
+    [self createSocialWPComAccountWithParams:params success:success failure:failure];
+}
+
+- (void)createWPComAccountWithApple:(NSString *)token
+                           andEmail:(NSString *)email
+                        andUserName:(NSString *)userName
+                        andClientID:(NSString *)clientID
+                    andClientSecret:(NSString *)clientSecret
+                            success:(WordPressComServiceSuccessBlock)success
+                            failure:(WordPressComServiceFailureBlock)failure
+{
+    NSDictionary *params = @{
+        @"client_id": clientID,
+        @"client_secret": clientSecret,
+        @"id_token": token,
+        @"service": @"apple",
+        @"signup_flow_name": @"social",
+        @"user_email": email,
+        @"user_name": userName,
+    };
+
+    [self createSocialWPComAccountWithParams:params success:success failure:failure];
+}
+
+- (void)createSocialWPComAccountWithParams:(NSDictionary *)params
+                                   success:(WordPressComServiceSuccessBlock)success
+                                   failure:(WordPressComServiceFailureBlock)failure
 {
     void (^successBlock)(id, NSHTTPURLResponse *) = ^(id responseObject, NSHTTPURLResponse *httpResponse) {
         success(responseObject);
@@ -80,16 +115,7 @@
         failure(errorWithLocalizedMessage);
     };
 
-    NSDictionary *params = @{
-                             @"client_id": clientID,
-                             @"client_secret": clientSecret,
-                             @"id_token": token,
-                             @"service": @"google",
-                             @"signup_flow_name": @"social",
-                             };
-
     NSString *requestUrl = [self pathForEndpoint:@"users/social/new" withVersion:ServiceRemoteWordPressComRESTApiVersion_1_0];
-
     [self.wordPressComRestApi POST:requestUrl parameters:params success:successBlock failure:failureBlock];
 }
 

--- a/WordPressKitTests/WPStatsServiceRemoteTests.m
+++ b/WordPressKitTests/WPStatsServiceRemoteTests.m
@@ -865,7 +865,6 @@
          XCTAssertNotNil(monthsYearsItems);
          XCTAssertTrue([[monthsYearsItems[0] label] isEqualToString:@"2014"]);
          XCTAssertTrue([[monthsYearsItems[1] label] isEqualToString:@"2015"]);
-         XCTAssertTrue([[[monthsYearsItems[0] children][0] label] isEqualToString:@"June"]);
          
          XCTAssertNotNil(averagePerDayItems);
          XCTAssertEqual(2, averagePerDayItems.count);


### PR DESCRIPTION
### Description
This adds a method to create a WordPress account using Apple ID credentials.

Fixes #n/a

### Testing Details

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12350
Also related to WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/116

- [ ] Please check here if your pull request includes additional test coverage.
