### PR TITLE
Make extensions public

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.2-beta.1"
+  s.version       = "4.5.2-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/NSAttributedString+extensions.swift
+++ b/WordPressKit/NSAttributedString+extensions.swift
@@ -4,7 +4,7 @@ extension NSAttributedString {
     /// This helper method returns a new NSAttributedString instance, with all of the the leading / trailing newLines
     /// characters removed.
     ///
-    @objc func trimNewlines() -> NSAttributedString {
+    @objc public func trimNewlines() -> NSAttributedString {
         guard let trimmed = mutableCopy() as? NSMutableAttributedString else {
             return self
         }

--- a/WordPressKit/NSMutableParagraphStyle+extensions.swift
+++ b/WordPressKit/NSMutableParagraphStyle+extensions.swift
@@ -1,14 +1,14 @@
 import Foundation
 
 extension NSMutableParagraphStyle {
-    @objc convenience init(minLineHeight: CGFloat, lineBreakMode: NSLineBreakMode, alignment: NSTextAlignment) {
+    @objc convenience public init(minLineHeight: CGFloat, lineBreakMode: NSLineBreakMode, alignment: NSTextAlignment) {
         self.init()
         self.minimumLineHeight  = minLineHeight
         self.lineBreakMode      = lineBreakMode
         self.alignment          = alignment
     }
 
-    @objc convenience init(minLineHeight: CGFloat, maxLineHeight: CGFloat, lineBreakMode: NSLineBreakMode, alignment: NSTextAlignment) {
+    @objc convenience public init(minLineHeight: CGFloat, maxLineHeight: CGFloat, lineBreakMode: NSLineBreakMode, alignment: NSTextAlignment) {
         self.init(minLineHeight: minLineHeight, lineBreakMode: lineBreakMode, alignment: alignment)
         self.maximumLineHeight  = maxLineHeight
     }

--- a/WordPressKit/NSString+MD5.m
+++ b/WordPressKit/NSString+MD5.m
@@ -2,7 +2,7 @@
 #import <CommonCrypto/CommonDigest.h>
 
 
-@implementation NSString (Gravatar)
+@implementation NSString (MD5)
 
 - (NSString *)md5
 {


### PR DESCRIPTION
Ref WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/10975

This makes some extension methods public so they can be used by host apps.

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12794
