### PR TITLE
Update CircleCI config to use Xcode 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
     jobs:
       - ios/test:
           name: Test
-          xcode-version: "10.2.0"
+          xcode-version: "11.2.1"
           workspace: WordPressKit.xcworkspace
           scheme: WordPressKitTests
           device: iPhone Xs
@@ -18,12 +18,12 @@ workflows:
           pod-install: true
       - ios/validate-podspec:
           name: Validate Podspec
-          xcode-version: "10.2.0"
+          xcode-version: "11.2.1"
           podspec-path: WordPressKit.podspec
           bundle-install: true
       - ios/publish-podspec:
           name: Publish to Trunk
-          xcode-version: "10.2.0"
+          xcode-version: "11.2.1"
           podspec-path: WordPressKit.podspec
           bundle-install: true
           post-to-slack: true


### PR DESCRIPTION
### Description

This PR updates the CircleCI config to use Xcode 11.

As I was working on #202, the CI tests were failing because the code used some of the newer Swift 5 syntax. Since we have all moved to Xcode 11 for development, I think we should update CI as well.

### Testing Details

I applied this to #202 and the tests started passing.

- [ ] Please check here if your pull request includes additional test coverage.
