### PR TITLE
Maps is_wpcom_atomic.

### DIFF
--- a/WordPressKit/RemoteBlogOptionsHelper.m
+++ b/WordPressKit/RemoteBlogOptionsHelper.m
@@ -30,7 +30,8 @@
                                           @"jetpack_version",
                                           @"is_automated_transfer",
                                           @"blog_public",
-                                          @"max_upload_size"
+                                          @"max_upload_size",
+                                          @"is_wpcom_atomic",
                                           ];
 
         for (NSString *key in optionsDirectMapKeys) {


### PR DESCRIPTION
### Description

Fixes #215 

Maps the `is_wpcom_atomic` option.

### Testing Details

Check out WPiOS branch: `try/integrated-latest-wordpresskit`
Build and run the unit tests.

- [ ] Please check here if your pull request includes additional test coverage.
