### PR TITLE
Fix reference cycle using weak reference for dataRequest

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.5"
+  s.version       = "4.5.6-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -189,9 +189,9 @@ open class WordPressComRestApi: NSObject {
         }
 
         let progress = Progress(totalUnitCount: 1)
-        let progressUpdater = {(taskProgress: Progress) in
-            progress.totalUnitCount = taskProgress.totalUnitCount
-            progress.completedUnitCount = taskProgress.completedUnitCount
+        let progressUpdater = { [weak progress] (taskProgress: Progress) in
+            progress?.totalUnitCount = taskProgress.totalUnitCount
+            progress?.completedUnitCount = taskProgress.completedUnitCount
         }
 
         let dataRequest = sessionManager.request(URLString, method: method, parameters: parameters, encoding:encoding)
@@ -205,7 +205,6 @@ open class WordPressComRestApi: NSObject {
                 let nserror = self.processError(response: response, originalError: error)
                 failure(nserror, response.response)
             }
-
         }).downloadProgress(closure: progressUpdater)
         progress.sessionTask = dataRequest.task
         progress.cancellationHandler = { [weak dataRequest] in

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -196,10 +196,10 @@ open class WordPressComRestApi: NSObject {
 
         let dataRequest = sessionManager.request(URLString, method: method, parameters: parameters, encoding:encoding)
             .validate()
-            .responseJSON(completionHandler: { (response) in
+            .responseJSON(completionHandler: { [weak progress] (response) in
             switch response.result {
             case .success(let responseObject):
-                progress.completedUnitCount = progress.totalUnitCount
+                progress?.completedUnitCount = progress?.totalUnitCount ?? 0
                 success(responseObject as AnyObject, response.response)
             case .failure(let error):
                 let nserror = self.processError(response: response, originalError: error)

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -208,8 +208,8 @@ open class WordPressComRestApi: NSObject {
 
         }).downloadProgress(closure: progressUpdater)
         progress.sessionTask = dataRequest.task
-        progress.cancellationHandler = {
-            dataRequest.cancel()
+        progress.cancellationHandler = { [weak dataRequest] in
+            dataRequest?.cancel()
         }
         return progress
     }


### PR DESCRIPTION
### Description

The Memory Graph Leak detector correctly identifies a leak of `DataRequest` and `DataRequestTaskDelegate` objects due to a strong reference in the `Progress` object's cancellation handler.

![Screen Shot 2020-01-01 at 8 00 51 PM](https://user-images.githubusercontent.com/3250/71650464-512f5700-2cd3-11ea-8025-30de2f53488d.png)

The Memory Graph Debugger shows the correct circular reference here where the Progress object is strongly held by various other completion blocks (`progressUpdater` and `responseJSON`'s `completionHandler`) and `dataRequest` is held by the progress's `cancellationHandler`

![Screen Shot 2020-01-01 at 8 01 16 PM](https://user-images.githubusercontent.com/3250/71650468-5ab8bf00-2cd3-11ea-8c04-01329c4282d1.png)

### Code Change

This PR changes three currently `strong` references to `weak`:
1. The `dataRequest` reference in the Progress `cancellationHandler` block 
2. The `progress` reference in the `progressUpdater` block (which is passed as `downloadProgress`'s `closure`)
3. The `progress` reference in the `completionHandler` of the `responseJSON` function.

Any one of the first two changes will fix the leak, but I think it makes sense for none of these blocks to be hanging on to these underlying objects. Progress' lifecycle should be determined by the caller who receives the object and the DataRequest lifecycle should be dictated by the manager handling the tasks.

### Testing Details

- Test with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/13169
- Scroll through the Reader section to reproduce the leak.

- [ ] Please check here if your pull request includes additional test coverage.
