### PR TITLE
Fix XML-RPC comment moderation to use correct comment ID

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.3-beta.2"
+  s.version       = "4.5.3-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -119,7 +119,7 @@
     NSParameterAssert(comment.commentID != nil);
     NSNumber *commentID = comment.commentID;
     NSArray *extraParameters = @[
-                                 comment.commentID,
+                                 commentID,
                                  @{@"status": comment.status},
                                  ];
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -117,6 +117,7 @@
                 failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(comment.commentID != nil);
+    NSNumber *commentID = comment.commentID;
     NSArray *extraParameters = @[
                                  comment.commentID,
                                  @{@"status": comment.status},
@@ -125,7 +126,6 @@
     [self.api callMethod:@"wp.editComment"
               parameters:parameters
                  success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-                     NSNumber *commentID = responseObject;
                      // TODO: validate response
                      [self getCommentWithID:commentID
                                     success:success


### PR DESCRIPTION
### Description

iOS issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/12909

Updates the method to moderate a comment so it uses the correct comment ID, instead of the boolean value in the `wp.editComment` response. (This is the same fix used for a similar issue [here](https://github.com/wordpress-mobile/WordPress-iOS/commit/ed2a107b1fd2b82fc543d65bdb7678e20d97d774).)

### Testing Details

Test instructions in this PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/12910

- [ ] Please check here if your pull request includes additional test coverage.
