### PR TITLE
Bumps up the version number to 4.5.9-beta.1.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.8"
+  s.version       = "4.5.9-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

Bumps up the version number to 4.5.9-beta.1.

### Testing Details

Just run `bundle exec pod install` in `try/integrated-latest-wordpresskit`.
Once this new version is published in CocoaPods we'll update the WPiOS podfile.

- [ ] Please check here if your pull request includes additional test coverage.
