### PR TITLE
Improves the error handling in our email checking service.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.9-beta.1"
+  s.version       = "4.5.9-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemoteREST.h
+++ b/WordPressKit/AccountServiceRemoteREST.h
@@ -2,6 +2,14 @@
 #import "AccountServiceRemote.h"
 #import "ServiceRemoteWordPressComREST.h"
 
+static NSString * const AccountServiceRemoteErrorDomain = @"AccountServiceErrorDomain";
+
+typedef NS_ERROR_ENUM(AccountServiceRemoteErrorDomain, AccountServiceRemoteError) {
+    AccountServiceRemoteCantReadServerResponse,
+    AccountServiceRemoteEmailAddressInvalid,
+    AccountServiceRemoteEmailAddressTaken,
+};
+
 @interface AccountServiceRemoteREST : ServiceRemoteWordPressComREST <AccountServiceRemote>
 
 @end

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -127,31 +127,54 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
 
 - (void)isEmailAvailable:(NSString *)email success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure
 {
+    static NSString * const errorEmailAddressInvalid = @"invalid";
+    static NSString * const errorEmailAddressTaken = @"taken";
+    
     [self.wordPressComRestApi GET:@"is-available/email"
-       parameters:@{ @"q": email, @"format": @"json"}
-          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-              if (!success) {
-                  return;
-              }
+                       parameters:@{ @"q": email, @"format": @"json"}
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+        if (!success) {
+            return;
+        }
 
-              // If the email address is not available (has already been used)
-              // the endpoint will reply with a 200 status code and an JSON
-              // object describing an error.
-              // The error is that the queried email address is not available,
-              // which is our failure case. Test the error response for the
-              // "taken" reason to confirm the email address exists.
-              BOOL available = NO;
-              if ([responseObject isKindOfClass:[NSDictionary class]]) {
-                  NSDictionary *dict = (NSDictionary *)responseObject;
-                  available = [[dict numberForKey:@"available"] boolValue];
-              }
-              success(available);
+        if ([responseObject isKindOfClass:[NSDictionary class]]) {
+            NSString *error = [responseObject objectForKey:@"error"];
+            NSString *message = [responseObject objectForKey:@"message"];
+            
+            if ([error isEqualToString:errorEmailAddressInvalid]) {
+                NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
+                                                            code:AccountServiceRemoteEmailAddressInvalid
+                                                        userInfo:@{
+                                                            @"response": responseObject,
+                                                            NSLocalizedDescriptionKey: message,
+                                                        }];
+                failure(error);
+                return;
+            } else if ([error isEqualToString:errorEmailAddressTaken]) {
+                NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
+                                                            code:AccountServiceRemoteEmailAddressTaken
+                                                        userInfo:@{
+                                                            @"response": responseObject,
+                                                            NSLocalizedDescriptionKey: message,
+                                                        }];
+                failure(error);
+                return;
+            }
+            
+            BOOL available = [[responseObject numberForKey:@"available"] boolValue];
+            success(available);
+        } else {
+            NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
+                                                        code:AccountServiceRemoteCantReadServerResponse
+                                                    userInfo:@{@"response": responseObject}];
 
-          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
+            failure(error);
+        }
+    } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+        if (failure) {
+            failure(error);
+        }
+    }];
 }
 
 - (void)isUsernameAvailable:(NSString *)username


### PR DESCRIPTION
### Description

Moves forward https://github.com/wordpress-mobile/WordPress-iOS/issues/13583

This PR improves the error handling in WPKit so that we don't ignore some error responses.

### Testing Details

You can test this PR by using WPiOS branch `try/fix-email-address-error`.

#### Test 1:

Try signing up with a valid email account.  It should send you the magic link.

#### Test 2:

Try signing up with an invalid email provider.  For example "tester@mailinator.com".
You should see an error prompting you to use a different email provider.

#### Test 3:

Try singing up with a used email address (you can try with the email of your existing account).
You should see an error letting you know the email address is not available.

- [ ] Please check here if your pull request includes additional test coverage.
