### PR TITLE
Add Plan fields for Zendesk integration

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "5.0.0-beta.1"
+  s.version       = "5.0.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PlanServiceRemote.swift
+++ b/WordPressKit/PlanServiceRemote.swift
@@ -159,7 +159,10 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
             let tagline = item["tagline"] as? String,
             let description = item["description"] as? String,
             let features = (item["features"] as? [String])?.joined(separator: ","),
-            let icon = item["icon"] as? String else {
+            let icon = item["icon"] as? String,
+            let supportPriority = item["support_priority"] as? Int,
+            let supportName = item["support_name"] as? String,
+            let nonLocalizedShortname = item["nonlocalized_short_name"] as? String else {
                 return nil
         }
 
@@ -172,7 +175,10 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
                                      tagline: tagline,
                                      description: description,
                                      features: features,
-                                     icon: icon)
+                                     icon: icon,
+                                     supportPriority: supportPriority,
+                                     supportName: supportName,
+                                     nonLocalizedShortname: nonLocalizedShortname)
     }
 
 

--- a/WordPressKit/RemoteWpcomPlan.swift
+++ b/WordPressKit/RemoteWpcomPlan.swift
@@ -17,6 +17,12 @@ public struct RemoteWpcomPlan {
     public let features: String
     // An icon representing the plan.
     public let icon: String
+    // The plan priority in Zendesk
+    public let supportPriority: Int
+    // The name of the plan in Zendesk
+    public let supportName: String
+    // Non localized version of the shortened name
+    public let nonLocalizedShortname: String
 }
 
 public struct RemotePlanGroup {

--- a/WordPressKitTests/Mock Data/plans-mobile-success.json
+++ b/WordPressKitTests/Mock Data/plans-mobile-success.json
@@ -21,6 +21,9 @@
             ],
             "name": "WordPress.com Free",
             "short_name": "Free",
+            "support_priority": 1,
+            "support_name": "free",
+            "nonlocalized_short_name": "Free",
             "tagline": "Best for Getting Started",
             "description": "If you just want to start creating, get a free site and be on your way to publishing in less than five minutes.",
             "features": [
@@ -48,6 +51,9 @@
             ],
             "name": "WordPress.com Blogger",
             "short_name": "Blogger",
+            "support_priority": 2,
+            "support_name": "blogger",
+            "nonlocalized_short_name": "Blogger",
             "tagline": "",
             "description": "",
             "features": [
@@ -75,6 +81,10 @@
             ],
             "name": "WordPress.com Personal",
             "short_name": "Personal",
+            "support_priority": 3,
+            "support_name": "personal",
+            "nonlocalized_short_name": "Personal",
+
             "tagline": "Best for Personal Use",
             "description": "Boost your website with a custom domain name, and remove all WordPress.com advertising. Get access to high quality email and live chat support.",
             "features": [
@@ -103,6 +113,9 @@
             ],
             "name": "WordPress.com Premium",
             "short_name": "Premium",
+            "support_priority": 4,
+            "support_name": "premium",
+            "nonlocalized_short_name": "Premium",
             "tagline": "Best for Entrepreneurs and Freelancers",
             "description": "Build a unique website with advanced design tools, CSS editing, lots of space for audio and video, and the ability to monetize your site with ads.",
             "features": [
@@ -133,6 +146,9 @@
             ],
             "name": "WordPress.com Business",
             "short_name": "Business",
+            "support_priority": 5,
+            "support_name": "business_professional",
+            "nonlocalized_short_name": "Business",
             "tagline": "Best for Small Business.",
             "description": "Power your business website with unlimited premium and business theme templates, Google Analytics support, unlimited storage, and the ability to remove WordPress.com branding.",
             "features": [
@@ -170,6 +186,9 @@
             ],
             "name": "WordPress.com E-commerce",
             "short_name": "E-commerce",
+            "support_priority": 6,
+            "support_name": "ecommerce",
+            "nonlocalized_short_name": "E-commerce",
             "tagline": "Best for Online Stores",
             "description": "Sell products or services with this powerful, all-in-one online store experience. This plan includes premium integrations and is extendable, so it’ll grow with you as your business grows.",
             "features": [

--- a/WordPressKitTests/PlanServiceRemoteTests.swift
+++ b/WordPressKitTests/PlanServiceRemoteTests.swift
@@ -159,6 +159,9 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
             ],
             "name": "WordPress.com Premium",
             "short_name": "Premium",
+            "support_priority": 4,
+            "support_name": "premium",
+            "nonlocalized_short_name": "Premium",
             "tagline": "Best for Entrepreneurs and Freelancers",
             "description": "Build a unique website with advanced design tools, CSS editing, lots of space for audio and video, and the ability to monetize your site with ads.",
             "features": [


### PR DESCRIPTION
Adds fields to the Plan entity to correctly set the highest priority plan in Zendesk

Can be tested in this WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14298

Related issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/14224

### Testing Details

