### PR TITLE
Updating social auth method to work with Apple 

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.3"
+  s.version       = "4.5.4-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -244,15 +244,16 @@ public final class WordPressComOAuthClient: NSObject {
     }
 
     /// Authenticate on WordPress.com with a social service's ID token.
-    /// Only google is supported at this time.
     ///
     /// - Parameters:
     ///     - token: A social ID token obtained from a supported social service.
+    ///     - service: The social service type (ex: "google" or "apple").
     ///     - success: block to be called if authentication was successful. The OAuth2 token is passed as a parameter.
     ///     - needsMultifactor: block to be called if a 2fa token is needed to complete the auth process.
     ///     - failure: block to be called if authentication failed. The error object is passed as a parameter.
     ///
     @objc public func authenticateWithIDToken(_ token: String,
+                                              service: String,
                                               success: @escaping (_ authToken: String?) -> Void,
                                               needsMultifactor: @escaping (_ userID: Int, _ nonceInfo: SocialLogin2FANonceInfo) -> Void,
                                               existingUserNeedsConnection: @escaping (_ email: String) -> Void,
@@ -260,7 +261,7 @@ public final class WordPressComOAuthClient: NSObject {
         let parameters = [
             "client_id": clientID,
             "client_secret": secret,
-            "service": "google",
+            "service": service,
             "get_bearer_token": true,
             "id_token" : token,
             ] as [String : Any]

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -417,13 +417,17 @@ public final class WordPressComOAuthClient: NSObject {
     }
 
     private func cleanedUpResponseForLogging(_ response: AnyObject) -> AnyObject {
-        guard var responseDictionary = response as? [String: AnyObject],
-            let _ = responseDictionary["access_token"]
-            else {
+        guard var responseDictionary = response as? [String: AnyObject] else {
                 return response
         }
 
-        responseDictionary["access_token"] = "*** REDACTED ***" as AnyObject?
+        let keys = ["access_token", "bearer_token"]
+        for key in keys {
+            if responseDictionary[key] != nil {
+                responseDictionary[key] = "*** REDACTED ***" as AnyObject?
+            }
+        }
+
         return responseDictionary as AnyObject
     }
 

--- a/WordPressKitTests/WordPressComOAuthTests.swift
+++ b/WordPressKitTests/WordPressComOAuthTests.swift
@@ -146,6 +146,7 @@ class WordPressComOAuthTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
         client.authenticateWithIDToken("token",
+                                       service: "google",
                                        success: { (token) in
                                         expect.fulfill()
                                         XCTAssert(!token!.isEmpty, "There should be a token available")
@@ -173,6 +174,7 @@ class WordPressComOAuthTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
         client.authenticateWithIDToken("token",
+                                       service: "google",
                                        success: { (token) in
                                         expect.fulfill()
                                         XCTFail("This call should need multifactor")
@@ -200,6 +202,7 @@ class WordPressComOAuthTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
         client.authenticateWithIDToken("token",
+                                       service: "google",
                                        success: { (token) in
                                         expect.fulfill()
                                         XCTFail("This call should invoke user needs connection")


### PR DESCRIPTION
### Description

WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/158
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13013

 This updates the `authenticateWithIDToken` method to accept a social service type so it can be used for either Google or Apple.

### Testing Details

Can be tested in WPiOS PR noted above.