### PR TITLE
Add Apple specific parameters to social service connect

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.0-beta.1"
+  s.version       = "4.5.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemoteREST+SocialService.swift
+++ b/WordPressKit/AccountServiceRemoteREST+SocialService.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum SocialServiceName: String {
     case google
+    case apple
 }
 
 

--- a/WordPressKit/AccountServiceRemoteREST+SocialService.swift
+++ b/WordPressKit/AccountServiceRemoteREST+SocialService.swift
@@ -13,19 +13,35 @@ extension AccountServiceRemoteREST {
     /// - Parameters:
     ///     - service The name of the social service.
     ///     - token The OpenID Connect (JWT) ID token identifying the user on the social service.
+    ///     - appleEmail The email address associated with an Apple ID. Optional.
+    ///     - appleFullName The full name associated with an Apple ID. Optional.
     ///     - oAuthClientID The WPCOM REST API client ID.
     ///     - oAuthClientSecret The WPCOM REST API client secret.
     ///     - success The block that will be executed on success.
     ///     - failure The block that will be executed on failure.
-    public func connectToSocialService(_ service: SocialServiceName, serviceIDToken token: String, oAuthClientID: String, oAuthClientSecret: String, success:@escaping (() -> Void), failure:@escaping ((NSError) -> Void)) {
+    public func connectToSocialService(_ service: SocialServiceName,
+                                       serviceIDToken token: String,
+                                       appleEmail: String? = nil,
+                                       appleFullName: String? = nil,
+                                       oAuthClientID: String,
+                                       oAuthClientSecret: String,
+                                       success:@escaping (() -> Void),
+                                       failure:@escaping ((NSError) -> Void)) {
         let path = self.path(forEndpoint: "me/social-login/connect", withVersion: ._1_1)
 
-        let params = [
+        var params = [
             "client_id": oAuthClientID,
             "client_secret": oAuthClientSecret,
             "service": service.rawValue,
             "id_token": token,
         ] as [String: AnyObject]
+        
+        // Append Apple specific parameters
+        if service == .apple {
+            params["user_email"] = appleEmail as AnyObject
+            params["user_name"] = appleFullName as AnyObject
+        }
+        
         wordPressComRestApi.POST(path, parameters: params, success: { (responseObject, httpResponse) in
             success()
         }, failure: { (error, httpResponse) in

--- a/WordPressKit/AccountServiceRemoteREST+SocialService.swift
+++ b/WordPressKit/AccountServiceRemoteREST+SocialService.swift
@@ -13,14 +13,14 @@ extension AccountServiceRemoteREST {
     /// - Parameters:
     ///     - service The name of the social service.
     ///     - token The OpenID Connect (JWT) ID token identifying the user on the social service.
-    ///     - appleConnectParameters Dictionary containing endpoint parameters specific to connecting to Apple service.
+    ///     - connectParameters Dictionary containing additional endpoint parameters. Currently only used for the Apple service.
     ///     - oAuthClientID The WPCOM REST API client ID.
     ///     - oAuthClientSecret The WPCOM REST API client secret.
     ///     - success The block that will be executed on success.
     ///     - failure The block that will be executed on failure.
     public func connectToSocialService(_ service: SocialServiceName,
                                        serviceIDToken token: String,
-                                       appleConnectParameters: [String:AnyObject]? = nil,
+                                       connectParameters: [String:AnyObject]? = nil,
                                        oAuthClientID: String,
                                        oAuthClientSecret: String,
                                        success:@escaping (() -> Void),
@@ -33,10 +33,9 @@ extension AccountServiceRemoteREST {
             "service": service.rawValue,
             "id_token": token,
         ] as [String: AnyObject]
-        
-        // Append Apple specific parameters
-        if service == .apple, let appleConnectParameters = appleConnectParameters {
-            params.merge(appleConnectParameters, uniquingKeysWith: { (current, _) in current })
+
+        if let connectParameters = connectParameters {
+            params.merge(connectParameters, uniquingKeysWith: { (current, _) in current })
         }
         
         wordPressComRestApi.POST(path, parameters: params, success: { (responseObject, httpResponse) in

--- a/WordPressKit/AccountServiceRemoteREST+SocialService.swift
+++ b/WordPressKit/AccountServiceRemoteREST+SocialService.swift
@@ -13,16 +13,14 @@ extension AccountServiceRemoteREST {
     /// - Parameters:
     ///     - service The name of the social service.
     ///     - token The OpenID Connect (JWT) ID token identifying the user on the social service.
-    ///     - appleEmail The email address associated with an Apple ID. Optional.
-    ///     - appleFullName The full name associated with an Apple ID. Optional.
+    ///     - appleConnectParameters Dictionary containing endpoint parameters specific to connecting to Apple service.
     ///     - oAuthClientID The WPCOM REST API client ID.
     ///     - oAuthClientSecret The WPCOM REST API client secret.
     ///     - success The block that will be executed on success.
     ///     - failure The block that will be executed on failure.
     public func connectToSocialService(_ service: SocialServiceName,
                                        serviceIDToken token: String,
-                                       appleEmail: String? = nil,
-                                       appleFullName: String? = nil,
+                                       appleConnectParameters: [String:AnyObject]? = nil,
                                        oAuthClientID: String,
                                        oAuthClientSecret: String,
                                        success:@escaping (() -> Void),
@@ -37,9 +35,8 @@ extension AccountServiceRemoteREST {
         ] as [String: AnyObject]
         
         // Append Apple specific parameters
-        if service == .apple {
-            params["user_email"] = appleEmail as AnyObject
-            params["user_name"] = appleFullName as AnyObject
+        if service == .apple, let appleConnectParameters = appleConnectParameters {
+            params.merge(appleConnectParameters, uniquingKeysWith: { (current, _) in current })
         }
         
         wordPressComRestApi.POST(path, parameters: params, success: { (responseObject, httpResponse) in
@@ -49,6 +46,19 @@ extension AccountServiceRemoteREST {
         })
     }
 
+    /// Get Apple connect parameters from provided account information.
+    ///
+    /// - Parameters:
+    ///     - email Email from Apple account.
+    ///     - fullName User's full name from Apple account.
+    /// - Returns: Dictionary with endpoint parameters, to be used when connecting to social service.
+    static public func appleSignInParameters(email: String, fullName: String) -> [String:AnyObject] {
+        return [
+            "user_email": email as AnyObject,
+            "user_name": fullName as AnyObject
+        ]
+    }
+    
     /// Disconnect fromm the specified social service.
     ///
     /// - Parameters:


### PR DESCRIPTION
### Description

Fixes #n/a

This does two things:
1) Adds an `apple` service name. This was needed for the associated WPAuth change.
2) Adds Apple specific parameters to the `social-login/connect` endpoint. This wasn't needed yet, but hey, while we're here...

### Testing Details

This can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12360
Ref WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/117

- [ ] Please check here if your pull request includes additional test coverage.
