### PR TITLE
[SIWA] Return user's email in constructed Error

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.0"
+  s.version       = "4.5.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -34,6 +34,7 @@ open class WordPressComRestApi: NSObject {
 
     @objc public static let ErrorKeyErrorCode       = "WordPressComRestApiErrorCodeKey"
     @objc public static let ErrorKeyErrorMessage    = "WordPressComRestApiErrorMessageKey"
+    @objc public static let ErrorKeyErrorData       = "WordPressComRestApiErrorDataKey"
 
     @objc public static let LocaleKeyDefault        = "locale"  // locale is specified with this for v1 endpoints
     @objc public static let LocaleKeyV2             = "_locale" // locale is prefixed with an underscore for v2
@@ -464,6 +465,11 @@ extension WordPressComRestApi {
         userInfo[WordPressComRestApi.ErrorKeyErrorCode] = errorCode
         userInfo[WordPressComRestApi.ErrorKeyErrorMessage] = errorDescription
         userInfo[NSLocalizedDescriptionKey] =  errorDescription
+
+        if let errorData = errorEntry["data"] {
+            userInfo[WordPressComRestApi.ErrorKeyErrorData] = errorData
+        }
+
         let nserror = mappedError as NSError
         let resultError = NSError(domain: nserror.domain,
                                code: nserror.code,

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -35,6 +35,7 @@ open class WordPressComRestApi: NSObject {
     @objc public static let ErrorKeyErrorCode       = "WordPressComRestApiErrorCodeKey"
     @objc public static let ErrorKeyErrorMessage    = "WordPressComRestApiErrorMessageKey"
     @objc public static let ErrorKeyErrorData       = "WordPressComRestApiErrorDataKey"
+    @objc public static let ErrorKeyErrorDataEmail  = "email"
 
     @objc public static let LocaleKeyDefault        = "locale"  // locale is specified with this for v1 endpoints
     @objc public static let LocaleKeyV2             = "_locale" // locale is prefixed with an underscore for v2


### PR DESCRIPTION
### Description

Ref WPiOS issue #https://github.com/wordpress-mobile/WordPress-iOS/issues/12556
WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/141

This adds the `data` part of the API's error response to the returned `NSError`'s `userInfo`. `data` contains the email needed to display on the WP password entry view when re-logging in with SIWA.

### Testing Details

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12606

- [ ] Please check here if your pull request includes additional test coverage.
