### PR TITLE
Make AtomicAuthenticationServiceRemote public

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.6.0-beta.6"
+  s.version       = "4.6.0-beta.7"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AtomicAuthenticationServiceRemote.swift
+++ b/WordPressKit/AtomicAuthenticationServiceRemote.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
+public class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
     
-    enum ResponseError: Error {
+    public enum ResponseError: Error {
         case responseIsNotADictionary(response: AnyObject)
         case decodingFailure(response: [String: AnyObject])
         case couldNotInstantiateCookie(name: String, value: String, domain: String, path: String, expires: Date)
     }
     
-    func getAuthCookie(
+    public func getAuthCookie(
         siteID: Int,
         success: @escaping (_ cookie: HTTPCookie) -> Void,
         failure: @escaping (Error) -> Void) {


### PR DESCRIPTION
### Description

Makes `AtomicAuthenticationServiceRemote` public.  It was a mistake that it wasn't made so in the original PR here: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/227

### Testing Details

Nothing really changed and this service isn't wired yet, so there's no need to test it.

That said, feel free to install this pod in the WPiOS integration branch and build the App: `issue/13563-implement-AtomicAuthenticationService`.

- [ ] Please check here if your pull request includes additional test coverage.
