### PR TITLE
Integrates the upcoming changes from D41085 into WPiOS.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.7.0"
+  s.version       = "4.7.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -43,6 +43,7 @@ NSString * const PostRESTKeyPosts = @"posts";
 NSString * const PostRESTKeyScore = @"score";
 NSString * const PostRESTKeySharingEnabled = @"sharing_enabled";
 NSString * const PostRESTKeySiteID = @"site_ID";
+NSString * const PostRESTKeySiteIsAtomic = @"site_is_atomic";
 NSString * const PostRESTKeySiteIsPrivate = @"site_is_private";
 NSString * const PostRESTKeySiteName = @"site_name";
 NSString * const PostRESTKeySiteURL = @"site_URL";
@@ -348,6 +349,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     post.feedID = [dict numberForKey:PostRESTKeyFeedID];
     post.feedItemID = [dict numberForKey:PostRESTKeyFeedItemID];
     post.globalID = [self stringOrEmptyString:[dict stringForKey:PostRESTKeyGlobalID]];
+    post.isBlogAtomic = [self siteIsAtomicFromPostDictionary:dict];
     post.isBlogPrivate = [self siteIsPrivateFromPostDictionary:dict];
     post.isFollowing = [[dict numberForKey:PostRESTKeyIsFollowing] boolValue];
     post.isLiked = [[dict numberForKey:PostRESTKeyILike] boolValue];
@@ -869,6 +871,13 @@ static const NSUInteger ReaderPostTitleLength = 30;
         summary = [self createSummaryFromContent:content];
     }
     return summary;
+}
+
+- (BOOL)siteIsAtomicFromPostDictionary:(NSDictionary *)dict
+{
+    NSNumber *isAtomic = [dict numberForKey:PostRESTKeySiteIsAtomic];
+
+    return [isAtomic boolValue];
 }
 
 /**

--- a/WordPressKit/RemoteReaderPost.h
+++ b/WordPressKit/RemoteReaderPost.h
@@ -20,6 +20,7 @@
 @property (nonatomic, strong) NSNumber *feedID;
 @property (nonatomic, strong) NSNumber *feedItemID;
 @property (nonatomic, strong) NSString *globalID;
+@property (nonatomic) BOOL isBlogAtomic;
 @property (nonatomic) BOOL isBlogPrivate;
 @property (nonatomic) BOOL isFollowing;
 @property (nonatomic) BOOL isLiked;

--- a/WordPressKitTests/ReaderPostServiceRemoteTests.m
+++ b/WordPressKitTests/ReaderPostServiceRemoteTests.m
@@ -9,6 +9,7 @@
 @interface ReaderPostServiceRemote ()
 
 - (RemoteReaderPost *)formatPostDictionary:(NSDictionary *)dict;
+- (BOOL)siteIsAtomicFromPostDictionary:(NSDictionary *)dict;
 - (BOOL)siteIsPrivateFromPostDictionary:(NSDictionary *)dict;
 - (NSString *)siteURLFromPostDictionary:(NSDictionary *)dict;
 - (NSString *)siteNameFromPostDictionary:(NSDictionary *)dict;
@@ -119,6 +120,25 @@
     NSDictionary *dict = @{@"excerpt": strWithHTML};
     NSString *sanatizedStr = [remoteService postSummaryFromPostDictionary:dict orPostContent:strWithHTML];
     XCTAssertTrue([str isEqualToString:sanatizedStr], @"The post summary was not plain text.");
+}
+
+- (void)testSiteIsAtomic {
+    NSString *key = @"site_is_atomic";
+    
+    ReaderPostServiceRemote *remoteService = nil;
+    XCTAssertNoThrow(remoteService = [self service]);
+
+    NSDictionary *dict = @{key: @"1"};
+    BOOL isAtomic = [remoteService siteIsAtomicFromPostDictionary:dict];
+    XCTAssertTrue(isAtomic, @"Site should be atomic.");
+
+    dict = @{key: @"0"};
+    isAtomic = [remoteService siteIsAtomicFromPostDictionary:dict];
+    XCTAssertFalse(isAtomic, @"Site should not be atomic.");
+    
+    dict = @{};
+    isAtomic = [remoteService siteIsAtomicFromPostDictionary:dict];
+    XCTAssertFalse(isAtomic, @"Site should not be atomic.");
 }
 
 - (void)testSiteIsPrivate {


### PR DESCRIPTION
### Description

This PR wires the upcoming `site_is_atomic` flag from the reader endpoint, so that we can access the value from within the Apps.

The reason this flag will be needed, is that the content of posts from Atomic Private sites needs specific authentication cookies to be visualized.  Knowing whether a post is coming from an atomic private site flags the need for such authentication.

### Related PRs and branches:

WPiOS branch integrating this: https://github.com/wordpress-mobile/WordPress-iOS/pull/13831

### Testing Details

I added unit tests to validate the logic.

You can sandbox your environment and apply D41085, then test the reader endpoint to validate:

1. The flag is present and set to `true` for atomic-private sites.
2. The flag is present and set to `false` for private-but-non-atomic.
3. The flag is absent for public sites.

- [x] Please check here if your pull request includes additional test coverage.
