### PR TITLE
Added signup_flow_name attribute

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.1"
+  s.version       = "4.5.2-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -245,7 +245,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
     NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:@{
                                                                                   @"email": email,
                                                                                   @"client_id": clientID,
-                                                                                  @"client_secret": clientSecret,
+                                                                                  @"client_secret": clientSecret
     }];
 
     if (![@"wordpress" isEqualToString:scheme]) {

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -240,7 +240,8 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
     NSMutableDictionary *params = [NSMutableDictionary dictionaryWithDictionary:@{
                                                                                   @"email": email,
                                                                                   @"client_id": clientID,
-                                                                                  @"client_secret": clientSecret
+                                                                                  @"client_secret": clientSecret,
+                                                                                  @"signup_flow_name": @"mobile-ios"
                                                                                   }];
     if (![@"wordpress" isEqualToString:scheme]) {
         [params setObject:scheme forKey:@"scheme"];

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -202,6 +202,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                    path:path
                                clientID:clientID
                            clientSecret:clientSecret
+                            extraParams: nil
                             wpcomScheme:scheme
                                 success:success
                                 failure:failure];
@@ -217,11 +218,14 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
     
     NSString *path = [self pathForEndpoint:@"auth/send-signup-email"
                                withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
-    
+
+    NSDictionary *signupFlowParam = @{@"signup_flow_name": @"mobile-ios"};
+
     [self requestWPComMagicLinkForEmail:email
                                    path:path
                                clientID:clientID
                            clientSecret:clientSecret
+                            extraParams:signupFlowParam
                             wpcomScheme:scheme
                                 success:success
                                 failure:failure];
@@ -231,6 +235,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                  path:(NSString *)path
                              clientID:(NSString *)clientID
                          clientSecret:(NSString *)clientSecret
+                          extraParams:(nullable NSDictionary *)extraParams
                           wpcomScheme:(NSString *)scheme
                               success:(void (^)(void))success
                               failure:(void (^)(NSError *error))failure
@@ -241,10 +246,14 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                                                                   @"email": email,
                                                                                   @"client_id": clientID,
                                                                                   @"client_secret": clientSecret,
-                                                                                  @"signup_flow_name": @"mobile-ios"
-                                                                                  }];
+    }];
+
     if (![@"wordpress" isEqualToString:scheme]) {
         [params setObject:scheme forKey:@"scheme"];
+    }
+    
+    if (extraParams != nil) {
+        [params addEntriesFromDictionary:extraParams];
     }
 
     [self.wordPressComRestApi POST:path

--- a/WordPressKit/WordPressComServiceRemote.m
+++ b/WordPressKit/WordPressComServiceRemote.m
@@ -55,7 +55,8 @@
                              @"password": password,
                              @"validate": @(validate),
                              @"client_id": clientID,
-                             @"client_secret": clientSecret
+                             @"client_secret": clientSecret,
+                             @"signup_flow_name": @"mobile-ios"
                              };
     
     NSString *requestUrl = [self pathForEndpoint:@"users/new"

--- a/WordPressKit/WordPressComServiceRemote.m
+++ b/WordPressKit/WordPressComServiceRemote.m
@@ -55,8 +55,7 @@
                              @"password": password,
                              @"validate": @(validate),
                              @"client_id": clientID,
-                             @"client_secret": clientSecret,
-                             @"signup_flow_name": @"mobile-ios"
+                             @"client_secret": clientSecret
                              };
     
     NSString *requestUrl = [self pathForEndpoint:@"users/new"


### PR DESCRIPTION
to account creation with email

### Description
https://github.com/wordpress-mobile/WordPress-iOS/issues/12724

To test: 
 in WPiOS update WordPressKit pod to: 
```pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'task/add_signup_attribute'```
and test signup with email works

Seems like `createWPComAccountWithEmail` is not being used anymore (which is where I originally added the param. I created an issue to remove this method : #191 

- [ ] Please check here if your pull request includes additional test coverage.
