### PR TITLE
Gravatar download: handle successful response for unknown user

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.7.1-beta.1"
+  s.version       = "4.8.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/GravatarServiceRemote.swift
+++ b/WordPressKit/GravatarServiceRemote.swift
@@ -35,15 +35,24 @@ open class GravatarServiceRemote {
             }
             do {
                 let jsonData = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-                if let jsonDictionary = jsonData as? [String: Array<Any>],
+                
+                guard let jsonDictionary = jsonData as? [String: Array<Any>],
                     let entry = jsonDictionary["entry"],
-                    let profileData = entry.first as? NSDictionary {
-                    let profile = RemoteGravatarProfile(dictionary: profileData)
-                    DispatchQueue.main.async {
-                        success(profile)
-                    }
-                    return
+                    let profileData = entry.first as? NSDictionary else {
+                        DispatchQueue.main.async {
+                            // This case typically happens when the endpoint does
+                            // successfully return but doesn't find the user.
+                            failure(nil)
+                        }
+                        return
                 }
+                
+                let profile = RemoteGravatarProfile(dictionary: profileData)
+                DispatchQueue.main.async {
+                    success(profile)
+                }
+                return
+
             } catch {
                 failure (error)
                 return


### PR DESCRIPTION
### Description

Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/11771

This handles the case where Gravatar would return a successful response, but there was no user matching the email address. 

Previously, this case was not handled and thus the caller received no response. Now the `failure`callback is called.

### Testing Details
Can be tested with WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/13917

- [ ] Please check here if your pull request includes additional test coverage.
