### PR TITLE
Fix memory layout issues with DDLogLevel

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (6.1.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (1.4.0)
-  - WordPressShared (1.8.8-beta.1):
+  - WordPressShared (1.8.10-beta-2):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - wpxmlrpc (0.8.4)
@@ -63,7 +63,7 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressShared: 43343deb20fa5a094d31b18646986a1bd1cbc0d8
+  WordPressShared: 1569e8d477069a7f63022d727b008511ed2df824
   wpxmlrpc: 6ba55c773cfa27083ae4a2173e69b19f46da98e2
 
 PODFILE CHECKSUM: 211d41e231cc0945dcbcefcf462fa2bca082d54e

--- a/WordPressKit/Private/WPKitLoggingPrivate.h
+++ b/WordPressKit/Private/WPKitLoggingPrivate.h
@@ -1,2 +1,2 @@
 @import CocoaLumberjack;
-extern int ddLogLevel;
+extern DDLogLevel ddLogLevel;

--- a/WordPressKit/Private/WPKitLoggingPrivate.m
+++ b/WordPressKit/Private/WPKitLoggingPrivate.m
@@ -1,2 +1,2 @@
 #import "WPKitLoggingPrivate.h"
-int ddLogLevel = DDLogLevelWarning;
+DDLogLevel ddLogLevel = DDLogLevelWarning;

--- a/WordPressKit/WPKitLogging.h
+++ b/WordPressKit/WPKitLogging.h
@@ -1,2 +1,4 @@
-int WPKitGetLoggingLevel(void);
-void WPKitSetLoggingLevel(int level);
+@import CocoaLumberjack;
+
+DDLogLevel WPKitGetLoggingLevel(void);
+void WPKitSetLoggingLevel(DDLogLevel level);

--- a/WordPressKit/WPKitLogging.m
+++ b/WordPressKit/WPKitLogging.m
@@ -1,10 +1,10 @@
 #import "WPKitLogging.h"
 #import "WPKitLoggingPrivate.h"
 
-int WPKitGetLoggingLevel() {
+DDLogLevel WPKitGetLoggingLevel() {
     return ddLogLevel;
 }
 
-void WPKitSetLoggingLevel(int level) {
+void WPKitSetLoggingLevel(DDLogLevel level) {
     ddLogLevel = level;
 }


### PR DESCRIPTION
Rather than using int as the type, we use DDLogLevel per https://github.com/CocoaLumberjack/CocoaLumberjack/blob/master/Documentation/DynamicLogLevels.md.

This PR also updates the `WordPressShared` dependency to use the latest beta version which also has this fix.
