### PR TITLE
Update dependency NSObject-SafeExpectations to v 0.0.4

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ def wordpresskit_pods
   pod 'CocoaLumberjack', '3.4.2'
   pod 'WordPressShared', '~> 1.8.13-beta'
   # pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => 'efe5a065f3ace331353595ef85eef502baa23497'
-  pod 'NSObject-SafeExpectations', '~> 0.0.3'
+  pod 'NSObject-SafeExpectations', '~> 0.0.4'
   pod 'wpxmlrpc', '0.8.5-beta.1'
   #pod 'wpxmlrpc', :git => 'https://github.com/wordpress-mobile/wpxmlrpc.git', :branch => 'feature/update-xcode-settings'
   pod 'UIDeviceIdentifier', '~> 1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -9,7 +9,7 @@ PODS:
   - FormatterKit/Resources (1.8.2)
   - FormatterKit/TimeIntervalFormatter (1.8.2):
     - FormatterKit/Resources
-  - NSObject-SafeExpectations (0.0.3)
+  - NSObject-SafeExpectations (0.0.4)
   - OCMock (3.4.3)
   - OHHTTPStubs (6.1.0):
     - OHHTTPStubs/Default (= 6.1.0)
@@ -35,7 +35,7 @@ PODS:
 DEPENDENCIES:
   - Alamofire (~> 4.8.0)
   - CocoaLumberjack (= 3.4.2)
-  - NSObject-SafeExpectations (~> 0.0.3)
+  - NSObject-SafeExpectations (~> 0.0.4)
   - OCMock (~> 3.4.2)
   - OHHTTPStubs (= 6.1.0)
   - OHHTTPStubs/Swift (= 6.1.0)
@@ -59,13 +59,13 @@ SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
   CocoaLumberjack: db7cc9e464771f12054c22ff6947c5a58d43a0fd
   FormatterKit: 4b8f29acc9b872d5d12a63efb560661e8f2e1b98
-  NSObject-SafeExpectations: b989b68a8a9b7b9f2b264a8b52ba9d7aab8f3129
+  NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: 1e21c7d2c084b8153fc53d48400d8919d2d432d0
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPressShared: 98ebacf932b8f7b99a6ccb9f61b3fb1792f82d55
   wpxmlrpc: d758b6ad17723d31d06493acc932f6d9b340de95
 
-PODFILE CHECKSUM: 5ce92d370c62c207679b4db9f2eb470dfa1f6e78
+PODFILE CHECKSUM: fab42fa1edfada850c4e7c8cda4f3c8748eaa9ca
 
 COCOAPODS: 1.8.4

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.6.0-beta.3"
+  s.version       = "4.6.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
   s.dependency 'Alamofire', '~> 4.8.0'
   s.dependency 'CocoaLumberjack', '~> 3.4'
   s.dependency 'WordPressShared', '~> 1.8.13-beta'
-  s.dependency 'NSObject-SafeExpectations', '0.0.3'
+  s.dependency 'NSObject-SafeExpectations', '0.0.4'
   s.dependency 'wpxmlrpc', '0.8.5-beta.1'
   s.dependency 'UIDeviceIdentifier', '~> 1'
 end


### PR DESCRIPTION
### Description

Hack Week Project: migrate pods to Swift 5

- Update Podflie, update NSObject-SafeExpectations to version 0.0.4
- Update podspec, increase version number to 4.6.0-beta.4
- Update Podfile.lock with new dependencies


### Testing Details

- Run pod install and verify that pods are installed successfully

- [ ] Please check here if your pull request includes additional test coverage.
