### PR TITLE
Fixes the error handling in our email checking service.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.5.7"
+  s.version       = "4.5.7.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemote.h
+++ b/WordPressKit/AccountServiceRemote.h
@@ -3,6 +3,14 @@
 
 @class WPAccount;
 
+static NSString * const AccountServiceRemoteErrorDomain = @"AccountServiceErrorDomain";
+
+typedef NS_ERROR_ENUM(AccountServiceRemoteErrorDomain, AccountServiceRemoteError) {
+    AccountServiceRemoteCantReadServerResponse,
+    AccountServiceRemoteEmailAddressInvalid,
+    AccountServiceRemoteEmailAddressTaken,
+};
+
 @protocol AccountServiceRemote <NSObject>
 
 /**

--- a/WordPressKit/AccountServiceRemoteREST.h
+++ b/WordPressKit/AccountServiceRemoteREST.h
@@ -2,6 +2,14 @@
 #import "AccountServiceRemote.h"
 #import "ServiceRemoteWordPressComREST.h"
 
+static NSString * const AccountServiceRemoteErrorDomain = @"AccountServiceErrorDomain";
+
+typedef NS_ERROR_ENUM(AccountServiceRemoteErrorDomain, AccountServiceRemoteError) {
+    AccountServiceRemoteCantReadServerResponse,
+    AccountServiceRemoteEmailAddressInvalid,
+    AccountServiceRemoteEmailAddressTaken,
+};
+
 @interface AccountServiceRemoteREST : ServiceRemoteWordPressComREST <AccountServiceRemote>
 
 @end

--- a/WordPressKit/AccountServiceRemoteREST.h
+++ b/WordPressKit/AccountServiceRemoteREST.h
@@ -2,14 +2,6 @@
 #import "AccountServiceRemote.h"
 #import "ServiceRemoteWordPressComREST.h"
 
-static NSString * const AccountServiceRemoteErrorDomain = @"AccountServiceErrorDomain";
-
-typedef NS_ERROR_ENUM(AccountServiceRemoteErrorDomain, AccountServiceRemoteError) {
-    AccountServiceRemoteCantReadServerResponse,
-    AccountServiceRemoteEmailAddressInvalid,
-    AccountServiceRemoteEmailAddressTaken,
-};
-
 @interface AccountServiceRemoteREST : ServiceRemoteWordPressComREST <AccountServiceRemote>
 
 @end

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -133,10 +133,6 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
     [self.wordPressComRestApi GET:@"is-available/email"
                        parameters:@{ @"q": email, @"format": @"json"}
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-        if (!success) {
-            return;
-        }
-
         if ([responseObject isKindOfClass:[NSDictionary class]]) {
             NSString *error = [responseObject objectForKey:@"error"];
             NSString *message = [responseObject objectForKey:@"message"];
@@ -148,7 +144,9 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                                             @"response": responseObject,
                                                             NSLocalizedDescriptionKey: message,
                                                         }];
-                failure(error);
+                if failure {
+                    failure(error);
+                }
                 return;
             } else if ([error isEqualToString:errorEmailAddressTaken]) {
                 NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
@@ -157,18 +155,24 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                                             @"response": responseObject,
                                                             NSLocalizedDescriptionKey: message,
                                                         }];
-                failure(error);
+                if failure {
+                    failure(error);
+                }
                 return;
             }
             
-            BOOL available = [[responseObject numberForKey:@"available"] boolValue];
-            success(available);
+            if success {
+                BOOL available = [[responseObject numberForKey:@"available"] boolValue];
+                success(available);
+            }
         } else {
             NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
                                                         code:AccountServiceRemoteCantReadServerResponse
                                                     userInfo:@{@"response": responseObject}];
 
-            failure(error);
+            if failure {
+                failure(error);
+            }
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -127,31 +127,54 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
 
 - (void)isEmailAvailable:(NSString *)email success:(void (^)(BOOL available))success failure:(void (^)(NSError *error))failure
 {
+    static NSString * const errorEmailAddressInvalid = @"invalid";
+    static NSString * const errorEmailAddressTaken = @"taken";
+    
     [self.wordPressComRestApi GET:@"is-available/email"
-       parameters:@{ @"q": email, @"format": @"json"}
-          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-              if (!success) {
-                  return;
-              }
+                       parameters:@{ @"q": email, @"format": @"json"}
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+        if (!success) {
+            return;
+        }
 
-              // If the email address is not available (has already been used)
-              // the endpoint will reply with a 200 status code and an JSON
-              // object describing an error.
-              // The error is that the queried email address is not available,
-              // which is our failure case. Test the error response for the
-              // "taken" reason to confirm the email address exists.
-              BOOL available = NO;
-              if ([responseObject isKindOfClass:[NSDictionary class]]) {
-                  NSDictionary *dict = (NSDictionary *)responseObject;
-                  available = [[dict numberForKey:@"available"] boolValue];
-              }
-              success(available);
+        if ([responseObject isKindOfClass:[NSDictionary class]]) {
+            NSString *error = [responseObject objectForKey:@"error"];
+            NSString *message = [responseObject objectForKey:@"message"];
+            
+            if ([error isEqualToString:errorEmailAddressInvalid]) {
+                NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
+                                                            code:AccountServiceRemoteEmailAddressInvalid
+                                                        userInfo:@{
+                                                            @"response": responseObject,
+                                                            NSLocalizedDescriptionKey: message,
+                                                        }];
+                failure(error);
+                return;
+            } else if ([error isEqualToString:errorEmailAddressTaken]) {
+                NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
+                                                            code:AccountServiceRemoteEmailAddressTaken
+                                                        userInfo:@{
+                                                            @"response": responseObject,
+                                                            NSLocalizedDescriptionKey: message,
+                                                        }];
+                failure(error);
+                return;
+            }
+            
+            BOOL available = [[responseObject numberForKey:@"available"] boolValue];
+            success(available);
+        } else {
+            NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
+                                                        code:AccountServiceRemoteCantReadServerResponse
+                                                    userInfo:@{@"response": responseObject}];
 
-          } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
-              if (failure) {
-                  failure(error);
-              }
-          }];
+            failure(error);
+        }
+    } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+        if (failure) {
+            failure(error);
+        }
+    }];
 }
 
 - (void)isUsernameAvailable:(NSString *)username

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -144,7 +144,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                                             @"response": responseObject,
                                                             NSLocalizedDescriptionKey: message,
                                                         }];
-                if failure {
+                if (failure) {
                     failure(error);
                 }
                 return;
@@ -155,13 +155,13 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                                             @"response": responseObject,
                                                             NSLocalizedDescriptionKey: message,
                                                         }];
-                if failure {
+                if (failure) {
                     failure(error);
                 }
                 return;
             }
             
-            if success {
+            if (success) {
                 BOOL available = [[responseObject numberForKey:@"available"] boolValue];
                 success(available);
             }
@@ -170,7 +170,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                                         code:AccountServiceRemoteCantReadServerResponse
                                                     userInfo:@{@"response": responseObject}];
 
-            if failure {
+            if (failure) {
                 failure(error);
             }
         }

--- a/WordPressKitTests/AccountServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/AccountServiceRemoteRESTTests.swift
@@ -406,10 +406,9 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(emailEndpoint, filename: isEmailAvailableFailureMockFilename, contentType: .JavaScript)
         remote.isEmailAvailable(email, success: { isAvailable in
-            XCTAssertFalse(isAvailable)
-            expect.fulfill()
-        }, failure: { error in
             XCTFail("This callback shouldn't get called")
+        }, failure: { error in
+            expect.fulfill()
         })
 
         waitForExpectations(timeout: timeout, handler: nil)

--- a/WordPressKitTests/RemoteTestCase.swift
+++ b/WordPressKitTests/RemoteTestCase.swift
@@ -19,7 +19,7 @@ class RemoteTestCase: XCTestCase {
 
     // MARK: - Constants
 
-    let timeout = TimeInterval(1000)
+    let timeout = TimeInterval(5)
 
 
     // MARK: - Overridden Methods


### PR DESCRIPTION
### Description

Moves forward https://github.com/wordpress-mobile/WordPress-iOS/issues/13583

This PR improves the error handling in WPKit so that we don't ignore some error responses.

## Related branches and PRs:

WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/13585
WPAuth: `release/1.10.7.1`

Once this is merged I'll open the WPiOS PR.

### Testing Details

#### Test 1:

Try signing up with a valid email account.  It should send you the magic link.

#### Test 2:

Try signing up with an invalid email provider.  For example "tester@mailinator.com".
You should see an error prompting you to use a different email provider.

#### Test 3:

Try singing up with a used email address (you can try with the email of your existing account).
You should see an error letting you know the email address is not available.

- [ ] Please check here if your pull request includes additional test coverage.
