### PR TITLE
Fixes a SignUp regression.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.6.0-beta.7"
+  s.version       = "4.6.0-beta.8"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemote.h
+++ b/WordPressKit/AccountServiceRemote.h
@@ -8,7 +8,7 @@ static NSString * const AccountServiceRemoteErrorDomain = @"AccountServiceErrorD
 typedef NS_ERROR_ENUM(AccountServiceRemoteErrorDomain, AccountServiceRemoteError) {
     AccountServiceRemoteCantReadServerResponse,
     AccountServiceRemoteEmailAddressInvalid,
-    AccountServiceRemoteEmailAddressTaken,
+    AccountServiceRemoteEmailAddressCheckError,
 };
 
 @protocol AccountServiceRemote <NSObject>

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -137,27 +137,34 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
             NSString *error = [responseObject objectForKey:@"error"];
             NSString *message = [responseObject objectForKey:@"message"];
             
-            if ([error isEqualToString:errorEmailAddressInvalid]) {
-                NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
-                                                            code:AccountServiceRemoteEmailAddressInvalid
-                                                        userInfo:@{
-                                                            @"response": responseObject,
-                                                            NSLocalizedDescriptionKey: message,
-                                                        }];
-                if (failure) {
-                    failure(error);
+            if (error != NULL) {
+                if ([error isEqualToString:errorEmailAddressTaken]) {
+                    // While this is informed as an error by the endpoint, for the purpose of this method
+                    // it's a success case.  We just need to inform the caller that the email is not
+                    // available.
+                    success(false);
+                } else if ([error isEqualToString:errorEmailAddressInvalid]) {
+                    NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
+                                                                code:AccountServiceRemoteEmailAddressInvalid
+                                                            userInfo:@{
+                                                                @"response": responseObject,
+                                                                NSLocalizedDescriptionKey: message,
+                                                            }];
+                    if (failure) {
+                        failure(error);
+                    }
+                } else {
+                    NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
+                                                                code:AccountServiceRemoteEmailAddressCheckError
+                                                            userInfo:@{
+                                                                @"response": responseObject,
+                                                                NSLocalizedDescriptionKey: message,
+                                                            }];
+                    if (failure) {
+                        failure(error);
+                    }
                 }
-                return;
-            } else if ([error isEqualToString:errorEmailAddressTaken]) {
-                NSError* error = [[NSError alloc] initWithDomain:AccountServiceRemoteErrorDomain
-                                                            code:AccountServiceRemoteEmailAddressTaken
-                                                        userInfo:@{
-                                                            @"response": responseObject,
-                                                            NSLocalizedDescriptionKey: message,
-                                                        }];
-                if (failure) {
-                    failure(error);
-                }
+                
                 return;
             }
             

--- a/WordPressKitTests/AccountServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/AccountServiceRemoteRESTTests.swift
@@ -406,9 +406,11 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(emailEndpoint, filename: isEmailAvailableFailureMockFilename, contentType: .JavaScript)
         remote.isEmailAvailable(email, success: { isAvailable in
-            XCTFail("This callback shouldn't get called")
+            if !isAvailable {
+                expect.fulfill()
+            }
         }, failure: { error in
-            expect.fulfill()
+            XCTFail("This callback shouldn't get called")
         })
 
         waitForExpectations(timeout: timeout, handler: nil)


### PR DESCRIPTION
## Description

Fixes a signup regression.  Existing accounts should be redirected to login, instead of displaying an error.

## Associated branches:

WPiOS: `try/fix-signup-issue`
WPAuth: `try/fix-signup-issue`

## Testing Details

### Test 1:

1. Check out the WPiOS branch.
2. Install the pods.
3. Run the app from scratch.
4. Try to sign up with an existing account.

Verify that you're redirected to login and that you an complete the login process.

### Test 2:

Same test steps as in Test 1, but try to sign up with a mailinator account instead (any random account will do, like `testing@mailinator.com`).

Verify that there's an error message explaining this email provider is not supported by us.

### Test 3:

Same test steps as in Test 1 and 2, but try to sign up using a valid / supported email account instead.

Verify that signup works.

- [ ] Please check here if your pull request includes additional test coverage.
