### PR TITLE
Make wpcom headers public

### DIFF
--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -120,6 +120,10 @@ open class WordPressComRestApi: NSObject {
     @objc convenience public init(oAuthToken: String? = nil, userAgent: String? = nil, baseUrlString: String = WordPressComRestApi.apiBaseURLString) {
         self.init(oAuthToken: oAuthToken, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressComRestApi.defaultBackgroundSessionIdentifier, baseUrlString: baseUrlString)
     }
+
+    public var headers: [AnyHashable: Any] {
+        return sessionManager.session.configuration.httpAdditionalHeaders ?? [:]
+    }
     
     /// Creates a new API object to connect to the WordPress Rest API.
     ///


### PR DESCRIPTION
### Description

This PR makes the wpcom api headers public, to be able to send them to gutenberg.

**Related PRs:**
gutenberg PR: https://github.com/WordPress/gutenberg/pull/17979
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12706

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details
Follow the tests steps from the WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
