### PR TITLE
Add Reader Card service

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.11.0"
+  s.version       = "4.12.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -314,6 +314,7 @@
 		8B2F4BED24ABCAEF0056C08A /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */; };
 		8B2F4BEF24ACCC120056C08A /* RemoteReaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */; };
 		8B2F4BF124ACE3C30056C08A /* RemoteReaderInterest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BF024ACE3C30056C08A /* RemoteReaderInterest.swift */; };
+		8BE67ED324AD05D3004DB4C9 /* Decodable+DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */; };
 		9309994D1F1657C600F006A1 /* ThemeServiceRemote.h in Headers */ = {isa = PBXBuildFile; fileRef = 9309994B1F1657C600F006A1 /* ThemeServiceRemote.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9309994E1F1657C600F006A1 /* ThemeServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309994C1F1657C600F006A1 /* ThemeServiceRemote.m */; };
 		930999521F1658F800F006A1 /* ThemeServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 930999511F1658F800F006A1 /* ThemeServiceRemoteTests.m */; };
@@ -809,6 +810,7 @@
 		8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Dictionary.swift"; sourceTree = "<group>"; };
 		8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReaderCard.swift; sourceTree = "<group>"; };
 		8B2F4BF024ACE3C30056C08A /* RemoteReaderInterest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReaderInterest.swift; sourceTree = "<group>"; };
+		8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+DictionaryTests.swift"; sourceTree = "<group>"; };
 		9309994B1F1657C600F006A1 /* ThemeServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThemeServiceRemote.h; sourceTree = "<group>"; };
 		9309994C1F1657C600F006A1 /* ThemeServiceRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemote.m; sourceTree = "<group>"; };
 		930999511F1658F800F006A1 /* ThemeServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemoteTests.m; sourceTree = "<group>"; };
@@ -1220,6 +1222,14 @@
 			name = Activity;
 			sourceTree = "<group>";
 		};
+		8BE67ED124AD05B5004DB4C9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		9309994F1F1658DB00F006A1 /* Theme */ = {
 			isa = PBXGroup;
 			children = (
@@ -1258,6 +1268,7 @@
 				74B5F0DF1EF82AAB00B411E7 /* Blog */,
 				74585B911F0D520700E7E667 /* Domains */,
 				7EC60EBC22DC4F5A00FB0336 /* Editor */,
+				8BE67ED124AD05B5004DB4C9 /* Extensions */,
 				9A2D0B29225E0DF7009E585F /* Jetpack */,
 				74FA25F81F1FDA240044BC54 /* Media */,
 				74D97CB91F1CF6E200AC49B7 /* Menu */,
@@ -2499,6 +2510,7 @@
 				7430C9BC1F192C0F0051B8E6 /* ReaderSiteServiceRemoteTests.swift in Sources */,
 				73D5930321E552CD00E4CF84 /* SiteVerticalsRequestEncodingTests.swift in Sources */,
 				930999521F1658F800F006A1 /* ThemeServiceRemoteTests.m in Sources */,
+				8BE67ED324AD05D3004DB4C9 /* Decodable+DictionaryTests.swift in Sources */,
 				74B335DA1F06F3D60053A184 /* WordPressComRestApiTests.swift in Sources */,
 				7403A2E61EF06F7000DED7DC /* AccountSettingsRemoteTests.swift in Sources */,
 				73D5930521E5541200E4CF84 /* WordPressComServiceRemoteTests+SiteVerticals.swift in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 		8B2F4BEB24ABCA700056C08A /* reader-cards-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEA24ABCA6F0056C08A /* reader-cards-success.json */; };
 		8B2F4BED24ABCAEF0056C08A /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */; };
 		8B2F4BEF24ACCC120056C08A /* RemoteReaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */; };
+		8B2F4BF124ACE3C30056C08A /* RemoteReaderInterest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BF024ACE3C30056C08A /* RemoteReaderInterest.swift */; };
 		9309994D1F1657C600F006A1 /* ThemeServiceRemote.h in Headers */ = {isa = PBXBuildFile; fileRef = 9309994B1F1657C600F006A1 /* ThemeServiceRemote.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9309994E1F1657C600F006A1 /* ThemeServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309994C1F1657C600F006A1 /* ThemeServiceRemote.m */; };
 		930999521F1658F800F006A1 /* ThemeServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 930999511F1658F800F006A1 /* ThemeServiceRemoteTests.m */; };
@@ -807,6 +808,7 @@
 		8B2F4BEA24ABCA6F0056C08A /* reader-cards-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-cards-success.json"; sourceTree = "<group>"; };
 		8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Dictionary.swift"; sourceTree = "<group>"; };
 		8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReaderCard.swift; sourceTree = "<group>"; };
+		8B2F4BF024ACE3C30056C08A /* RemoteReaderInterest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReaderInterest.swift; sourceTree = "<group>"; };
 		9309994B1F1657C600F006A1 /* ThemeServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThemeServiceRemote.h; sourceTree = "<group>"; };
 		9309994C1F1657C600F006A1 /* ThemeServiceRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemote.m; sourceTree = "<group>"; };
 		930999511F1658F800F006A1 /* ThemeServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemoteTests.m; sourceTree = "<group>"; };
@@ -1488,6 +1490,7 @@
 				7430C9D61F1933200051B8E6 /* RemoteReaderCrossPostMeta.swift */,
 				7430C9A91F1927C50051B8E6 /* RemoteReaderPost.h */,
 				8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */,
+				8B2F4BF024ACE3C30056C08A /* RemoteReaderInterest.swift */,
 				7430C9AA1F1927C50051B8E6 /* RemoteReaderPost.m */,
 				7430C9AB1F1927C50051B8E6 /* RemoteReaderSite.h */,
 				7430C9AC1F1927C50051B8E6 /* RemoteReaderSite.m */,
@@ -2384,6 +2387,7 @@
 				74D67F061F1528470010C5ED /* PeopleServiceRemote.swift in Sources */,
 				98DC787522BAEBF200267279 /* StatsAllAnnualInsight.swift in Sources */,
 				740B23C31F17EE8000067A2A /* RemotePostCategory.m in Sources */,
+				8B2F4BF124ACE3C30056C08A /* RemoteReaderInterest.swift in Sources */,
 				74B5F0E71EF8699C00B411E7 /* RemotePostType.m in Sources */,
 				93188D1F1F2262BF0028ED4D /* RemotePostTag.m in Sources */,
 				74D67F081F15BEB70010C5ED /* RemotePerson.swift in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -312,6 +312,7 @@
 		8B2F4BE924ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BE824ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift */; };
 		8B2F4BEB24ABCA700056C08A /* reader-cards-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEA24ABCA6F0056C08A /* reader-cards-success.json */; };
 		8B2F4BED24ABCAEF0056C08A /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */; };
+		8B2F4BEF24ACCC120056C08A /* RemoteReaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */; };
 		9309994D1F1657C600F006A1 /* ThemeServiceRemote.h in Headers */ = {isa = PBXBuildFile; fileRef = 9309994B1F1657C600F006A1 /* ThemeServiceRemote.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9309994E1F1657C600F006A1 /* ThemeServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309994C1F1657C600F006A1 /* ThemeServiceRemote.m */; };
 		930999521F1658F800F006A1 /* ThemeServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 930999511F1658F800F006A1 /* ThemeServiceRemoteTests.m */; };
@@ -805,6 +806,7 @@
 		8B2F4BE824ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostServiceRemote+CardsTests.swift"; sourceTree = "<group>"; };
 		8B2F4BEA24ABCA6F0056C08A /* reader-cards-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-cards-success.json"; sourceTree = "<group>"; };
 		8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Dictionary.swift"; sourceTree = "<group>"; };
+		8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReaderCard.swift; sourceTree = "<group>"; };
 		9309994B1F1657C600F006A1 /* ThemeServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThemeServiceRemote.h; sourceTree = "<group>"; };
 		9309994C1F1657C600F006A1 /* ThemeServiceRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemote.m; sourceTree = "<group>"; };
 		930999511F1658F800F006A1 /* ThemeServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemoteTests.m; sourceTree = "<group>"; };
@@ -1485,6 +1487,7 @@
 				74E2294D1F1E73FE0085F7F2 /* RemotePublicizeService.swift */,
 				7430C9D61F1933200051B8E6 /* RemoteReaderCrossPostMeta.swift */,
 				7430C9A91F1927C50051B8E6 /* RemoteReaderPost.h */,
+				8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */,
 				7430C9AA1F1927C50051B8E6 /* RemoteReaderPost.m */,
 				7430C9AB1F1927C50051B8E6 /* RemoteReaderSite.h */,
 				7430C9AC1F1927C50051B8E6 /* RemoteReaderSite.m */,
@@ -2367,6 +2370,7 @@
 				826016F31F9FA17B00533B6C /* Activity.swift in Sources */,
 				40819783221F5C8200A298E4 /* StatsPostDetails.swift in Sources */,
 				7397F01A220A072500C723F3 /* ActivityServiceRemote_ApiVersion1_0.swift in Sources */,
+				8B2F4BEF24ACCC120056C08A /* RemoteReaderCard.swift in Sources */,
 				40E7FEB1220FB3B60032834E /* StatsAnnualAndMostPopularTimeInsight.swift in Sources */,
 				7E3E7A4A20E443890075D159 /* Scanner+extensions.swift in Sources */,
 				742362E31F1025B400BD0A7F /* RemoteMenuLocation.m in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -308,6 +308,10 @@
 		82FFBF521F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */; };
 		82FFBF561F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF551F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift */; };
 		8B2F4BE524ABB3C70056C08A /* RemoteReaderPostTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BE424ABB3C70056C08A /* RemoteReaderPostTests.m */; };
+		8B2F4BE724ABC8A90056C08A /* ReaderPostServiceRemote+Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BE624ABC8A90056C08A /* ReaderPostServiceRemote+Cards.swift */; };
+		8B2F4BE924ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BE824ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift */; };
+		8B2F4BEB24ABCA700056C08A /* reader-cards-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEA24ABCA6F0056C08A /* reader-cards-success.json */; };
+		8B2F4BED24ABCAEF0056C08A /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */; };
 		9309994D1F1657C600F006A1 /* ThemeServiceRemote.h in Headers */ = {isa = PBXBuildFile; fileRef = 9309994B1F1657C600F006A1 /* ThemeServiceRemote.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9309994E1F1657C600F006A1 /* ThemeServiceRemote.m in Sources */ = {isa = PBXBuildFile; fileRef = 9309994C1F1657C600F006A1 /* ThemeServiceRemote.m */; };
 		930999521F1658F800F006A1 /* ThemeServiceRemoteTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 930999511F1658F800F006A1 /* ThemeServiceRemoteTests.m */; };
@@ -797,6 +801,10 @@
 		82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteBlogJetpackMonitorSettings.swift; sourceTree = "<group>"; };
 		82FFBF551F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlogJetpackSettingsServiceRemote.swift; sourceTree = "<group>"; };
 		8B2F4BE424ABB3C70056C08A /* RemoteReaderPostTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = RemoteReaderPostTests.m; sourceTree = "<group>"; };
+		8B2F4BE624ABC8A90056C08A /* ReaderPostServiceRemote+Cards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostServiceRemote+Cards.swift"; sourceTree = "<group>"; };
+		8B2F4BE824ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostServiceRemote+CardsTests.swift"; sourceTree = "<group>"; };
+		8B2F4BEA24ABCA6F0056C08A /* reader-cards-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-cards-success.json"; sourceTree = "<group>"; };
+		8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Dictionary.swift"; sourceTree = "<group>"; };
 		9309994B1F1657C600F006A1 /* ThemeServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThemeServiceRemote.h; sourceTree = "<group>"; };
 		9309994C1F1657C600F006A1 /* ThemeServiceRemote.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemote.m; sourceTree = "<group>"; };
 		930999511F1658F800F006A1 /* ThemeServiceRemoteTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeServiceRemoteTests.m; sourceTree = "<group>"; };
@@ -1092,6 +1100,7 @@
 				7430C9BB1F192C0F0051B8E6 /* ReaderTopicServiceRemoteTests.m */,
 				17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */,
 				8B2F4BE424ABB3C70056C08A /* RemoteReaderPostTests.m */,
+				8B2F4BE824ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift */,
 			);
 			name = Reader;
 			sourceTree = "<group>";
@@ -1186,6 +1195,7 @@
 				7E3E7A4720E443370075D159 /* NSMutableAttributedString+extensions.swift */,
 				7E3E7A4920E443890075D159 /* Scanner+extensions.swift */,
 				7E3E7A4B20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift */,
+				8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -1381,6 +1391,7 @@
 				74A44DCA1F13C533006CD8F4 /* PushAuthenticationServiceRemote.swift */,
 				7430C99D1F1927180051B8E6 /* ReaderPostServiceRemote.h */,
 				7430C99E1F1927180051B8E6 /* ReaderPostServiceRemote.m */,
+				8B2F4BE624ABC8A90056C08A /* ReaderPostServiceRemote+Cards.swift */,
 				7430C99F1F1927180051B8E6 /* ReaderSiteServiceRemote.h */,
 				7430C9A01F1927180051B8E6 /* ReaderSiteServiceRemote.m */,
 				7430C9A11F1927180051B8E6 /* ReaderTopicServiceRemote.h */,
@@ -1627,6 +1638,7 @@
 				17BF9A7120C7E18200BF57D2 /* reader-site-search-success-no-data.json */,
 				17BF9A7020C7E18200BF57D2 /* reader-site-search-success-no-icon.json */,
 				17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */,
+				8B2F4BEA24ABCA6F0056C08A /* reader-cards-success.json */,
 				74A44DD71F13C7AC006CD8F4 /* remote-notification.json */,
 				74B040711EF8B366002C6258 /* rest-site-settings.json */,
 				74C473CA1EF33696009918F2 /* site-active-purchases-auth-failure.json */,
@@ -2040,6 +2052,7 @@
 				404057D4221C5FC40060250C /* stats-countries-data.json in Resources */,
 				74D67F1F1F15C3240010C5ED /* people-send-invitation-success.json in Resources */,
 				FFE247B020C891E6002DF3A2 /* WordPressComAuthenticateWithIDToken2FANeededSuccess.json in Resources */,
+				8B2F4BEB24ABCA700056C08A /* reader-cards-success.json in Resources */,
 				436D563E2118E34D00CEAA33 /* supported-states-success.json in Resources */,
 				D813437821F6D7DC0060D99A /* site-segments-single.json in Resources */,
 				93BD27561EE73442002BB00B /* auth-send-login-email-invalid-secret-failure.json in Resources */,
@@ -2276,6 +2289,7 @@
 				74585B8E1F0D51A100E7E667 /* DomainsServiceRemote.swift in Sources */,
 				7430C9A41F1927180051B8E6 /* ReaderPostServiceRemote.m in Sources */,
 				408197882220A35000A298E4 /* StatsLastPostInsight.swift in Sources */,
+				8B2F4BE724ABC8A90056C08A /* ReaderPostServiceRemote+Cards.swift in Sources */,
 				74E2294E1F1E73FE0085F7F2 /* RemotePublicizeService.swift in Sources */,
 				9F3E0BA22087345F009CB5BA /* ServiceRequest.swift in Sources */,
 				E1A6605F1FD694ED00BAC339 /* PluginDirectoryEntry.swift in Sources */,
@@ -2320,6 +2334,7 @@
 				9311A68B1F22625A00704AC9 /* TaxonomyServiceRemoteXMLRPC.m in Sources */,
 				40414060220F9F1F00CF7C5B /* StatsAllTimesInsight.swift in Sources */,
 				93BD277E1EE73944002BB00B /* NSDate+WordPressJSON.m in Sources */,
+				8B2F4BED24ABCAEF0056C08A /* Decodable+Dictionary.swift in Sources */,
 				7E3E7A4820E443370075D159 /* NSMutableAttributedString+extensions.swift in Sources */,
 				E194CB731FBDEF6500B0A8B8 /* PluginState.swift in Sources */,
 				404057D6221C92660060250C /* StatsTopClicksTimeIntervalData.swift in Sources */,
@@ -2447,6 +2462,7 @@
 				74585B901F0D51F900E7E667 /* DomainsServiceRemoteRESTTests.swift in Sources */,
 				9AB6D64A218727D60008F274 /* PostServiceRemoteRESTRevisionsTest.swift in Sources */,
 				7430C9BD1F192C0F0051B8E6 /* ReaderPostServiceRemoteTests.m in Sources */,
+				8B2F4BE924ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift in Sources */,
 				40F9880C221ACEEE00B7B369 /* StatsRemoteV2Tests.swift in Sources */,
 				826017001F9FD60A00533B6C /* ActivityServiceRemoteTests.swift in Sources */,
 				93F50A3A1F226BB600B5BEBA /* WordPressComServiceRemoteRestTests.swift in Sources */,

--- a/WordPressKit/Decodable+Dictionary.swift
+++ b/WordPressKit/Decodable+Dictionary.swift
@@ -15,6 +15,7 @@ struct JSONCodingKeys: CodingKey {
 
 
 /// Add support do decode to a Dictionary
+/// From: https://stackoverflow.com/q/44603248
 extension KeyedDecodingContainer {
 
     func decode(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> Dictionary<String, Any> {

--- a/WordPressKit/Decodable+Dictionary.swift
+++ b/WordPressKit/Decodable+Dictionary.swift
@@ -1,0 +1,100 @@
+struct JSONCodingKeys: CodingKey {
+    var stringValue: String
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    var intValue: Int?
+
+    init?(intValue: Int) {
+        self.init(stringValue: "\(intValue)")
+        self.intValue = intValue
+    }
+}
+
+
+/// Add support do decode to a Dictionary
+extension KeyedDecodingContainer {
+
+    func decode(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> Dictionary<String, Any> {
+        let container = try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
+        return try container.decode(type)
+    }
+
+    func decodeIfPresent(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> Dictionary<String, Any>? {
+        guard contains(key) else {
+            return nil
+        }
+        guard try decodeNil(forKey: key) == false else {
+            return nil
+        }
+        return try decode(type, forKey: key)
+    }
+
+    func decode(_ type: Array<Any>.Type, forKey key: K) throws -> Array<Any> {
+        var container = try self.nestedUnkeyedContainer(forKey: key)
+        return try container.decode(type)
+    }
+
+    func decodeIfPresent(_ type: Array<Any>.Type, forKey key: K) throws -> Array<Any>? {
+        guard contains(key) else {
+            return nil
+        }
+        guard try decodeNil(forKey: key) == false else {
+            return nil
+        }
+        return try decode(type, forKey: key)
+    }
+
+    func decode(_ type: Dictionary<String, Any>.Type) throws -> Dictionary<String, Any> {
+        var dictionary = Dictionary<String, Any>()
+
+        for key in allKeys {
+            if let boolValue = try? decode(Bool.self, forKey: key) {
+                dictionary[key.stringValue] = boolValue
+            } else if let stringValue = try? decode(String.self, forKey: key) {
+                dictionary[key.stringValue] = stringValue
+            } else if let intValue = try? decode(Int.self, forKey: key) {
+                dictionary[key.stringValue] = intValue
+            } else if let doubleValue = try? decode(Double.self, forKey: key) {
+                dictionary[key.stringValue] = doubleValue
+            } else if let nestedDictionary = try? decode(Dictionary<String, Any>.self, forKey: key) {
+                dictionary[key.stringValue] = nestedDictionary
+            } else if let nestedArray = try? decode(Array<Any>.self, forKey: key) {
+                dictionary[key.stringValue] = nestedArray
+            }
+        }
+        return dictionary
+    }
+}
+
+extension UnkeyedDecodingContainer {
+
+    mutating func decode(_ type: Array<Any>.Type) throws -> Array<Any> {
+        var array: [Any] = []
+        while isAtEnd == false {
+            // See if the current value in the JSON array is `null` first and prevent infite recursion with nested arrays.
+            if try decodeNil() {
+                continue
+            } else if let value = try? decode(Bool.self) {
+                array.append(value)
+            } else if let value = try? decode(Double.self) {
+                array.append(value)
+            } else if let value = try? decode(String.self) {
+                array.append(value)
+            } else if let nestedDictionary = try? decode(Dictionary<String, Any>.self) {
+                array.append(nestedDictionary)
+            } else if let nestedArray = try? decode(Array<Any>.self) {
+                array.append(nestedArray)
+            }
+        }
+        return array
+    }
+
+    mutating func decode(_ type: Dictionary<String, Any>.Type) throws -> Dictionary<String, Any> {
+
+        let nestedContainer = try self.nestedContainer(keyedBy: JSONCodingKeys.self)
+        return try nestedContainer.decode(type)
+    }
+}

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -1,6 +1,7 @@
 extension ReaderPostServiceRemote {
     func fetchCards(for interests: [String],
-                    success: @escaping ([RemoteReaderCard]) -> Void) {
+                    success: @escaping ([RemoteReaderCard]) -> Void,
+                    failure: @escaping (Error) -> Void) {
         guard let requestUrl = cardsEndpoint(for: interests) else {
             return
         }
@@ -17,10 +18,11 @@ extension ReaderPostServiceRemote {
                                         success(envelope.cards)
                                     } catch {
                                         DDLogError("\(error)")
-                                        DDLogDebug("Full response: \(response)")
+                                        failure(error)
                                     }
         }, failure: { error, _ in
             DDLogError("\(error)")
+            failure(error)
         })
     }
 

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -8,7 +8,7 @@ extension ReaderPostServiceRemote {
     /// - Parameter interests: an array of String representing the interests
     /// - Parameter success: Called when the request succeeds and the data returned is valid
     /// - Parameter failure: Called if the request fails for any reason, or the response data is invalid
-    func fetchCards(for interests: [String],
+    public func fetchCards(for interests: [String],
                     success: @escaping ([RemoteReaderCard]) -> Void,
                     failure: @escaping (Error) -> Void) {
         guard let requestUrl = cardsEndpoint(for: interests) else {

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -1,7 +1,9 @@
 extension ReaderPostServiceRemote {
-    func fetchCards(success: @escaping ([RemoteReaderCard]) -> Void) {
-        let path = "read/cards"
-        let requestUrl = self.path(forEndpoint: path, withVersion: ._1_2)
+    func fetchCards(for interests: [String],
+                    success: @escaping ([RemoteReaderCard]) -> Void) {
+        guard let requestUrl = cardsEndpoint(for: interests) else {
+            return
+        }
 
         wordPressComRestApi.GET(requestUrl,
                                 parameters: nil,
@@ -20,5 +22,11 @@ extension ReaderPostServiceRemote {
         }, failure: { error, _ in
             DDLogError("\(error)")
         })
+    }
+
+    private func cardsEndpoint(for interests: [String]) -> String? {
+        var path = URLComponents(string: "read/tags/cards")
+        path?.queryItems = interests.map { URLQueryItem(name: "tags[]", value: $0) }
+        return self.path(forEndpoint: path!.string!, withVersion: ._1_2)
     }
 }

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -1,0 +1,57 @@
+struct ReaderCardEnvelope: Decodable {
+    var cards: [ReaderRemoteCard]
+}
+
+struct ReaderRemoteCard: Decodable {
+    enum CardType: String {
+        case post
+        case unknown
+    }
+
+    var type: CardType
+    var post: RemoteReaderPost?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case data
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let typeString = try container.decode(String.self, forKey: .type)
+        type = CardType(rawValue: typeString) ?? .unknown
+
+        switch type {
+        case .post:
+            let postDictionary = try container.decode([String: Any].self, forKey: .data)
+            post = RemoteReaderPost(dictionary: postDictionary)
+        default:
+            post = nil
+        }
+    }
+}
+
+extension ReaderPostServiceRemote {
+    func fetchCards(success: @escaping ([ReaderRemoteCard]) -> Void) {
+        let path = "read/cards"
+        let requestUrl = self.path(forEndpoint: path, withVersion: ._1_2)
+
+        wordPressComRestApi.GET(requestUrl,
+                                parameters: nil,
+                                success: { (response, _) in
+
+                                    do {
+                                        let decoder = JSONDecoder()
+                                        let data = try JSONSerialization.data(withJSONObject: response, options: [])
+                                        let envelope = try decoder.decode(ReaderCardEnvelope.self, from: data)
+
+                                        success(envelope.cards)
+                                    } catch {
+                                        DDLogError("\(error)")
+                                        DDLogDebug("Full response: \(response)")
+                                    }
+        }, failure: { error, _ in
+            DDLogError("\(error)")
+        })
+    }
+}

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -30,7 +30,8 @@ extension ReaderPostServiceRemote {
                                         failure(error)
                                     }
         }, failure: { error, _ in
-            DDLogError("\(error)")
+            DDLogError("Error fetching reader cards: \(error)")
+            
             failure(error)
         })
     }

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -1,38 +1,5 @@
-struct ReaderCardEnvelope: Decodable {
-    var cards: [ReaderRemoteCard]
-}
-
-struct ReaderRemoteCard: Decodable {
-    enum CardType: String {
-        case post
-        case unknown
-    }
-
-    var type: CardType
-    var post: RemoteReaderPost?
-
-    private enum CodingKeys: String, CodingKey {
-        case type
-        case data
-    }
-
-    init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let typeString = try container.decode(String.self, forKey: .type)
-        type = CardType(rawValue: typeString) ?? .unknown
-
-        switch type {
-        case .post:
-            let postDictionary = try container.decode([String: Any].self, forKey: .data)
-            post = RemoteReaderPost(dictionary: postDictionary)
-        default:
-            post = nil
-        }
-    }
-}
-
 extension ReaderPostServiceRemote {
-    func fetchCards(success: @escaping ([ReaderRemoteCard]) -> Void) {
+    func fetchCards(success: @escaping ([RemoteReaderCard]) -> Void) {
         let path = "read/cards"
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_2)
 

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -1,4 +1,13 @@
 extension ReaderPostServiceRemote {
+    /// Returns a collection of RemoteReaderCard
+    /// a Reader Card can represent an item for the reader feed, such as
+    /// - Reader Post
+    /// - Interests you may like
+    /// - Blogs you may like and so on
+    ///
+    /// - Parameter interests: an array of String representing the interests
+    /// - Parameter success: Called when the request succeeds and the data returned is valid
+    /// - Parameter failure: Called if the request fails for any reason, or the response data is invalid
     func fetchCards(for interests: [String],
                     success: @escaping ([RemoteReaderCard]) -> Void,
                     failure: @escaping (Error) -> Void) {
@@ -8,7 +17,7 @@ extension ReaderPostServiceRemote {
 
         wordPressComRestApi.GET(requestUrl,
                                 parameters: nil,
-                                success: { (response, _) in
+                                success: { response, _ in
 
                                     do {
                                         let decoder = JSONDecoder()

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -26,7 +26,7 @@ extension ReaderPostServiceRemote {
 
                                         success(envelope.cards)
                                     } catch {
-                                        DDLogError("\(error)")
+                                        DDLogError("Error parsing the reader cards response: \(error)")
                                         failure(error)
                                     }
         }, failure: { error, _ in

--- a/WordPressKit/RemoteReaderCard.swift
+++ b/WordPressKit/RemoteReaderCard.swift
@@ -4,7 +4,7 @@ struct ReaderCardEnvelope: Decodable {
     var cards: [RemoteReaderCard]
 }
 
-struct RemoteReaderCard: Decodable {
+public struct RemoteReaderCard: Decodable {
     enum CardType: String {
         case post
         case interests = "interests_you_may_like"
@@ -20,7 +20,7 @@ struct RemoteReaderCard: Decodable {
         case data
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let typeString = try container.decode(String.self, forKey: .type)
         type = CardType(rawValue: typeString) ?? .unknown

--- a/WordPressKit/RemoteReaderCard.swift
+++ b/WordPressKit/RemoteReaderCard.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct ReaderCardEnvelope: Decodable {
+    var cards: [RemoteReaderCard]
+}
+
+struct RemoteReaderCard: Decodable {
+    enum CardType: String {
+        case post
+        case unknown
+    }
+
+    var type: CardType
+    var post: RemoteReaderPost?
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case data
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let typeString = try container.decode(String.self, forKey: .type)
+        type = CardType(rawValue: typeString) ?? .unknown
+
+        switch type {
+        case .post:
+            let postDictionary = try container.decode([String: Any].self, forKey: .data)
+            post = RemoteReaderPost(dictionary: postDictionary)
+        default:
+            post = nil
+        }
+    }
+}

--- a/WordPressKit/RemoteReaderCard.swift
+++ b/WordPressKit/RemoteReaderCard.swift
@@ -7,11 +7,13 @@ struct ReaderCardEnvelope: Decodable {
 struct RemoteReaderCard: Decodable {
     enum CardType: String {
         case post
+        case interests = "interests_you_may_like"
         case unknown
     }
 
     var type: CardType
     var post: RemoteReaderPost?
+    var interests: [RemoteReaderInterest]?
 
     private enum CodingKeys: String, CodingKey {
         case type
@@ -27,6 +29,8 @@ struct RemoteReaderCard: Decodable {
         case .post:
             let postDictionary = try container.decode([String: Any].self, forKey: .data)
             post = RemoteReaderPost(dictionary: postDictionary)
+        case .interests:
+            interests = try container.decode([RemoteReaderInterest].self, forKey: .data)
         default:
             post = nil
         }

--- a/WordPressKit/RemoteReaderInterest.swift
+++ b/WordPressKit/RemoteReaderInterest.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct RemoteReaderInterest: Decodable {
+public struct RemoteReaderInterest: Decodable {
     var title: String
     var slug: String
 
@@ -9,7 +9,7 @@ struct RemoteReaderInterest: Decodable {
         case slug = "slug-en"
     }
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         title = try container.decode(String.self, forKey: .title)
         slug = try container.decode(String.self, forKey: .slug)

--- a/WordPressKit/RemoteReaderInterest.swift
+++ b/WordPressKit/RemoteReaderInterest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct RemoteReaderInterest: Decodable {
+    var title: String
+    var slug: String
+
+    private enum CodingKeys: String, CodingKey {
+        case title
+        case slug = "slug-en"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        title = try container.decode(String.self, forKey: .title)
+        slug = try container.decode(String.self, forKey: .slug)
+    }
+}

--- a/WordPressKitTests/Extensions/Decodable+DictionaryTests.swift
+++ b/WordPressKitTests/Extensions/Decodable+DictionaryTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import WordPressKit
+
+class DecodableDictionaryTests: XCTestCase {
+    // Decode a JSON into a Dictionary using Decodable
+    //
+    func testDecodableToDictionary() {
+        let json = """
+            {
+                "data": {
+                    "int": 5,
+                    "bool": true,
+                    "string": "foo",
+                    "array": [1.0, 2.0],
+                    "obj": {
+                        "foo": "bar"
+                    }
+                }
+            }
+        """
+        let data = json.data(using: .utf8)!
+
+        let dictionary = try! JSONDecoder().decode(Dict.self, from: data)
+
+        XCTAssertTrue(dictionary.data["int"] as? Int == 5)
+        XCTAssertTrue(dictionary.data["bool"] as? Bool == true)
+        XCTAssertTrue(dictionary.data["string"] as? String == "foo")
+        XCTAssertTrue(dictionary.data["array"] as? [Double] == [1.0, 2.0])
+        XCTAssertTrue((dictionary.data["obj"] as? [String: Any])?["foo"] as? String == "bar")
+    }
+}
+
+private struct Dict: Decodable {
+    var data: [String: Any]
+
+    private enum CodingKeys: String, CodingKey {
+        case data
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        data = try container.decode([String: Any].self, forKey: .data)
+    }
+}

--- a/WordPressKitTests/Mock Data/reader-cards-success.json
+++ b/WordPressKitTests/Mock Data/reader-cards-success.json
@@ -1,0 +1,2564 @@
+{
+	"date_range": {
+		"before": "2020-04-29T14:38:57-05:00",
+		"after": "2020-04-29T12:00:59-04:00"
+	},
+	"number": 10,
+	"cards": [{
+			"type": "interests_you_may_like",
+			"data": [{
+					"title": "Activism",
+					"slug-en": "activism"
+				},
+				{
+					"title": "Advice",
+					"slug-en": "advice"
+				}
+			]
+		},
+		{
+			"type": "recommended_blogs",
+			"data": []
+		},
+		{
+			"type": "post",
+			"data": {
+				"ID": 2005987,
+				"author": {
+					"ID": 321129,
+					"login": "catherinepickavet",
+					"email": false,
+					"name": "Henry Pickavet",
+					"first_name": "",
+					"last_name": "",
+					"nice_name": "henry-pickavet",
+					"URL": "",
+					"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/1e86d9c92b3cd6f22f7af2317d348375?s=96&d=identicon&r=G",
+					"profile_URL": "https:\/\/en.gravatar.com\/1e86d9c92b3cd6f22f7af2317d348375",
+					"site_ID": -1,
+					"has_avatar": true
+				},
+				"date": "2020-06-24T19:00:04+00:00",
+				"modified": "2020-06-24T19:00:04+00:00",
+				"title": "Crypto Startup School: The legal and fundraising implications of crypto tokens",
+				"URL": "https:\/\/techcrunch.com\/2020\/06\/24\/crypto-startup-school-the-legal-and-fundraising-implications-of-crypto-tokens\/",
+				"short_URL": "https:\/\/techcrunch.com\/2020\/06\/24\/crypto-startup-school-the-legal-and-fundraising-implications-of-crypto-tokens\/",
+				"content": "<div class=\"article__contributor-byline-wrapper\">\n<div class=\"article__contributor-byline\">\n\t<div class=\"contributor-byline__contributor\">\n\t\t<div class=\"byline__author\">\n\t\t\t\t\t\t\t<span class=\"byline__author-name\">Zoran Basich<\/span>\n\t\t\t\t\t\t<span class=\"byline__author-title\" style=\"display: block;\">Contributor<\/span>\n\t\t<\/div>\n\n\t\t\t\t<div class=\"contributor__twitter\">\n\t\t\t<a target=\"_blank\" href=\"https:\/\/twitter.com\/zoranbasich\">\n\t\t\t\t\t<svg class=\"icon icon--twitter icon--white\" viewbox=\"0 0 20 20\" version=\"1.1\" aria-labelledby=\"title\"><title>Share on Twitter<\/title><path d=\"M20,4c-0.7,0.3-1.5,0.6-2.4,0.7c0.9-0.5,1.5-1.4,1.8-2.3c-0.8,0.5-1.7,0.8-2.6,1C16.1,2.5,15,2,13.8,2c-2.3,0-4.1,1.9-4.1,4.2c0,0.3,0,0.7,0.1,1C6.4,7,3.4,5.4,1.4,2.9C1,3.5,0.8,4.1,0.8,4.9c0,1.4,0.7,2.7,1.8,3.5C2,8.4,1.4,8.2,0.8,7.9v0.1c0,2,1.4,3.7,3.3,4.1c-0.4,0.1-0.7,0.2-1.1,0.2c-0.3,0-0.5,0-0.8-0.1c0.5,1.7,2,2.9,3.8,2.9c-1.4,1.1-3.2,2-5.1,2c-0.3,0-0.7,0-1-0.1c1.8,1.2,4,1.7,6.3,1.7c7.5,0,11.7-6.4,11.7-12V6.1C18.8,5.6,19.4,4.8,20,4z\"><\/path><\/svg><\/a>\n\t\t<\/div>\n\t\t\t<\/div>\n\n\t\t<div class=\"contributor-byline__bio\">\n\t\tZoran Basich is the crypto editor for Andreessen Horowitz.\t<\/div>\n\t\n\t\t<div class=\"contributor-byline__more-articles\">\n\t\t<span class=\"more-articles-title\">More posts by this contributor<\/span>\n\t\t<ul class=\"more-articles-list\"><li><a href=\"https:\/\/techcrunch.com\/2020\/06\/17\/crypto-startup-school-how-to-build-projects-and-keep-them-safe\/\">Crypto Startup School: How to build projects and keep them safe&nbsp;&nbsp;&nbsp;&nbsp;<\/a><\/li>\n\t\t\t\t\t\t<li><a href=\"https:\/\/techcrunch.com\/2020\/06\/10\/crypto-startup-school-how-to-build-companies-by-building-communities\/\">Crypto Startup School: How to build companies by building communities&nbsp;&nbsp;&nbsp;&nbsp;<\/a><\/li>\n\t\t\t\t\t<\/ul><\/div>\n\t<\/div>\n<\/div><p id=\"speakable-summary\"><strong>Editor&rsquo;s note: <\/strong><em>Andreessen Horowitz&rsquo;s<\/em><a href=\"https:\/\/a16z.com\/crypto-startup-school\"> <em>Crypto Startup School<\/em><\/a><em> brought together 45 participants from around the U.S. and overseas in a six-week course to learn how to build crypto companies. Andreessen Horowitz partnered with TechCrunch to release the online version of the course.<\/em><em>&nbsp;<\/em><\/p>\n<p>The final week of a16z&rsquo;s Crypto Startup School kicks off with former Coinbase Chief Legal Officer Brian Brooks discussing &ldquo;Token Securities Frameworks and Launching a Network.&rdquo; Brooks starts off calling crypto the &ldquo;most perfect intersection of tech and finance,&rdquo; but he cautions that crypto builders must navigate traditional financial-services regulatory structures.<\/p>\n<p>This takes on special importance because tokens, the native assets of crypto networks, can be deemed securities by regulators, making them illegal to list on exchanges and subject to disclosures and other legal requirements.<\/p><div class=\"piano-inline-promo\"><\/div>\n<p>Brooks explains the four-part Howey test, the Supreme Court ruling that has come to define when a given transaction is a securities transaction. Because crypto is still relatively new, however, the path to legality is still developing.<\/p>\n<p>In the meantime, the crypto industry has created the Crypto Rating Council, a new tool to objectively rate tokens and gauge their risk of being deemed securities. Broadly, the tokens that carry the most risk of being labeled securities are those issued before a crypto network is fully decentralized, and while the actions of the management team remain critical to a network&rsquo;s success. (Bitcoin, for example, is not a security, because it is completely decentralized and there is no core management team.)<\/p>\n<p>Brooks introduces some promising new regulatory paths for crypto including membership models &mdash; <a href=\"https:\/\/a16z.com\/2019\/03\/02\/cooperatives-cryptonetworks\/\">similar to cooperatives or mutuals<\/a> &mdash; in which token holders agree to only sell the token to other members of the network, avoiding a secondary sales market and thus steering clear of securities issues. While this model hasn&rsquo;t been tested with the SEC, it has a long track record in other industries and bears further study.<\/p>\n<p><iframe class=\"youtube-player\" width=\"640\" height=\"360\" src=\"https:\/\/www.youtube.com\/embed\/CrrcGiyPglI?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent\" allowfullscreen=\"true\" style=\"border:0;\"><\/iframe><\/p>\n<p>In the final video of the program, former a16z partner and Mediachain co-founder Jesse Walden discusses &ldquo;Fundraising and Deal Structure&rdquo; for crypto startups. During early product development, crypto startups can raise traditional venture capital through equity, which allows for the most alignment between founders and investors.<\/p>\n<p>Then, unlike a traditional startup, a crypto startup can invite its user base to participate in ownership and operation via the disbursement of tokens, once the core founding team has found product-market fit and established a viable network. This aligns incentives among the network, its users, the core team, and venture investors. Issuing tokens dilutes the stakes of the core team and early investors, but this is a desirable outcome because incentivizing more participants increases the chances that a network will grow. This leads to a larger pie overall for investors to share.<\/p>\n<p>Walden also discusses Network Monetary Policy, citing Bitcoin, with its guaranteed limit of 21 million tokens, as having a fixed, deflationary supply policy. Other networks may be inflationary, with no ceiling on token amount, thereby perpetually diluting founders and early investors.<\/p>\n<p>A perpetually dilutive system can nonetheless be productive for token holders due to staking, or the process of holders contributing to the operation of the network, which pays off in newly minted tokens for stakers and the retention of their ownership stakes.<\/p>\n<p><iframe class=\"youtube-player\" width=\"640\" height=\"360\" src=\"https:\/\/www.youtube.com\/embed\/jNbPriRubUs?version=3&amp;rel=1&amp;fs=1&amp;autohide=2&amp;showsearch=0&amp;showinfo=1&amp;iv_load_policy=1&amp;wmode=transparent\" allowfullscreen=\"true\" style=\"border:0;\"><\/iframe><\/p>\n<p><a href=\"https:\/\/a16z.com\/crypto-startup-school\/\"><em>See the videos from all six weeks of Crypto Startup School<\/em><\/a><em>.<\/em><\/p>",
+				"excerpt": "Zoran Basich Contributor Share on Twitter Zoran Basich is the crypto editor for Andreessen Horowitz. More posts by this contributor Crypto Startup School: How to build projects and keep them safe&nbsp;&nbsp;&nbsp;&nbsp; Crypto Startup School: How to build companies by building communities&nbsp;&nbsp;&nbsp;&nbsp; Editor&rsquo;s note: Andreessen Horowitz&rsquo;s Crypto Startup School brought together 45 participants from around the&hellip;",
+				"slug": "",
+				"status": "",
+				"password": "",
+				"parent": false,
+				"type": "",
+				"discussion": {
+					"comments_open": false,
+					"comment_status": "closed",
+					"pings_open": false,
+					"ping_status": "closed",
+					"comment_count": 0
+				},
+				"like_count": 0,
+				"i_like": false,
+				"is_reblogged": false,
+				"is_following": true,
+				"featured_image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/GettyImages-1174590894.jpg",
+				"format": "standard",
+				"geo": false,
+				"publicize_URLs": {},
+				"tags": {
+					"a16z Crypto Startup School": {
+						"ID": 576765260,
+						"name": "a16z Crypto Startup School",
+						"slug": "a16z-crypto-startup-school",
+						"description": "",
+						"post_count": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:a16z-crypto-startup-school",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:a16z-crypto-startup-school\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "a16z-crypto-startup-school"
+					}
+				},
+				"categories": {
+					"Column": {
+						"ID": 25515,
+						"name": "Column",
+						"slug": "column",
+						"description": "",
+						"post_count": 4493,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:column",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:column\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"TC": {
+						"ID": 17396,
+						"name": "TC",
+						"slug": "tc",
+						"description": "",
+						"post_count": 94670,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:tc",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:tc\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					}
+				},
+				"attachments": {},
+				"metadata": false,
+				"meta": {
+					"links": {
+						"feed": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577\/",
+						"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/read\/sites\/136296444",
+						"amp": "https:\/\/techcrunch.com\/2020\/06\/24\/crypto-startup-school-the-legal-and-fundraising-implications-of-crypto-tokens\/amp\/"
+					},
+					"data": {
+						"feed": {
+							"blog_ID": "136296444",
+							"feed_ID": "80112577",
+							"name": "TechCrunch",
+							"URL": "https:\/\/techcrunch.com\/",
+							"feed_URL": "http:\/\/techcrunch.com",
+							"subscribers_count": 41583,
+							"is_following": true,
+							"last_update": "2020-06-24T19:00:04+00:00",
+							"last_checked": "2020-06-24T19:17:08+00:00",
+							"marked_for_refresh": false,
+							"next_refresh_time": null,
+							"organization_id": 0,
+							"unseen_count": 0,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577",
+									"site": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/sites\/136296444"
+								}
+							},
+							"resolved_feed_url": "https:\/\/techcrunch.com\/",
+							"image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=32",
+							"description": "Startup and Technology News"
+						},
+						"site": {
+							"ID": 136296444,
+							"name": "TechCrunch",
+							"description": "Startup and Technology News",
+							"URL": "https:\/\/techcrunch.com",
+							"jetpack": true,
+							"post_count": 150193,
+							"subscribers_count": 41583,
+							"lang": "en-US",
+							"icon": {
+								"img": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png",
+								"ico": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=16"
+							},
+							"logo": {
+								"id": 0,
+								"sizes": [],
+								"url": ""
+							},
+							"visible": true,
+							"is_private": false,
+							"is_coming_soon": false,
+							"is_following": true,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/help",
+									"posts": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/posts\/",
+									"comments": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/comments\/",
+									"xmlrpc": "https:\/\/techcrunch.com\/xmlrpc.php"
+								}
+							},
+							"launch_status": false,
+							"site_migration": null,
+							"is_fse_active": false,
+							"is_fse_eligible": false,
+							"is_core_site_editor_enabled": false,
+							"capabilities": {
+								"edit_pages": false,
+								"edit_posts": false,
+								"edit_others_posts": false,
+								"edit_theme_options": false,
+								"list_users": false,
+								"manage_categories": false,
+								"manage_options": false,
+								"publish_posts": false,
+								"upload_files": false,
+								"view_stats": false
+							},
+							"is_multi_author": true,
+							"feed_ID": 80112577,
+							"feed_URL": "http:\/\/techcrunch.com",
+							"prefer_feed": true,
+							"header_image": false,
+							"owner": {
+								"ID": 22573739,
+								"login": "wpcomvip",
+								"name": "WordPress.com VIP",
+								"first_name": "WordPress.com VIP",
+								"last_name": "",
+								"nice_name": "wpcomvip",
+								"URL": "https:\/\/vip.wordpress.com",
+								"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/dcd97d06942b5bcff00f77699961700e?s=96&d=identicon&r=G",
+								"profile_URL": "https:\/\/en.gravatar.com\/wpcomvip",
+								"ip_address": false,
+								"site_visible": false,
+								"has_avatar": true
+							},
+							"subscription": {
+								"delivery_methods": {
+									"email": null,
+									"notification": {
+										"send_posts": true
+									}
+								}
+							},
+							"is_blocked": false,
+							"organization_id": 0,
+							"unseen_count": 0
+						}
+					}
+				},
+				"word_count": 590,
+				"pseudo_ID": "50ded23ec2e3a08d65a3c7538c4ff669",
+				"global_ID": "50ded23ec2e3a08d65a3c7538c4ff669",
+				"site_ID": 136296444,
+				"site_name": "TechCrunch",
+				"site_URL": "https:\/\/techcrunch.com\/",
+				"site_is_private": false,
+				"featured_media": {
+					"uri": "https:\/\/www.youtube.com\/embed\/CrrcGiyPglI?version=3&rel=1&fs=1&autohide=2&showsearch=0&showinfo=1&iv_load_policy=1&wmode=transparent",
+					"type": "video"
+				},
+				"is_external": false,
+				"is_jetpack": true,
+				"likes_enabled": false,
+				"is_following_conversation": false,
+				"post_thumbnail": {
+					"ID": 2005989,
+					"URL": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/GettyImages-1174590894.jpg",
+					"guid": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/GettyImages-1174590894.jpg",
+					"mime_type": "image\/jpeg",
+					"width": 2235,
+					"height": 1341
+				},
+				"capabilities": {
+					"publish_post": false,
+					"delete_post": false,
+					"edit_post": false
+				},
+				"reblogs_enabled": false,
+				"use_excerpt": false,
+				"feed_ID": 80112577,
+				"feed_URL": "http:\/\/techcrunch.com",
+				"feed_item_ID": 2774640106,
+				"is_seen": false
+			}
+		},
+		{
+			"type": "post",
+			"data": {
+				"ID": 2007856,
+				"author": {
+					"ID": 521068,
+					"login": "ronjourn",
+					"email": false,
+					"name": "Ron Miller",
+					"first_name": "",
+					"last_name": "",
+					"nice_name": "ron-miller",
+					"URL": "",
+					"avatar_URL": "https:\/\/0.gravatar.com\/avatar\/0b82cfe9f0e15c08c5816481c9f383d9?s=96&d=identicon&r=G",
+					"profile_URL": "https:\/\/en.gravatar.com\/0b82cfe9f0e15c08c5816481c9f383d9",
+					"site_ID": -1,
+					"has_avatar": true
+				},
+				"date": "2020-06-24T18:57:15+00:00",
+				"modified": "2020-06-24T18:57:15+00:00",
+				"title": "Dell\u2019s debt hangover from $67B EMC deal could put VMware stock in play",
+				"URL": "https:\/\/techcrunch.com\/2020\/06\/24\/dells-debt-hangover-from-67b-emc-deal-could-put-vmware-stock-in-play\/",
+				"short_URL": "https:\/\/techcrunch.com\/2020\/06\/24\/dells-debt-hangover-from-67b-emc-deal-could-put-vmware-stock-in-play\/",
+				"content": "<p id=\"speakable-summary\">When <a href=\"https:\/\/techcrunch.com\/2016\/09\/07\/67-billion-dell-emc-deal-becomes-official-today\/\">Dell bought EMC in 2016<\/a> for $67 billion it was one of the biggest acquisitions in tech history, and it brought with it a boatload of debt. Since then <a href=\"http:\/\/dell.com\/\">Dell<\/a> has been working on ways to mitigate that debt by selling off various pieces of the corporate empire and <a href=\"https:\/\/techcrunch.com\/2018\/12\/11\/dell-votes-to-buy-back-vmware-tracking-stock-and-will-likely-go-public\/\">going public again<\/a>, but one of its most valuable assets remains <a href=\"http:\/\/vmware.com\/\">VMware<\/a>, a company that came over as part of the huge EMC deal.<\/p>\n<p>The <a href=\"https:\/\/www.wsj.com\/articles\/dell-explores-options-for-81-vmware-stake-11592942687?mod=hp_lista_pos3\">Wall Street Journal reported yesterday<\/a> that Dell is considering selling part of its stake in VMware. The news sent the stock <a href=\"https:\/\/www.cnbc.com\/2020\/06\/23\/shares-of-dell-vmware-spike-on-report-that-dell-is-considering-options-for-its-50-billion-stake-in-the-company.html\">of both companies soaring<\/a>.<\/p>\n<p>It&rsquo;s important to understand that even though <a class=\"crunchbase-link\" href=\"https:\/\/crunchbase.com\/organization\/vmware\" target=\"_blank\" data-type=\"organization\" data-entity=\"vmware\">VMware <span class=\"crunchbase-tooltip-indicator\"><\/span><\/a> is part of the <a class=\"crunchbase-link\" href=\"https:\/\/crunchbase.com\/organization\/dell\" target=\"_blank\" data-type=\"organization\" data-entity=\"dell\">Dell <span class=\"crunchbase-tooltip-indicator\"><\/span><\/a> family, it runs as a separate company, with its own stock and operations, just as it did when it was part of EMC. Still, Dell owns 81% of that stock, so it could sell a substantial stake and still own a majority the company, or it could sell it all, or incorporate into the Dell family, or of course it could do nothing at all.<\/p><div class=\"piano-inline-promo\"><\/div>\n<p>Patrick Moorhead, founder and principal analyst at Moor Insights &amp; Strategy thinks this might just be about floating a trial balloon. &ldquo;Companies do things like this all the time to gauge value, together and apart, and my hunch is this is one of those pieces of research,&rdquo; Moorhead told TechCrunch.<\/p>\n<p>But as Holger Mueller, an analyst with Constellation Research, points out, it&rsquo;s an idea that could make sense. &ldquo;It&rsquo;s plausible. VMware is more valuable than Dell, and their innovation track record is better than Dell&rsquo;s over the last few years,&rdquo; he said.<\/p>\n<p>Mueller added that Dell has been juggling its debts since the <a class=\"crunchbase-link\" href=\"https:\/\/crunchbase.com\/organization\/emc\" target=\"_blank\" data-type=\"organization\" data-entity=\"emc\">EMC <span class=\"crunchbase-tooltip-indicator\"><\/span><\/a> acquisition, and it will struggle to innovate its way out of that situation. What&rsquo;s more, Dell has to wait on any decision until September 2021 when it can move some or all of VMware tax-free, five years after the EMC acquisition closed.<\/p>\n<p>&ldquo;While Dell can juggle finances, it cannot master innovation. The company&rsquo;s cloud strategy is only working on a shrinking market and that ain&rsquo;t easy to execute and grow on. So yeah, next year makes sense after the five year tax free thing kicks in,&rdquo; he said.<\/p>\n<div class=\"embed breakout\">\n<blockquote class=\"wp-embedded-content\" data-secret=\"azawbjjGlt\"><p><a href=\"https:\/\/techcrunch.com\/2016\/09\/07\/67-billion-dell-emc-deal-becomes-official-today\/\">$67 billion Dell-EMC deal closes today<\/a><\/p><\/blockquote>\n<p><iframe class=\"wp-embedded-content\" sandbox=\"allow-scripts\" security=\"restricted\" title=\"&ldquo;$67 billion Dell-EMC deal closes today&rdquo; &mdash; TechCrunch\" src=\"https:\/\/techcrunch.com\/2016\/09\/07\/67-billion-dell-emc-deal-becomes-official-today\/embed\/#?secret=azawbjjGlt\" data-secret=\"azawbjjGlt\" width=\"800\" height=\"450\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\"><\/iframe><\/p><\/div>\n<h2>In between the spreadsheets<\/h2>\n<p>VMware is worth $63.9 billion today, while Dell is valued at a far more modest $38.9 billion, according to Yahoo Finance data. But beyond the fact that the companies&rsquo; market caps differ, they are also quite different in terms of their ability to generate profit.<\/p>\n<p>Looking at their most recent quarters each ending May 1, 2020, Dell turned $21.9 billion in revenue into just $143 million in net income after all expenses were counted. In contrast, VMware generated just $2.73 billion in revenue, but managed to turn that top line into $386 million worth of net income.<\/p>\n<p>So, VMware is far more profitable than Dell from a far smaller revenue base. Even more, VMware grew more last year (from $2.45 billion to $2.73 billion in revenue in its most recent quarter) than Dell, which shrank from $21.91 billion in Q1 F2020 revenue to $21.90 billion in its own most recent three-month period.<\/p>\n<p>VMware also has growing subscription software (SaaS) revenues. Investors love that top line varietal in 2020, having pushed the valuation <a href=\"https:\/\/techcrunch.com\/2020\/06\/04\/saas-earnings-rise-as-pandemic-pushes-companies-more-rapidly-to-the-cloud\/\">of SaaS companies to new heights<\/a>. VMware grew its SaaS revenues from $411 million in the year-ago period to $572 million in its most recent quarter. That&rsquo;s not rocketship growth mind you, but the business category was VMware&rsquo;s fastest growing segment in percentage and gross dollar terms.<\/p>\n<p>So VMware is worth more than Dell, and there are some understandable reasons for the situation. Why wouldn&rsquo;t Dell sell some VMware to lower its debts if the market is willing to price the virtualization company so strongly? Heck, with less debt perhaps Dell&rsquo;s own market value would rise.<\/p>\n<div class=\"embed breakout\">\n<blockquote class=\"wp-embedded-content\" data-secret=\"oK43sbjnTO\"><p><a href=\"https:\/\/techcrunch.com\/2018\/12\/11\/dell-votes-to-buy-back-vmware-tracking-stock-and-will-likely-go-public\/\">Dell votes to buy back VMware tracking stock and go public again<\/a><\/p><\/blockquote>\n<p><iframe class=\"wp-embedded-content\" sandbox=\"allow-scripts\" security=\"restricted\" title=\"&ldquo;Dell votes to buy back VMware tracking stock and go public again&rdquo; &mdash; TechCrunch\" src=\"https:\/\/techcrunch.com\/2018\/12\/11\/dell-votes-to-buy-back-vmware-tracking-stock-and-will-likely-go-public\/embed\/#?secret=oK43sbjnTO\" data-secret=\"oK43sbjnTO\" width=\"800\" height=\"450\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\"><\/iframe><\/p><\/div>\n<h2>It&rsquo;s all about that debt<\/h2>\n<p>Almost four years after the deal closed, Dell is still struggling to figure out how to handle all the debt, and in a weak economy, that&rsquo;s an even bigger challenge now. At some point, it would make sense for Dell to cash in some of its valuable chips, and its most valuable one is clearly VMware.<\/p>\n<p>Nothing is imminent because of the five year tax break business, but could something happen? September 2021 is a long time away, and a lot could change between now and then, but on its face, VMware offers a good avenue to erase a bunch of that outstanding debt very quickly and get Dell on much firmer financial ground. Time will tell if that&rsquo;s what happens.<\/p>\n<div class=\"embed breakout\">\n<blockquote class=\"wp-embedded-content\" data-secret=\"fxCnOebubs\"><p><a href=\"https:\/\/techcrunch.com\/2020\/03\/10\/dell-spent-67b-buying-emc-more-than-3-years-later-was-it-worth-the-debt\/\">Dell spent $67B buying EMC &mdash; more than 3 years later, was it worth the debt?<\/a><\/p><\/blockquote>\n<p><iframe class=\"wp-embedded-content\" sandbox=\"allow-scripts\" security=\"restricted\" title=\"&ldquo;Dell spent $67B buying EMC &mdash; more than 3 years later, was it worth the debt?&rdquo; &mdash; TechCrunch\" src=\"https:\/\/techcrunch.com\/2020\/03\/10\/dell-spent-67b-buying-emc-more-than-3-years-later-was-it-worth-the-debt\/embed\/#?secret=fxCnOebubs\" data-secret=\"fxCnOebubs\" width=\"800\" height=\"450\" frameborder=\"0\" marginwidth=\"0\" marginheight=\"0\" scrolling=\"no\"><\/iframe><\/p><\/div>",
+				"excerpt": "When Dell bought EMC in 2016 for $67 billion it was one of the biggest acquisitions in tech history, and it brought with it a boatload of debt. Since then Dell has been working on ways to mitigate that debt by selling off various pieces of the corporate empire and going public again, but one&hellip;",
+				"slug": "",
+				"status": "",
+				"password": "",
+				"parent": false,
+				"type": "",
+				"discussion": {
+					"comments_open": false,
+					"comment_status": "closed",
+					"pings_open": false,
+					"ping_status": "closed",
+					"comment_count": 0
+				},
+				"like_count": 0,
+				"i_like": false,
+				"is_reblogged": false,
+				"is_following": true,
+				"featured_image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2019\/02\/dell-vmware.jpg",
+				"format": "standard",
+				"geo": false,
+				"publicize_URLs": {},
+				"tags": {
+					"Dell": {
+						"ID": 78,
+						"name": "Dell",
+						"slug": "dell",
+						"description": "",
+						"post_count": 281,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:dell",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:dell\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "dell"
+					},
+					"Dell-EMC Deal": {
+						"ID": 419800079,
+						"name": "Dell-EMC Deal",
+						"slug": "dell-emc-deal",
+						"description": "",
+						"post_count": 25,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:dell-emc-deal",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:dell-emc-deal\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "dell-emc-deal"
+					},
+					"EMC": {
+						"ID": 223148,
+						"name": "EMC",
+						"slug": "emc",
+						"description": "",
+						"post_count": 45,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:emc",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:emc\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "emc"
+					},
+					"Mergers and Acquisitions": {
+						"ID": 103613,
+						"name": "Mergers and Acquisitions",
+						"slug": "mergers-and-acquisitions",
+						"description": "",
+						"post_count": 223,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:mergers-and-acquisitions",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:mergers-and-acquisitions\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "mergers-and-acquisitions"
+					},
+					"vmware": {
+						"ID": 38600,
+						"name": "vmware",
+						"slug": "vmware",
+						"description": "",
+						"post_count": 128,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:vmware",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:vmware\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "vmware"
+					}
+				},
+				"categories": {
+					"Cloud": {
+						"ID": 24405894,
+						"name": "Cloud",
+						"slug": "cloud",
+						"description": "",
+						"post_count": 1933,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:cloud",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:cloud\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"Enterprise": {
+						"ID": 449557044,
+						"name": "Enterprise",
+						"slug": "enterprise",
+						"description": "How cloud computing, big data and new devices are changing work",
+						"post_count": 6363,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:enterprise",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:enterprise\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"Finance": {
+						"ID": 15835174,
+						"name": "Finance",
+						"slug": "finance",
+						"description": "",
+						"post_count": 2282,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:finance",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:finance\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"M&amp;A": {
+						"ID": 449560964,
+						"name": "M&amp;A",
+						"slug": "ma",
+						"description": "",
+						"post_count": 738,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:ma",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:ma\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					}
+				},
+				"attachments": {},
+				"metadata": false,
+				"meta": {
+					"links": {
+						"feed": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577\/",
+						"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/read\/sites\/136296444",
+						"amp": "https:\/\/techcrunch.com\/2020\/06\/24\/dells-debt-hangover-from-67b-emc-deal-could-put-vmware-stock-in-play\/amp\/"
+					},
+					"data": {
+						"feed": {
+							"blog_ID": "136296444",
+							"feed_ID": "80112577",
+							"name": "TechCrunch",
+							"URL": "https:\/\/techcrunch.com\/",
+							"feed_URL": "http:\/\/techcrunch.com",
+							"subscribers_count": 41583,
+							"is_following": true,
+							"last_update": "2020-06-24T19:00:04+00:00",
+							"last_checked": "2020-06-24T19:17:08+00:00",
+							"marked_for_refresh": false,
+							"next_refresh_time": null,
+							"organization_id": 0,
+							"unseen_count": 0,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577",
+									"site": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/sites\/136296444"
+								}
+							},
+							"resolved_feed_url": "https:\/\/techcrunch.com\/",
+							"image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=32",
+							"description": "Startup and Technology News"
+						},
+						"site": {
+							"ID": 136296444,
+							"name": "TechCrunch",
+							"description": "Startup and Technology News",
+							"URL": "https:\/\/techcrunch.com",
+							"jetpack": true,
+							"post_count": 150193,
+							"subscribers_count": 41583,
+							"lang": "en-US",
+							"icon": {
+								"img": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png",
+								"ico": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=16"
+							},
+							"logo": {
+								"id": 0,
+								"sizes": [],
+								"url": ""
+							},
+							"visible": true,
+							"is_private": false,
+							"is_coming_soon": false,
+							"is_following": true,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/help",
+									"posts": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/posts\/",
+									"comments": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/comments\/",
+									"xmlrpc": "https:\/\/techcrunch.com\/xmlrpc.php"
+								}
+							},
+							"launch_status": false,
+							"site_migration": null,
+							"is_fse_active": false,
+							"is_fse_eligible": false,
+							"is_core_site_editor_enabled": false,
+							"capabilities": {
+								"edit_pages": false,
+								"edit_posts": false,
+								"edit_others_posts": false,
+								"edit_theme_options": false,
+								"list_users": false,
+								"manage_categories": false,
+								"manage_options": false,
+								"publish_posts": false,
+								"upload_files": false,
+								"view_stats": false
+							},
+							"is_multi_author": true,
+							"feed_ID": 80112577,
+							"feed_URL": "http:\/\/techcrunch.com",
+							"prefer_feed": true,
+							"header_image": false,
+							"owner": {
+								"ID": 22573739,
+								"login": "wpcomvip",
+								"name": "WordPress.com VIP",
+								"first_name": "WordPress.com VIP",
+								"last_name": "",
+								"nice_name": "wpcomvip",
+								"URL": "https:\/\/vip.wordpress.com",
+								"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/dcd97d06942b5bcff00f77699961700e?s=96&d=identicon&r=G",
+								"profile_URL": "https:\/\/en.gravatar.com\/wpcomvip",
+								"ip_address": false,
+								"site_visible": false,
+								"has_avatar": true
+							},
+							"subscription": {
+								"delivery_methods": {
+									"email": null,
+									"notification": {
+										"send_posts": true
+									}
+								}
+							},
+							"is_blocked": false,
+							"organization_id": 0,
+							"unseen_count": 0
+						}
+					}
+				},
+				"word_count": 803,
+				"pseudo_ID": "9a648d6cd8945521c29c0b02882a3448",
+				"global_ID": "9a648d6cd8945521c29c0b02882a3448",
+				"site_ID": 136296444,
+				"site_name": "TechCrunch",
+				"site_URL": "https:\/\/techcrunch.com\/",
+				"site_is_private": false,
+				"featured_media": {},
+				"is_external": false,
+				"is_jetpack": true,
+				"likes_enabled": false,
+				"is_following_conversation": false,
+				"post_thumbnail": {
+					"ID": 1788562,
+					"URL": "https:\/\/techcrunch.com\/wp-content\/uploads\/2019\/02\/dell-vmware.jpg",
+					"guid": "https:\/\/techcrunch.com\/wp-content\/uploads\/2019\/02\/dell-vmware.jpg",
+					"mime_type": "image\/jpeg",
+					"width": 4812,
+					"height": 3208
+				},
+				"capabilities": {
+					"publish_post": false,
+					"delete_post": false,
+					"edit_post": false
+				},
+				"reblogs_enabled": false,
+				"use_excerpt": false,
+				"feed_ID": 80112577,
+				"feed_URL": "http:\/\/techcrunch.com",
+				"feed_item_ID": 2774640107,
+				"is_seen": false
+			}
+		},
+		{
+			"type": "post",
+			"data": {
+				"ID": 2007869,
+				"author": {
+					"ID": 2414667,
+					"login": "sarahintampa",
+					"email": false,
+					"name": "Sarah Perez",
+					"first_name": "",
+					"last_name": "",
+					"nice_name": "sarah-perez",
+					"URL": "",
+					"avatar_URL": "https:\/\/2.gravatar.com\/avatar\/5225bb627e112543aa03bf3b2958be3f?s=96&d=identicon&r=G",
+					"profile_URL": "https:\/\/en.gravatar.com\/5225bb627e112543aa03bf3b2958be3f",
+					"site_ID": -1,
+					"has_avatar": true
+				},
+				"date": "2020-06-24T18:51:47+00:00",
+				"modified": "2020-06-24T18:51:47+00:00",
+				"title": "Instagram expands its TikTok clone \u2018Reels\u2019 to new markets",
+				"URL": "https:\/\/techcrunch.com\/2020\/06\/24\/instagram-expands-its-tiktok-clone-reels-to-new-markets\/",
+				"short_URL": "https:\/\/techcrunch.com\/2020\/06\/24\/instagram-expands-its-tiktok-clone-reels-to-new-markets\/",
+				"content": "<p id=\"speakable-summary\">Instagram is expanding <a href=\"https:\/\/techcrunch.com\/2019\/11\/12\/instagram-reels\/\">its TikTok competitor known as &ldquo;Reels&rdquo;<\/a> to new markets, following its launch last year in Brazil. Starting today, Instagram is rolling out further access to Reels in France and Germany, allowing users to record short, 15-second video clips set to music or other audio, then share them on the platform where they have the potential to go viral.<\/p>\n<p>The Reels feature is similar to TikTok in that it presents a set of editing tools that make it easier to film creative videos. At launch, for example, Reels offered a countdown timer, the ability to adjust the video&rsquo;s speed, and other effects.<\/p>\n<p>The company learned from its early tests in Brazil and has since rethought key aspects to the Reels experience.<\/p><div class=\"piano-inline-promo\"><\/div>\n<p>Before, Reels were meant to be shared only within Instagram Stories. But the Instagram community said they wanted the ability to share Reels with followers and friends in a more permanent way, and also have the opportunity to expand that distribution more broadly if desired.<\/p>\n<p><img class=\"vertical aligncenter size-large wp-image-2007894\" src=\"https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Profile_EN.png?w=346\" alt=\"\" width=\"346\" height=\"680\" srcset=\"https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Profile_EN.png 453w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Profile_EN.png?resize=76,150 76w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Profile_EN.png?resize=153,300 153w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Profile_EN.png?resize=346,680 346w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Profile_EN.png?resize=25,50 25w\" sizes=\"(max-width: 346px) 100vw, 346px\"><\/p>\n<p>In addition, the community said they wanted a dedicated space where they could easily compile Reels and watch other people&rsquo;s Reels.<\/p>\n<p>With the expansion in Germany and France, Instagram has moved Reels to a dedicated space on the user Profile and in Explore &mdash; the latter for public accounts &mdash; so people can share with a new audience and share on their Instagram Feed, a company spokesperson tells TechCrunch.<\/p>\n<p><img class=\"vertical aligncenter size-large wp-image-2007895\" src=\"https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Viewer_EN.png?w=346\" alt=\"\" width=\"346\" height=\"680\" srcset=\"https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Viewer_EN.png 453w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Viewer_EN.png?resize=76,150 76w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Viewer_EN.png?resize=153,300 153w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Viewer_EN.png?resize=346,680 346w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Viewer_EN.png?resize=25,50 25w\" sizes=\"(max-width: 346px) 100vw, 346px\"><\/p>\n<p>These changes offer the chance for more exposure for both Reels and their creators, as Reels becomes more of a destination in the app &mdash; like the Stories row is today, for instance.<\/p>\n<p>Reels are not Facebook&rsquo;s first attempt at challenging TikTok&rsquo;s growing popularity.<\/p>\n<p>The Instagram parent company had previously launched short-form video app <a href=\"https:\/\/lassovideos.com\/\">Lasso<\/a>, but it has so far failed to gain significant traction. With Reels, however, Instagram is able to tap into its existing base of creators and leverage users&rsquo; familiarity with its video editing tools.<\/p>\n<p><img class=\"vertical aligncenter size-large wp-image-2007897\" src=\"https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Audio_EN.png?w=346\" alt=\"\" width=\"346\" height=\"680\" srcset=\"https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Audio_EN.png 453w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Audio_EN.png?resize=76,150 76w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Audio_EN.png?resize=153,300 153w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Audio_EN.png?resize=346,680 346w, https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_Audio_EN.png?resize=25,50 25w\" sizes=\"(max-width: 346px) 100vw, 346px\"><\/p>\n<p>The challenge for Reels is in getting Instagram users to create a different type of content than they do today in Feed posts and in Stories. Those video tend to be more personal in nature &mdash; like clips from someone&rsquo;s day or a vlog, for example. Meanwhile, more professional creator content has been relocated to IGTV.<\/p>\n<p>TikTok videos, on the other hand, tend to be rehearsed and choreographed. Users learn a dance, perform a trick, make jokes, lip-sync to songs or audio, or replicate a popular meme in their own way. These videos are not typically off-the-cuff, as on Instagram. Encouraging this content requires a different editing tool set and workflow, which is what Reels offers.<\/p>\n<p>Instagram didn&rsquo;t say when it plans to roll out Reels globally or when it expects to bring the product to the U.S., but says the further expansion will allow the company to continue to build on the existing experience and evolve the product.<\/p>",
+				"excerpt": "Instagram is expanding its TikTok competitor known as &ldquo;Reels&rdquo; to new markets, following its launch last year in Brazil. Starting today, Instagram is rolling out further access to Reels in France and Germany, allowing users to record short, 15-second video clips set to music or other audio, then share them on the platform where they&hellip;",
+				"slug": "",
+				"status": "",
+				"password": "",
+				"parent": false,
+				"type": "",
+				"discussion": {
+					"comments_open": false,
+					"comment_status": "closed",
+					"pings_open": false,
+					"ping_status": "closed",
+					"comment_count": 0
+				},
+				"like_count": 0,
+				"i_like": false,
+				"is_reblogged": false,
+				"is_following": true,
+				"featured_image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_EN-1.png",
+				"format": "standard",
+				"geo": false,
+				"publicize_URLs": {},
+				"tags": {
+					"Instagram": {
+						"ID": 42653521,
+						"name": "Instagram",
+						"slug": "instagram",
+						"description": "",
+						"post_count": 920,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:instagram",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:instagram\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "instagram"
+					},
+					"reels": {
+						"ID": 576600886,
+						"name": "reels",
+						"slug": "reels",
+						"description": "",
+						"post_count": 1,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:reels",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:reels\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "reels"
+					},
+					"social": {
+						"ID": 1404273,
+						"name": "social",
+						"slug": "social",
+						"description": "",
+						"post_count": 164,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:social",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:social\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "social"
+					},
+					"social media": {
+						"ID": 49818,
+						"name": "social media",
+						"slug": "social-media",
+						"description": "",
+						"post_count": 960,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:social-media",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:social-media\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "social-media"
+					},
+					"tiktok": {
+						"ID": 5938293,
+						"name": "tiktok",
+						"slug": "tiktok",
+						"description": "",
+						"post_count": 133,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:tiktok",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:tiktok\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "tiktok"
+					},
+					"videos": {
+						"ID": 1149,
+						"name": "videos",
+						"slug": "videos",
+						"description": "",
+						"post_count": 514,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:videos",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:videos\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "videos"
+					}
+				},
+				"categories": {
+					"Apps": {
+						"ID": 449557102,
+						"name": "Apps",
+						"slug": "apps",
+						"description": "",
+						"post_count": 12400,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:apps",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:apps\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"Social": {
+						"ID": 3457,
+						"name": "Social",
+						"slug": "social",
+						"description": "How technology is shaping the way we live with each other",
+						"post_count": 8460,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:social",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:social\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					}
+				},
+				"attachments": {},
+				"metadata": false,
+				"meta": {
+					"links": {
+						"feed": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577\/",
+						"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/read\/sites\/136296444",
+						"amp": "https:\/\/techcrunch.com\/2020\/06\/24\/instagram-expands-its-tiktok-clone-reels-to-new-markets\/amp\/"
+					},
+					"data": {
+						"feed": {
+							"blog_ID": "136296444",
+							"feed_ID": "80112577",
+							"name": "TechCrunch",
+							"URL": "https:\/\/techcrunch.com\/",
+							"feed_URL": "http:\/\/techcrunch.com",
+							"subscribers_count": 41583,
+							"is_following": true,
+							"last_update": "2020-06-24T19:00:04+00:00",
+							"last_checked": "2020-06-24T19:17:08+00:00",
+							"marked_for_refresh": false,
+							"next_refresh_time": null,
+							"organization_id": 0,
+							"unseen_count": 0,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577",
+									"site": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/sites\/136296444"
+								}
+							},
+							"resolved_feed_url": "https:\/\/techcrunch.com\/",
+							"image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=32",
+							"description": "Startup and Technology News"
+						},
+						"site": {
+							"ID": 136296444,
+							"name": "TechCrunch",
+							"description": "Startup and Technology News",
+							"URL": "https:\/\/techcrunch.com",
+							"jetpack": true,
+							"post_count": 150193,
+							"subscribers_count": 41583,
+							"lang": "en-US",
+							"icon": {
+								"img": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png",
+								"ico": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=16"
+							},
+							"logo": {
+								"id": 0,
+								"sizes": [],
+								"url": ""
+							},
+							"visible": true,
+							"is_private": false,
+							"is_coming_soon": false,
+							"is_following": true,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/help",
+									"posts": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/posts\/",
+									"comments": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/comments\/",
+									"xmlrpc": "https:\/\/techcrunch.com\/xmlrpc.php"
+								}
+							},
+							"launch_status": false,
+							"site_migration": null,
+							"is_fse_active": false,
+							"is_fse_eligible": false,
+							"is_core_site_editor_enabled": false,
+							"capabilities": {
+								"edit_pages": false,
+								"edit_posts": false,
+								"edit_others_posts": false,
+								"edit_theme_options": false,
+								"list_users": false,
+								"manage_categories": false,
+								"manage_options": false,
+								"publish_posts": false,
+								"upload_files": false,
+								"view_stats": false
+							},
+							"is_multi_author": true,
+							"feed_ID": 80112577,
+							"feed_URL": "http:\/\/techcrunch.com",
+							"prefer_feed": true,
+							"header_image": false,
+							"owner": {
+								"ID": 22573739,
+								"login": "wpcomvip",
+								"name": "WordPress.com VIP",
+								"first_name": "WordPress.com VIP",
+								"last_name": "",
+								"nice_name": "wpcomvip",
+								"URL": "https:\/\/vip.wordpress.com",
+								"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/dcd97d06942b5bcff00f77699961700e?s=96&d=identicon&r=G",
+								"profile_URL": "https:\/\/en.gravatar.com\/wpcomvip",
+								"ip_address": false,
+								"site_visible": false,
+								"has_avatar": true
+							},
+							"subscription": {
+								"delivery_methods": {
+									"email": null,
+									"notification": {
+										"send_posts": true
+									}
+								}
+							},
+							"is_blocked": false,
+							"organization_id": 0,
+							"unseen_count": 0
+						}
+					}
+				},
+				"word_count": 484,
+				"pseudo_ID": "296be90b30a2a89e0a5bcfaf17b8cea2",
+				"global_ID": "296be90b30a2a89e0a5bcfaf17b8cea2",
+				"site_ID": 136296444,
+				"site_name": "TechCrunch",
+				"site_URL": "https:\/\/techcrunch.com\/",
+				"site_is_private": false,
+				"featured_media": {},
+				"is_external": false,
+				"is_jetpack": true,
+				"likes_enabled": false,
+				"is_following_conversation": false,
+				"post_thumbnail": {
+					"ID": 2007891,
+					"URL": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_EN-1.png",
+					"guid": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/Reels_IOSX_EN-1.png",
+					"mime_type": "image\/png",
+					"width": 1603,
+					"height": 1016
+				},
+				"capabilities": {
+					"publish_post": false,
+					"delete_post": false,
+					"edit_post": false
+				},
+				"reblogs_enabled": false,
+				"use_excerpt": false,
+				"feed_ID": 80112577,
+				"feed_URL": "http:\/\/techcrunch.com",
+				"feed_item_ID": 2774634432,
+				"is_seen": false
+			}
+		},
+		{
+			"type": "post",
+			"data": {
+				"ID": 2005647,
+				"author": {
+					"ID": 133574362,
+					"login": "nkmascarenhas",
+					"email": false,
+					"name": "Natasha Mascarenhas",
+					"first_name": "",
+					"last_name": "",
+					"nice_name": "natasha-mascarenhas",
+					"URL": "",
+					"avatar_URL": "https:\/\/2.gravatar.com\/avatar\/2f10add080685bb138750d850afec5b4?s=96&d=identicon&r=G",
+					"profile_URL": "https:\/\/en.gravatar.com\/2f10add080685bb138750d850afec5b4",
+					"site_ID": -1,
+					"has_avatar": true
+				},
+				"date": "2020-06-24T18:51:21+00:00",
+				"modified": "2020-06-24T18:51:21+00:00",
+				"title": "How first-time fund managers are de-risking",
+				"URL": "https:\/\/techcrunch.com\/2020\/06\/24\/how-first-time-fund-managers-are-de-risking\/",
+				"short_URL": "https:\/\/techcrunch.com\/2020\/06\/24\/how-first-time-fund-managers-are-de-risking\/",
+				"content": "<p id=\"speakable-summary\">After what felt like winter, investors say startup deals are back on &mdash; although the <a href=\"https:\/\/techcrunch.com\/2020\/06\/15\/a-new-silicon-valley-venture-report-shocks-because-of-how-little-the-pandemic-has-impacted-dealmaking\/\">numbers suggest they never stopped<\/a>. As Semil Shah of Haystack VC <a href=\"https:\/\/semilshah.com\/writing\/\">phrased it in a blog post,<\/a> &ldquo;It&rsquo;s game on, pandemic or bust.&rdquo;<\/p>\n<p>This is good news for founders and big funds, but the investment landscape becomes more complicated when it comes to up-and-coming venture capitalists. &ldquo;My impression of the current mood amongst traditional limited partners is that most have slowed down considerably in terms of net new investments, new relationships,&rdquo; Shah told TechCrunch.<\/p>\n<p>So rebound or not, we&rsquo;re in a volatile time, and first-time fund managers are looking for unique ways to de-risk themselves.<\/p>\n<p>One route: Put liquidity up high in your pitch deck. Moore Ventures, a new fund focused on investing in diverse teams working on sustainability, is experimenting with an unconventional fund structure. Instead of traditional ventures where returns come from multiple rounds of financing and an exit either through acquisition or IPO, Moore is concentrating on successful liquidity strategies throughout a portfolio company&rsquo;s life.<\/p>\n<p>Constant commercialization, if it works, could be music to a limited partner&rsquo;s ears.<\/p>\n<p>&ldquo;Some will fall into the licensing model, some will be developing the product and then selling the design and manufacturing process to an existing company before expanding marketing and sales. Only if a company has the ability to expand its product base and scale will we plan to commercialize through the traditional company development process,&rdquo; said <a class=\"crunchbase-link\" href=\"https:\/\/crunchbase.com\/person\/darius-sankey\" target=\"_blank\" data-type=\"person\" data-entity=\"darius-sankey\">Darius Sankey, <span class=\"crunchbase-tooltip-indicator\"><\/span><\/a> a general partner at Moore Ventures.<\/p><div class=\"extra-crunch-offer-container\"><\/div>",
+				"excerpt": "After what felt like winter, investors say startup deals are back on &mdash; although the numbers suggest they never stopped. As Semil Shah of Haystack VC phrased it in a blog post, &ldquo;It&rsquo;s game on, pandemic or bust.&rdquo; This is good news for founders and big funds, but the investment landscape becomes more complicated when&hellip;",
+				"slug": "",
+				"status": "",
+				"password": "",
+				"parent": false,
+				"type": "",
+				"discussion": {
+					"comments_open": false,
+					"comment_status": "closed",
+					"pings_open": false,
+					"ping_status": "closed",
+					"comment_count": 0
+				},
+				"like_count": 0,
+				"i_like": false,
+				"is_reblogged": false,
+				"is_following": true,
+				"featured_image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/GettyImages-1194970648.jpg",
+				"format": "standard",
+				"geo": false,
+				"publicize_URLs": {},
+				"tags": {
+					"Chris Sacca": {
+						"ID": 494230,
+						"name": "Chris Sacca",
+						"slug": "chris-sacca",
+						"description": "",
+						"post_count": 28,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:chris-sacca",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:chris-sacca\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "chris-sacca"
+					},
+					"coronavirus": {
+						"ID": 576734528,
+						"name": "coronavirus",
+						"slug": "coronavirus",
+						"description": "",
+						"post_count": 1006,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:coronavirus",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:coronavirus\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "coronavirus"
+					},
+					"COVID-19": {
+						"ID": 576740177,
+						"name": "COVID-19",
+						"slug": "covid-19",
+						"description": "",
+						"post_count": 982,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:covid-19",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:covid-19\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "covid-19"
+					},
+					"darius sankey": {
+						"ID": 576778412,
+						"name": "darius sankey",
+						"slug": "darius-sankey",
+						"description": "",
+						"post_count": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:darius-sankey",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:darius-sankey\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "darius-sankey"
+					},
+					"haystack vc": {
+						"ID": 576778413,
+						"name": "haystack vc",
+						"slug": "haystack-vc",
+						"description": "",
+						"post_count": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:haystack-vc",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:haystack-vc\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "haystack-vc"
+					},
+					"market": {
+						"ID": 8611,
+						"name": "market",
+						"slug": "market",
+						"description": "",
+						"post_count": 18,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:market",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:market\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "market"
+					},
+					"Mary Meeker": {
+						"ID": 2293239,
+						"name": "Mary Meeker",
+						"slug": "mary-meeker",
+						"description": "",
+						"post_count": 37,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:mary-meeker",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:mary-meeker\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "mary-meeker"
+					},
+					"moore ventures": {
+						"ID": 576778408,
+						"name": "moore ventures",
+						"slug": "moore-ventures",
+						"description": "",
+						"post_count": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:moore-ventures",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:moore-ventures\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "moore-ventures"
+					},
+					"Semil Shah": {
+						"ID": 48784753,
+						"name": "Semil Shah",
+						"slug": "semil-shah",
+						"description": "",
+						"post_count": 75,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:semil-shah",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:semil-shah\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "semil-shah"
+					},
+					"shila nieves burney": {
+						"ID": 576778409,
+						"name": "shila nieves burney",
+						"slug": "shila-nieves-burney",
+						"description": "",
+						"post_count": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:shila-nieves-burney",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:shila-nieves-burney\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "shila-nieves-burney"
+					},
+					"venture capital": {
+						"ID": 202,
+						"name": "venture capital",
+						"slug": "venture-capital",
+						"description": "",
+						"post_count": 728,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:venture-capital",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:venture-capital\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "venture-capital"
+					},
+					"zane venture fund": {
+						"ID": 576778410,
+						"name": "zane venture fund",
+						"slug": "zane-venture-fund",
+						"description": "",
+						"post_count": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:zane-venture-fund",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:zane-venture-fund\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "zane-venture-fund"
+					}
+				},
+				"categories": {
+					"Diversity": {
+						"ID": 35027640,
+						"name": "Diversity",
+						"slug": "diversity",
+						"description": "",
+						"post_count": 706,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:diversity",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:diversity\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"Extra Crunch": {
+						"ID": 576737633,
+						"name": "Extra Crunch",
+						"slug": "extra-crunch",
+						"description": "",
+						"post_count": 313,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:extra-crunch",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:extra-crunch\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"Fundraising": {
+						"ID": 576737635,
+						"name": "Fundraising",
+						"slug": "fundraising",
+						"description": "",
+						"post_count": 160,
+						"parent": 576737633,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:fundraising",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:fundraising\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"Market Analysis": {
+						"ID": 576754162,
+						"name": "Market Analysis",
+						"slug": "market-analysis",
+						"description": "",
+						"post_count": 436,
+						"parent": 576737633,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:market-analysis",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:market-analysis\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"Startups": {
+						"ID": 20429,
+						"name": "Startups",
+						"slug": "startups",
+						"description": "The newest companies that could change the world",
+						"post_count": 21566,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:startups",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:startups\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"TC": {
+						"ID": 17396,
+						"name": "TC",
+						"slug": "tc",
+						"description": "",
+						"post_count": 94670,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:tc",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:tc\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					},
+					"Venture Capital": {
+						"ID": 35394854,
+						"name": "Venture Capital",
+						"slug": "venture-capital",
+						"description": "",
+						"post_count": 3796,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:venture-capital",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:venture-capital\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					}
+				},
+				"attachments": {},
+				"metadata": false,
+				"meta": {
+					"links": {
+						"feed": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577\/",
+						"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/read\/sites\/136296444",
+						"amp": "https:\/\/techcrunch.com\/2020\/06\/24\/how-first-time-fund-managers-are-de-risking\/amp\/"
+					},
+					"data": {
+						"feed": {
+							"blog_ID": "136296444",
+							"feed_ID": "80112577",
+							"name": "TechCrunch",
+							"URL": "https:\/\/techcrunch.com\/",
+							"feed_URL": "http:\/\/techcrunch.com",
+							"subscribers_count": 41583,
+							"is_following": true,
+							"last_update": "2020-06-24T19:00:04+00:00",
+							"last_checked": "2020-06-24T19:17:08+00:00",
+							"marked_for_refresh": false,
+							"next_refresh_time": null,
+							"organization_id": 0,
+							"unseen_count": 0,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577",
+									"site": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/sites\/136296444"
+								}
+							},
+							"resolved_feed_url": "https:\/\/techcrunch.com\/",
+							"image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=32",
+							"description": "Startup and Technology News"
+						},
+						"site": {
+							"ID": 136296444,
+							"name": "TechCrunch",
+							"description": "Startup and Technology News",
+							"URL": "https:\/\/techcrunch.com",
+							"jetpack": true,
+							"post_count": 150193,
+							"subscribers_count": 41583,
+							"lang": "en-US",
+							"icon": {
+								"img": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png",
+								"ico": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=16"
+							},
+							"logo": {
+								"id": 0,
+								"sizes": [],
+								"url": ""
+							},
+							"visible": true,
+							"is_private": false,
+							"is_coming_soon": false,
+							"is_following": true,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/help",
+									"posts": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/posts\/",
+									"comments": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/comments\/",
+									"xmlrpc": "https:\/\/techcrunch.com\/xmlrpc.php"
+								}
+							},
+							"launch_status": false,
+							"site_migration": null,
+							"is_fse_active": false,
+							"is_fse_eligible": false,
+							"is_core_site_editor_enabled": false,
+							"capabilities": {
+								"edit_pages": false,
+								"edit_posts": false,
+								"edit_others_posts": false,
+								"edit_theme_options": false,
+								"list_users": false,
+								"manage_categories": false,
+								"manage_options": false,
+								"publish_posts": false,
+								"upload_files": false,
+								"view_stats": false
+							},
+							"is_multi_author": true,
+							"feed_ID": 80112577,
+							"feed_URL": "http:\/\/techcrunch.com",
+							"prefer_feed": true,
+							"header_image": false,
+							"owner": {
+								"ID": 22573739,
+								"login": "wpcomvip",
+								"name": "WordPress.com VIP",
+								"first_name": "WordPress.com VIP",
+								"last_name": "",
+								"nice_name": "wpcomvip",
+								"URL": "https:\/\/vip.wordpress.com",
+								"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/dcd97d06942b5bcff00f77699961700e?s=96&d=identicon&r=G",
+								"profile_URL": "https:\/\/en.gravatar.com\/wpcomvip",
+								"ip_address": false,
+								"site_visible": false,
+								"has_avatar": true
+							},
+							"subscription": {
+								"delivery_methods": {
+									"email": null,
+									"notification": {
+										"send_posts": true
+									}
+								}
+							},
+							"is_blocked": false,
+							"organization_id": 0,
+							"unseen_count": 0
+						}
+					}
+				},
+				"word_count": 252,
+				"pseudo_ID": "80c397148c3ef68e9f0df12b69c9437d",
+				"global_ID": "80c397148c3ef68e9f0df12b69c9437d",
+				"site_ID": 136296444,
+				"site_name": "TechCrunch",
+				"site_URL": "https:\/\/techcrunch.com\/",
+				"site_is_private": false,
+				"featured_media": {},
+				"is_external": false,
+				"is_jetpack": true,
+				"likes_enabled": false,
+				"is_following_conversation": false,
+				"post_thumbnail": {
+					"ID": 2007863,
+					"URL": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/GettyImages-1194970648.jpg",
+					"guid": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/GettyImages-1194970648.jpg",
+					"mime_type": "image\/jpeg",
+					"width": 1000,
+					"height": 667
+				},
+				"capabilities": {
+					"publish_post": false,
+					"delete_post": false,
+					"edit_post": false
+				},
+				"reblogs_enabled": false,
+				"use_excerpt": false,
+				"feed_ID": 80112577,
+				"feed_URL": "http:\/\/techcrunch.com",
+				"feed_item_ID": 2774634433,
+				"is_seen": false
+			}
+		},
+		{
+			"type": "post",
+			"data": {
+				"ID": 1478,
+				"site_ID": 159889361,
+				"author": {
+					"ID": 154288761,
+					"login": "testuser0313",
+					"email": false,
+					"name": "Sally Sparrow",
+					"first_name": "Sally",
+					"last_name": "Sparrow",
+					"nice_name": "testuser0313",
+					"URL": "http:\/\/Example.org",
+					"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/18b70acbdcfcd560f4707a6e3485f298?s=96&d=identicon&r=G",
+					"profile_URL": "https:\/\/en.gravatar.com\/testuser0313",
+					"site_ID": 160502386,
+					"has_avatar": true
+				},
+				"date": "2020-06-24T18:49:38+00:00",
+				"modified": "2020-06-24T09:01:42-10:00",
+				"title": "Moonlight Sonota",
+				"URL": "http:\/\/made4testing0318.blog\/2020\/06\/24\/moonlight-sonota-slow-and-dark-mix\/",
+				"short_URL": "https:\/\/wp.me\/paOSwF-nQ",
+				"content": "<iframe width=\"100%\" height=\"450\" scrolling=\"no\" frameborder=\"no\" src=\"https:\/\/w.soundcloud.com\/player\/?url=https%3A%2F%2Fsoundcloud.com%2Fuser-670680461%2Fsets%2Fmoonlight-sonota&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false\"><\/iframe>\n\n\n\n<p>Added via shortcode block with <code><iframe width=\"100%\" height=\"450\" scrolling=\"no\" frameborder=\"no\" src=\"https:\/\/w.soundcloud.com\/player\/?url=https%3A%2F%2Fsoundcloud.com%2Fuser-670680461%2Fsets%2Fmoonlight-sonota&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false\"><\/iframe><\/code><\/p>\n\n\n\n<p>See <a href=\"https:\/\/wordpress.com\/support\/soundcloud-audio-player\/\" rel=\"nofollow\">https:\/\/wordpress.com\/support\/soundcloud-audio-player\/<\/a>.<\/p>\n",
+				"excerpt": "<p>Added via shortcode block with See <a href=\"https:\/\/wordpress.com\/support\/soundcloud-audio-player\/\" rel=\"nofollow\">https:\/\/wordpress.com\/support\/soundcloud-audio-player\/<\/a>.<\/p>\n",
+				"slug": "moonlight-sonota-slow-and-dark-mix",
+				"guid": "http:\/\/made4testing0318.blog\/?p=1478",
+				"status": "publish",
+				"sticky": false,
+				"password": "",
+				"parent": false,
+				"type": "post",
+				"discussion": {
+					"comments_open": true,
+					"comment_status": "open",
+					"pings_open": true,
+					"ping_status": "open",
+					"comment_count": 0
+				},
+				"likes_enabled": true,
+				"sharing_enabled": true,
+				"like_count": 0,
+				"i_like": false,
+				"is_reblogged": false,
+				"is_following": true,
+				"global_ID": "2f4d6df67b1a383ce11b06cbc00f436d",
+				"featured_image": "",
+				"post_thumbnail": null,
+				"format": "standard",
+				"geo": false,
+				"menu_order": 0,
+				"page_template": "",
+				"publicize_URLs": [],
+				"terms": {
+					"category": {
+						"Testing": {
+							"ID": 12,
+							"name": "Testing",
+							"slug": "testing",
+							"description": "",
+							"post_count": 11,
+							"parent": 0,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/categories\/slug:testing",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/categories\/slug:testing\/help",
+									"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361"
+								}
+							}
+						}
+					},
+					"post_tag": {},
+					"post_format": {},
+					"mentions": {}
+				},
+				"tags": [],
+				"categories": {
+					"Testing": {
+						"ID": 12,
+						"name": "Testing",
+						"slug": "testing",
+						"description": "",
+						"post_count": 11,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/categories\/slug:testing",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/categories\/slug:testing\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361"
+							}
+						}
+					}
+				},
+				"attachments": {},
+				"attachment_count": 0,
+				"metadata": [{
+					"id": "6989",
+					"key": "email_notification",
+					"value": "1593024581"
+				}, {
+					"id": "6981",
+					"key": "jabber_published",
+					"value": "1593024580"
+				}, {
+					"id": "6987",
+					"key": "timeline_notification",
+					"value": "1593024581"
+				}, {
+					"id": "6978",
+					"key": "_wpas_skip_22486614",
+					"value": "1"
+				}, {
+					"id": "6979",
+					"key": "_wpas_skip_22491199",
+					"value": "1"
+				}],
+				"meta": {
+					"links": {
+						"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1478",
+						"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/posts\/1478\/help",
+						"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361",
+						"replies": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1478\/replies\/",
+						"likes": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1478\/likes\/"
+					},
+					"data": {
+						"site": {
+							"ID": 159889361,
+							"name": "Made 4 Testing",
+							"description": "boring tagline",
+							"URL": "http:\/\/made4testing0318.blog",
+							"capabilities": {
+								"edit_pages": true,
+								"edit_posts": true,
+								"edit_others_posts": true,
+								"edit_others_pages": true,
+								"delete_posts": true,
+								"delete_others_posts": true,
+								"edit_theme_options": true,
+								"edit_users": false,
+								"list_users": true,
+								"manage_categories": true,
+								"manage_options": true,
+								"moderate_comments": true,
+								"activate_wordads": false,
+								"promote_users": true,
+								"publish_posts": true,
+								"upload_files": true,
+								"delete_users": false,
+								"remove_users": true,
+								"view_hosting": true,
+								"view_stats": true
+							},
+							"jetpack": false,
+							"is_multisite": true,
+							"post_count": 236,
+							"subscribers_count": 16,
+							"locale": "en",
+							"icon": {
+								"img": "https:\/\/madefortesting190318.files.wordpress.com\/2019\/03\/image.jpg?w=96",
+								"ico": "https:\/\/madefortesting190318.files.wordpress.com\/2019\/03\/image.jpg?w=96",
+								"media_id": 12
+							},
+							"logo": {
+								"id": 0,
+								"sizes": [],
+								"url": ""
+							},
+							"visible": true,
+							"is_private": false,
+							"is_coming_soon": false,
+							"single_user_site": false,
+							"is_vip": false,
+							"is_following": true,
+							"options": {
+								"timezone": "Pacific\/Honolulu",
+								"gmt_offset": -10,
+								"blog_public": 0,
+								"videopress_enabled": true,
+								"upgraded_filetypes_enabled": true,
+								"login_url": "https:\/\/madefortesting190318.wordpress.com\/wp-login.php",
+								"admin_url": "https:\/\/madefortesting190318.wordpress.com\/wp-admin\/",
+								"is_mapped_domain": true,
+								"is_redirect": false,
+								"unmapped_url": "https:\/\/madefortesting190318.wordpress.com",
+								"featured_images_enabled": false,
+								"theme_slug": "pub\/twentytwenty",
+								"header_image": false,
+								"background_color": false,
+								"image_default_link_type": "none",
+								"image_thumbnail_width": 150,
+								"image_thumbnail_height": 150,
+								"image_thumbnail_crop": 0,
+								"image_medium_width": 300,
+								"image_medium_height": 300,
+								"image_large_width": 1024,
+								"image_large_height": 1024,
+								"permalink_structure": "\/%year%\/%monthnum%\/%day%\/%postname%\/",
+								"post_formats": [],
+								"default_post_format": "standard",
+								"default_category": 12,
+								"allowed_file_types": ["jpg", "jpeg", "png", "gif", "pdf", "doc", "ppt", "odt", "pptx", "docx", "pps", "ppsx", "xls", "xlsx", "key", "asc", "mp3", "m4a", "wav", "ogg", "zip", "ogv", "mp4", "m4v", "mov", "wmv", "avi", "mpg", "3gp", "3g2"],
+								"show_on_front": "posts",
+								"default_likes_enabled": true,
+								"default_sharing_status": true,
+								"default_comment_status": true,
+								"default_ping_status": true,
+								"software_version": "5.4.2",
+								"created_at": "2019-03-18T23:21:18+00:00",
+								"wordads": false,
+								"publicize_permanently_disabled": false,
+								"frame_nonce": "712cf7373b",
+								"jetpack_frame_nonce": "712cf7373b",
+								"headstart": false,
+								"headstart_is_fresh": false,
+								"ak_vp_bundle_enabled": null,
+								"advanced_seo_front_page_description": "",
+								"advanced_seo_title_formats": [],
+								"verification_services_codes": null,
+								"podcasting_archive": null,
+								"is_domain_only": false,
+								"is_automated_transfer": false,
+								"is_wpcom_atomic": false,
+								"is_wpcom_store": false,
+								"woocommerce_is_active": false,
+								"design_type": null,
+								"site_goals": null,
+								"site_segment": 4,
+								"import_engine": null,
+								"is_pending_plan": false,
+								"is_wpforteams_site": false,
+								"is_cloud_eligible": false
+							},
+							"plan": {
+								"product_id": 1003,
+								"product_slug": "value_bundle",
+								"product_name": "WordPress.com Premium",
+								"product_name_short": "Premium",
+								"expired": false,
+								"user_is_owner": false,
+								"is_free": false,
+								"features": {
+									"active": ["free-blog", "custom-domain", "space", "no-adverts\/no-adverts.php", "custom-design", "videopress", "unlimited_themes", "live_support", "private_whois", "simple-payments", "calendly", "opentable", "support", "wordads-jetpack"],
+									"available": {
+										"free-blog": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"space": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"support": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"custom-domain": ["personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"no-adverts\/no-adverts.php": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"custom-design": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"videopress": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"unlimited_themes": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"live_support": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"private_whois": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"premium-themes": ["business-bundle", "ecommerce-bundle", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"google-analytics": ["business-bundle", "ecommerce-bundle", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"simple-payments": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"calendly": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"opentable": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"]
+									}
+								}
+							},
+							"products": [],
+							"jetpack_modules": null,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/help",
+									"posts": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/posts\/",
+									"comments": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/comments\/",
+									"xmlrpc": "https:\/\/madefortesting190318.wordpress.com\/xmlrpc.php",
+									"site_icon": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/media\/12"
+								}
+							},
+							"quota": {
+								"space_allowed": 13958643712,
+								"space_used": 679620943,
+								"percent_used": 4.8688178953643035,
+								"space_available": 13279022769
+							},
+							"launch_status": false,
+							"site_migration": null,
+							"is_fse_active": false,
+							"is_fse_eligible": false,
+							"is_core_site_editor_enabled": false,
+							"is_white_glove": false
+						}
+					}
+				},
+				"capabilities": {
+					"publish_post": true,
+					"delete_post": true,
+					"edit_post": true
+				},
+				"other_URLs": {},
+				"pseudo_ID": "2f4d6df67b1a383ce11b06cbc00f436d",
+				"is_external": false,
+				"site_name": "Made 4 Testing",
+				"site_URL": "http:\/\/made4testing0318.blog",
+				"site_is_private": false,
+				"featured_media": {
+					"uri": "https:\/\/w.soundcloud.com\/player\/?url=https%3A%2F%2Fsoundcloud.com%2Fuser-670680461%2Fsets%2Fmoonlight-sonota&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false",
+					"type": "video"
+				},
+				"feed_ID": 96421692,
+				"feed_URL": "http:\/\/made4testing0318.blog",
+				"is_jetpack": false,
+				"use_excerpt": false,
+				"feed_item_ID": 2774627424,
+				"word_count": 11,
+				"is_following_conversation": false,
+				"is_seen": false
+			}
+		},
+		{
+			"type": "post",
+			"data": {
+				"ID": 1475,
+				"site_ID": 159889361,
+				"author": {
+					"ID": 154288761,
+					"login": "testuser0313",
+					"email": false,
+					"name": "Sally Sparrow",
+					"first_name": "Sally",
+					"last_name": "Sparrow",
+					"nice_name": "testuser0313",
+					"URL": "http:\/\/Example.org",
+					"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/18b70acbdcfcd560f4707a6e3485f298?s=96&d=identicon&r=G",
+					"profile_URL": "https:\/\/en.gravatar.com\/testuser0313",
+					"site_ID": 160502386,
+					"has_avatar": true
+				},
+				"date": "2020-06-24T18:46:25+00:00",
+				"modified": "2020-06-24T08:46:25-10:00",
+				"title": "Clair de Lune SoundCloud URL Paste",
+				"URL": "http:\/\/made4testing0318.blog\/2020\/06\/24\/clair-de-lune-soundcloud-url-paste\/",
+				"short_URL": "https:\/\/wp.me\/paOSwF-nN",
+				"content": "\n<figure class=\"wp-block-embed-soundcloud wp-block-embed is-type-rich wp-embed-aspect-1-1 wp-has-aspect-ratio\"><div class=\"wp-block-embed__wrapper\">\n<div class=\"embed-soundcloud\"><iframe data-wpcom-embed-url=\"https:\/\/soundcloud.com\/claude-debussy\/clair-de-lune\" title=\"Clair de Lune by Claude Debussy\" width=\"500\" height=\"400\" scrolling=\"no\" frameborder=\"no\" src=\"https:\/\/w.soundcloud.com\/player\/?visual=true&#038;url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F43782479&#038;show_artwork=true&#038;maxwidth=500&#038;maxheight=750&#038;dnt=1\"><\/iframe><\/div>\n<\/div><\/figure>\n\n\n\n<p>See <a href=\"https:\/\/wordpress.com\/support\/soundcloud-audio-player\/\">https:\/\/wordpress.com\/support\/soundcloud-audio-player\/<\/a>.<\/p>\n",
+				"excerpt": "<p>See <a href=\"https:\/\/wordpress.com\/support\/soundcloud-audio-player\/\" rel=\"nofollow\">https:\/\/wordpress.com\/support\/soundcloud-audio-player\/<\/a>.<\/p>\n",
+				"slug": "clair-de-lune-soundcloud-url-paste",
+				"guid": "http:\/\/made4testing0318.blog\/?p=1475",
+				"status": "publish",
+				"sticky": false,
+				"password": "",
+				"parent": false,
+				"type": "post",
+				"discussion": {
+					"comments_open": true,
+					"comment_status": "open",
+					"pings_open": true,
+					"ping_status": "open",
+					"comment_count": 0
+				},
+				"likes_enabled": true,
+				"sharing_enabled": true,
+				"like_count": 0,
+				"i_like": false,
+				"is_reblogged": false,
+				"is_following": true,
+				"global_ID": "d2274c9bb5fc683ae8ff32400e751152",
+				"featured_image": "",
+				"post_thumbnail": null,
+				"format": "standard",
+				"geo": false,
+				"menu_order": 0,
+				"page_template": "",
+				"publicize_URLs": [],
+				"terms": {
+					"category": {
+						"Testing": {
+							"ID": 12,
+							"name": "Testing",
+							"slug": "testing",
+							"description": "",
+							"post_count": 11,
+							"parent": 0,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/categories\/slug:testing",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/categories\/slug:testing\/help",
+									"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361"
+								}
+							}
+						}
+					},
+					"post_tag": {},
+					"post_format": {},
+					"mentions": {}
+				},
+				"tags": [],
+				"categories": {
+					"Testing": {
+						"ID": 12,
+						"name": "Testing",
+						"slug": "testing",
+						"description": "",
+						"post_count": 11,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/categories\/slug:testing",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/categories\/slug:testing\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361"
+							}
+						}
+					}
+				},
+				"attachments": {},
+				"attachment_count": 0,
+				"metadata": [{
+					"id": "6968",
+					"key": "email_notification",
+					"value": "1593024388"
+				}, {
+					"id": "6959",
+					"key": "jabber_published",
+					"value": "1593024386"
+				}, {
+					"id": "6965",
+					"key": "timeline_notification",
+					"value": "1593024387"
+				}, {
+					"id": "6956",
+					"key": "_wpas_skip_22486614",
+					"value": "1"
+				}, {
+					"id": "6957",
+					"key": "_wpas_skip_22491199",
+					"value": "1"
+				}],
+				"meta": {
+					"links": {
+						"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1475",
+						"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/posts\/1475\/help",
+						"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361",
+						"replies": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1475\/replies\/",
+						"likes": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1475\/likes\/"
+					},
+					"data": {
+						"site": {
+							"ID": 159889361,
+							"name": "Made 4 Testing",
+							"description": "boring tagline",
+							"URL": "http:\/\/made4testing0318.blog",
+							"capabilities": {
+								"edit_pages": true,
+								"edit_posts": true,
+								"edit_others_posts": true,
+								"edit_others_pages": true,
+								"delete_posts": true,
+								"delete_others_posts": true,
+								"edit_theme_options": true,
+								"edit_users": false,
+								"list_users": true,
+								"manage_categories": true,
+								"manage_options": true,
+								"moderate_comments": true,
+								"activate_wordads": false,
+								"promote_users": true,
+								"publish_posts": true,
+								"upload_files": true,
+								"delete_users": false,
+								"remove_users": true,
+								"view_hosting": true,
+								"view_stats": true
+							},
+							"jetpack": false,
+							"is_multisite": true,
+							"post_count": 236,
+							"subscribers_count": 16,
+							"locale": "en",
+							"icon": {
+								"img": "https:\/\/madefortesting190318.files.wordpress.com\/2019\/03\/image.jpg?w=96",
+								"ico": "https:\/\/madefortesting190318.files.wordpress.com\/2019\/03\/image.jpg?w=96",
+								"media_id": 12
+							},
+							"logo": {
+								"id": 0,
+								"sizes": [],
+								"url": ""
+							},
+							"visible": true,
+							"is_private": false,
+							"is_coming_soon": false,
+							"single_user_site": false,
+							"is_vip": false,
+							"is_following": true,
+							"options": {
+								"timezone": "Pacific\/Honolulu",
+								"gmt_offset": -10,
+								"blog_public": 0,
+								"videopress_enabled": true,
+								"upgraded_filetypes_enabled": true,
+								"login_url": "https:\/\/madefortesting190318.wordpress.com\/wp-login.php",
+								"admin_url": "https:\/\/madefortesting190318.wordpress.com\/wp-admin\/",
+								"is_mapped_domain": true,
+								"is_redirect": false,
+								"unmapped_url": "https:\/\/madefortesting190318.wordpress.com",
+								"featured_images_enabled": false,
+								"theme_slug": "pub\/twentytwenty",
+								"header_image": false,
+								"background_color": false,
+								"image_default_link_type": "none",
+								"image_thumbnail_width": 150,
+								"image_thumbnail_height": 150,
+								"image_thumbnail_crop": 0,
+								"image_medium_width": 300,
+								"image_medium_height": 300,
+								"image_large_width": 1024,
+								"image_large_height": 1024,
+								"permalink_structure": "\/%year%\/%monthnum%\/%day%\/%postname%\/",
+								"post_formats": [],
+								"default_post_format": "standard",
+								"default_category": 12,
+								"allowed_file_types": ["jpg", "jpeg", "png", "gif", "pdf", "doc", "ppt", "odt", "pptx", "docx", "pps", "ppsx", "xls", "xlsx", "key", "asc", "mp3", "m4a", "wav", "ogg", "zip", "ogv", "mp4", "m4v", "mov", "wmv", "avi", "mpg", "3gp", "3g2"],
+								"show_on_front": "posts",
+								"default_likes_enabled": true,
+								"default_sharing_status": true,
+								"default_comment_status": true,
+								"default_ping_status": true,
+								"software_version": "5.4.2",
+								"created_at": "2019-03-18T23:21:18+00:00",
+								"wordads": false,
+								"publicize_permanently_disabled": false,
+								"frame_nonce": "712cf7373b",
+								"jetpack_frame_nonce": "712cf7373b",
+								"headstart": false,
+								"headstart_is_fresh": false,
+								"ak_vp_bundle_enabled": null,
+								"advanced_seo_front_page_description": "",
+								"advanced_seo_title_formats": [],
+								"verification_services_codes": null,
+								"podcasting_archive": null,
+								"is_domain_only": false,
+								"is_automated_transfer": false,
+								"is_wpcom_atomic": false,
+								"is_wpcom_store": false,
+								"woocommerce_is_active": false,
+								"design_type": null,
+								"site_goals": null,
+								"site_segment": 4,
+								"import_engine": null,
+								"is_pending_plan": false,
+								"is_wpforteams_site": false,
+								"is_cloud_eligible": false
+							},
+							"plan": {
+								"product_id": 1003,
+								"product_slug": "value_bundle",
+								"product_name": "WordPress.com Premium",
+								"product_name_short": "Premium",
+								"expired": false,
+								"user_is_owner": false,
+								"is_free": false,
+								"features": {
+									"active": ["free-blog", "custom-domain", "space", "no-adverts\/no-adverts.php", "custom-design", "videopress", "unlimited_themes", "live_support", "private_whois", "simple-payments", "calendly", "opentable", "support", "wordads-jetpack"],
+									"available": {
+										"free-blog": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"space": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"support": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"custom-domain": ["personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"no-adverts\/no-adverts.php": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"custom-design": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"videopress": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"unlimited_themes": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"live_support": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"private_whois": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"premium-themes": ["business-bundle", "ecommerce-bundle", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"google-analytics": ["business-bundle", "ecommerce-bundle", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"simple-payments": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"calendly": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"opentable": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"]
+									}
+								}
+							},
+							"products": [],
+							"jetpack_modules": null,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/help",
+									"posts": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/posts\/",
+									"comments": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/comments\/",
+									"xmlrpc": "https:\/\/madefortesting190318.wordpress.com\/xmlrpc.php",
+									"site_icon": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/media\/12"
+								}
+							},
+							"quota": {
+								"space_allowed": 13958643712,
+								"space_used": 679620943,
+								"percent_used": 4.8688178953643035,
+								"space_available": 13279022769
+							},
+							"launch_status": false,
+							"site_migration": null,
+							"is_fse_active": false,
+							"is_fse_eligible": false,
+							"is_core_site_editor_enabled": false,
+							"is_white_glove": false
+						}
+					}
+				},
+				"capabilities": {
+					"publish_post": true,
+					"delete_post": true,
+					"edit_post": true
+				},
+				"other_URLs": {},
+				"pseudo_ID": "d2274c9bb5fc683ae8ff32400e751152",
+				"is_external": false,
+				"site_name": "Made 4 Testing",
+				"site_URL": "http:\/\/made4testing0318.blog",
+				"site_is_private": false,
+				"featured_media": {
+					"uri": "https:\/\/w.soundcloud.com\/player\/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F43782479&show_artwork=true&maxwidth=500&maxheight=750&dnt=1",
+					"type": "video"
+				},
+				"feed_ID": 96421692,
+				"feed_URL": "http:\/\/made4testing0318.blog",
+				"is_jetpack": false,
+				"use_excerpt": false,
+				"feed_item_ID": 2774623955,
+				"word_count": 6,
+				"is_following_conversation": false,
+				"is_seen": false
+			}
+		},
+		{
+			"type": "post",
+			"data": {
+				"ID": 1471,
+				"site_ID": 159889361,
+				"author": {
+					"ID": 154288761,
+					"login": "testuser0313",
+					"email": false,
+					"name": "Sally Sparrow",
+					"first_name": "Sally",
+					"last_name": "Sparrow",
+					"nice_name": "testuser0313",
+					"URL": "http:\/\/Example.org",
+					"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/18b70acbdcfcd560f4707a6e3485f298?s=96&d=identicon&r=G",
+					"profile_URL": "https:\/\/en.gravatar.com\/testuser0313",
+					"site_ID": 160502386,
+					"has_avatar": true
+				},
+				"date": "2020-06-24T18:36:32+00:00",
+				"modified": "2020-06-24T08:36:32-10:00",
+				"title": "SoundCloud Audio Player",
+				"URL": "http:\/\/made4testing0318.blog\/2020\/06\/24\/soundcloud-audio-player\/",
+				"short_URL": "https:\/\/wp.me\/paOSwF-nJ",
+				"content": "\n<p>See instructions at <a href=\"https:\/\/wordpress.com\/support\/soundcloud-audio-player\/\" rel=\"nofollow\">https:\/\/wordpress.com\/support\/soundcloud-audio-player\/<\/a>.<\/p>\n\n\n\n<figure class=\"wp-block-embed-soundcloud wp-block-embed is-type-rich wp-embed-aspect-1-1 wp-has-aspect-ratio\"><div class=\"wp-block-embed__wrapper\">\n<div class=\"embed-soundcloud\"><iframe data-wpcom-embed-url=\"https:\/\/soundcloud.com\/temumusic\/boogaloo-blues\" title=\"Boogaloo Blues by Temu Music\" width=\"500\" height=\"400\" scrolling=\"no\" frameborder=\"no\" src=\"https:\/\/w.soundcloud.com\/player\/?visual=true&#038;url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F148719689&#038;show_artwork=true&#038;maxwidth=500&#038;maxheight=750&#038;dnt=1\"><\/iframe><\/div>\n<\/div><\/figure>\n\n\n\n<p>I pasted the <a href=\"https:\/\/soundcloud.com\/temumusic\/boogaloo-blues\"><code>https:\/\/soundcloud.com\/temumusic\/boogaloo-blues<\/code><\/a> link above to embed it, and below I did the shortcode route.<\/p>\n\n\n<iframe width=\"100%\" height=\"166\" scrolling=\"no\" frameborder=\"no\" src=\"https:\/\/w.soundcloud.com\/player\/?url=https%3A%2F%2Fsoundcloud.com%2Ftemumusic%2Fboogaloo-blues&width=false&height=false&auto_play=false&hide_related=false&visual=false&show_comments=false&color=false&show_user=false&show_reposts=false\"><\/iframe>\n",
+				"excerpt": "<p>See instructions at <a href=\"https:\/\/wordpress.com\/support\/soundcloud-audio-player\/\" rel=\"nofollow\">https:\/\/wordpress.com\/support\/soundcloud-audio-player\/<\/a>. I pasted the <a href=\"https:\/\/soundcloud.com\/temumusic\/boogaloo-blues\" rel=\"nofollow\">https:\/\/soundcloud.com\/temumusic\/boogaloo-blues<\/a> link above to embed it, and below I did the shortcode route.<\/p>\n",
+				"slug": "soundcloud-audio-player",
+				"guid": "http:\/\/made4testing0318.blog\/?p=1471",
+				"status": "publish",
+				"sticky": false,
+				"password": "",
+				"parent": false,
+				"type": "post",
+				"discussion": {
+					"comments_open": true,
+					"comment_status": "open",
+					"pings_open": true,
+					"ping_status": "open",
+					"comment_count": 0
+				},
+				"likes_enabled": true,
+				"sharing_enabled": true,
+				"like_count": 0,
+				"i_like": false,
+				"is_reblogged": false,
+				"is_following": true,
+				"global_ID": "21247cfedd2a16d6c7c1eb0910905778",
+				"featured_image": "",
+				"post_thumbnail": null,
+				"format": "standard",
+				"geo": false,
+				"menu_order": 0,
+				"page_template": "",
+				"publicize_URLs": [],
+				"terms": {
+					"category": {
+						"Testing": {
+							"ID": 12,
+							"name": "Testing",
+							"slug": "testing",
+							"description": "",
+							"post_count": 11,
+							"parent": 0,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/categories\/slug:testing",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/categories\/slug:testing\/help",
+									"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361"
+								}
+							}
+						}
+					},
+					"post_tag": {},
+					"post_format": {},
+					"mentions": {}
+				},
+				"tags": [],
+				"categories": {
+					"Testing": {
+						"ID": 12,
+						"name": "Testing",
+						"slug": "testing",
+						"description": "",
+						"post_count": 11,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/categories\/slug:testing",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/categories\/slug:testing\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361"
+							}
+						}
+					}
+				},
+				"attachments": {},
+				"attachment_count": 0,
+				"metadata": [{
+					"id": "6941",
+					"key": "email_notification",
+					"value": "1593023795"
+				}, {
+					"id": "6934",
+					"key": "jabber_published",
+					"value": "1593023793"
+				}, {
+					"id": "6939",
+					"key": "timeline_notification",
+					"value": "1593023795"
+				}, {
+					"id": "6931",
+					"key": "_wpas_skip_22486614",
+					"value": "1"
+				}, {
+					"id": "6932",
+					"key": "_wpas_skip_22491199",
+					"value": "1"
+				}],
+				"meta": {
+					"links": {
+						"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1471",
+						"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/posts\/1471\/help",
+						"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361",
+						"replies": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1471\/replies\/",
+						"likes": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/posts\/1471\/likes\/"
+					},
+					"data": {
+						"site": {
+							"ID": 159889361,
+							"name": "Made 4 Testing",
+							"description": "boring tagline",
+							"URL": "http:\/\/made4testing0318.blog",
+							"capabilities": {
+								"edit_pages": true,
+								"edit_posts": true,
+								"edit_others_posts": true,
+								"edit_others_pages": true,
+								"delete_posts": true,
+								"delete_others_posts": true,
+								"edit_theme_options": true,
+								"edit_users": false,
+								"list_users": true,
+								"manage_categories": true,
+								"manage_options": true,
+								"moderate_comments": true,
+								"activate_wordads": false,
+								"promote_users": true,
+								"publish_posts": true,
+								"upload_files": true,
+								"delete_users": false,
+								"remove_users": true,
+								"view_hosting": true,
+								"view_stats": true
+							},
+							"jetpack": false,
+							"is_multisite": true,
+							"post_count": 236,
+							"subscribers_count": 16,
+							"locale": "en",
+							"icon": {
+								"img": "https:\/\/madefortesting190318.files.wordpress.com\/2019\/03\/image.jpg?w=96",
+								"ico": "https:\/\/madefortesting190318.files.wordpress.com\/2019\/03\/image.jpg?w=96",
+								"media_id": 12
+							},
+							"logo": {
+								"id": 0,
+								"sizes": [],
+								"url": ""
+							},
+							"visible": true,
+							"is_private": false,
+							"is_coming_soon": false,
+							"single_user_site": false,
+							"is_vip": false,
+							"is_following": true,
+							"options": {
+								"timezone": "Pacific\/Honolulu",
+								"gmt_offset": -10,
+								"blog_public": 0,
+								"videopress_enabled": true,
+								"upgraded_filetypes_enabled": true,
+								"login_url": "https:\/\/madefortesting190318.wordpress.com\/wp-login.php",
+								"admin_url": "https:\/\/madefortesting190318.wordpress.com\/wp-admin\/",
+								"is_mapped_domain": true,
+								"is_redirect": false,
+								"unmapped_url": "https:\/\/madefortesting190318.wordpress.com",
+								"featured_images_enabled": false,
+								"theme_slug": "pub\/twentytwenty",
+								"header_image": false,
+								"background_color": false,
+								"image_default_link_type": "none",
+								"image_thumbnail_width": 150,
+								"image_thumbnail_height": 150,
+								"image_thumbnail_crop": 0,
+								"image_medium_width": 300,
+								"image_medium_height": 300,
+								"image_large_width": 1024,
+								"image_large_height": 1024,
+								"permalink_structure": "\/%year%\/%monthnum%\/%day%\/%postname%\/",
+								"post_formats": [],
+								"default_post_format": "standard",
+								"default_category": 12,
+								"allowed_file_types": ["jpg", "jpeg", "png", "gif", "pdf", "doc", "ppt", "odt", "pptx", "docx", "pps", "ppsx", "xls", "xlsx", "key", "asc", "mp3", "m4a", "wav", "ogg", "zip", "ogv", "mp4", "m4v", "mov", "wmv", "avi", "mpg", "3gp", "3g2"],
+								"show_on_front": "posts",
+								"default_likes_enabled": true,
+								"default_sharing_status": true,
+								"default_comment_status": true,
+								"default_ping_status": true,
+								"software_version": "5.4.2",
+								"created_at": "2019-03-18T23:21:18+00:00",
+								"wordads": false,
+								"publicize_permanently_disabled": false,
+								"frame_nonce": "712cf7373b",
+								"jetpack_frame_nonce": "712cf7373b",
+								"headstart": false,
+								"headstart_is_fresh": false,
+								"ak_vp_bundle_enabled": null,
+								"advanced_seo_front_page_description": "",
+								"advanced_seo_title_formats": [],
+								"verification_services_codes": null,
+								"podcasting_archive": null,
+								"is_domain_only": false,
+								"is_automated_transfer": false,
+								"is_wpcom_atomic": false,
+								"is_wpcom_store": false,
+								"woocommerce_is_active": false,
+								"design_type": null,
+								"site_goals": null,
+								"site_segment": 4,
+								"import_engine": null,
+								"is_pending_plan": false,
+								"is_wpforteams_site": false,
+								"is_cloud_eligible": false
+							},
+							"plan": {
+								"product_id": 1003,
+								"product_slug": "value_bundle",
+								"product_name": "WordPress.com Premium",
+								"product_name_short": "Premium",
+								"expired": false,
+								"user_is_owner": false,
+								"is_free": false,
+								"features": {
+									"active": ["free-blog", "custom-domain", "space", "no-adverts\/no-adverts.php", "custom-design", "videopress", "unlimited_themes", "live_support", "private_whois", "simple-payments", "calendly", "opentable", "support", "wordads-jetpack"],
+									"available": {
+										"free-blog": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"space": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"support": ["free_plan", "personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"custom-domain": ["personal-bundle", "business-bundle", "ecommerce-bundle", "personal-bundle-2y", "value_bundle-2y", "business-bundle-2y", "blogger-bundle", "blogger-bundle-2y", "ecommerce-bundle-2y"],
+										"no-adverts\/no-adverts.php": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"custom-design": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"videopress": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"unlimited_themes": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"live_support": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"private_whois": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"premium-themes": ["business-bundle", "ecommerce-bundle", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"google-analytics": ["business-bundle", "ecommerce-bundle", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"simple-payments": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"calendly": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"],
+										"opentable": ["business-bundle", "ecommerce-bundle", "value_bundle-2y", "business-bundle-2y", "ecommerce-bundle-2y"]
+									}
+								}
+							},
+							"products": [],
+							"jetpack_modules": null,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/help",
+									"posts": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/posts\/",
+									"comments": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/159889361\/comments\/",
+									"xmlrpc": "https:\/\/madefortesting190318.wordpress.com\/xmlrpc.php",
+									"site_icon": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/159889361\/media\/12"
+								}
+							},
+							"quota": {
+								"space_allowed": 13958643712,
+								"space_used": 679620943,
+								"percent_used": 4.8688178953643035,
+								"space_available": 13279022769
+							},
+							"launch_status": false,
+							"site_migration": null,
+							"is_fse_active": false,
+							"is_fse_eligible": false,
+							"is_core_site_editor_enabled": false,
+							"is_white_glove": false
+						}
+					}
+				},
+				"capabilities": {
+					"publish_post": true,
+					"delete_post": true,
+					"edit_post": true
+				},
+				"other_URLs": {},
+				"pseudo_ID": "21247cfedd2a16d6c7c1eb0910905778",
+				"is_external": false,
+				"site_name": "Made 4 Testing",
+				"site_URL": "http:\/\/made4testing0318.blog",
+				"site_is_private": false,
+				"featured_media": {
+					"uri": "https:\/\/w.soundcloud.com\/player\/?visual=true&url=https%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F148719689&show_artwork=true&maxwidth=500&maxheight=750&dnt=1",
+					"type": "video"
+				},
+				"feed_ID": 96421692,
+				"feed_URL": "http:\/\/made4testing0318.blog",
+				"is_jetpack": false,
+				"use_excerpt": false,
+				"feed_item_ID": 2774613104,
+				"word_count": 28,
+				"is_following_conversation": false,
+				"is_seen": false
+			}
+		},
+		{
+			"type": "post",
+			"data": {
+				"ID": 2004973,
+				"author": {
+					"ID": 133574364,
+					"login": "mfoster724",
+					"email": false,
+					"name": "Marquise Foster",
+					"first_name": "",
+					"last_name": "",
+					"nice_name": "marquise-foster",
+					"URL": "",
+					"avatar_URL": "https:\/\/2.gravatar.com\/avatar\/ba4ca0fe0f7354b6e4c98feb74995c8b?s=96&d=identicon&r=G",
+					"profile_URL": "https:\/\/en.gravatar.com\/ba4ca0fe0f7354b6e4c98feb74995c8b",
+					"site_ID": -1,
+					"has_avatar": true
+				},
+				"date": "2020-06-24T18:14:04+00:00",
+				"modified": "2020-06-24T18:14:04+00:00",
+				"title": "Register for next week&rsquo;s Pitches &amp; Pitchers session",
+				"URL": "https:\/\/techcrunch.com\/2020\/06\/24\/register-for-next-weeks-pitches-pitchers-session\/",
+				"short_URL": "https:\/\/techcrunch.com\/2020\/06\/24\/register-for-next-weeks-pitches-pitchers-session\/",
+				"content": "<p id=\"speakable-summary\">Does your elevator pitch lack traction? Could it do with a serious makeover? We&rsquo;re here to help. Tune into Pitchers &amp; Pitches, an interactive pitch-off and feedback session, on July 1 at 4pm ET \/ 1pm PT. This event is 100% free &mdash; simply <a href=\"https:\/\/events.bizzabo.com\/226397\">register here<\/a> to attend.<\/p>\n<p>Pitchers &amp; Pitches &mdash; part pitch-off, part masterclass &mdash; features startups (all exhibitors in Digital Startup Alley during Disrupt 2020) delivering their best 60-second pitch to a panel of judges. The panel for this session consists of two TechCrunch editors &mdash; Jordan Crook and Kirsten Korosec &mdash; and two VCs &mdash; <a href=\"https:\/\/betaworksventures.com\/matthewhartman\">Matthew Hartman<\/a> of Betaworks Ventures and <a href=\"https:\/\/www.nea.com\/team\/dayna-grayson\">Dayna Grayson<\/a> of Construct Capital.<\/p>\n<p>The panel will critique each presentation, offer advice and suggest ways to forge a pitch for the ages. Take their tips, adapt them your specific situation and get ready super charge your elevator pitch.<\/p><div class=\"piano-inline-promo\"><\/div>\n<p><strong>Note<\/strong>: The Pitchers &amp; Pitches webinar series is free and open to all, but only companies that purchased a&nbsp;<a href=\"https:\/\/techcrunch.com\/events\/disrupt-sf-2020\/startup-alley\/?utm_medium=marketingpost&amp;utm_campaign=disruptsf202&amp;utm_content=pitcherspitches&amp;utm_source=tc&amp;promo=6920digitalsua&amp;display=\">Disrupt Digital Startup Alley Package<\/a> are eligible to pitch. We randomly chose these startups to compete on July 1st:<\/p>\n<p dir=\"ltr\"><a href=\"http:\/\/www.cognidna.com\/\">Cognidna<\/a> &ndash; provides DNA insights on cognitive traits, helping parents make more informed educational decisions for their children.<\/p>\n<p dir=\"ltr\"><a href=\"http:\/\/munch.cloud\/\">Munch<\/a> &ndash;<span data-sheets-userformat='{\"2\":6592,\"9\":1,\"10\":2,\"11\":4,\"14\":{\"1\":2,\"2\":0},\"15\":\"Arial\"}' data-sheets-value='{\"1\":2,\"2\":\"Our product, Munch, is a digital platform for restaurants that creates better customer experiences.\"}'> a digital platform for restaurants designed to create better customer experiences.<\/span><\/p>\n<p dir=\"ltr\"><a href=\"http:\/\/www.flexlane.co\/\">Flexlane<\/a> &ndash; an<span data-sheets-userformat='{\"2\":6592,\"9\":1,\"10\":2,\"11\":4,\"14\":{\"1\":2,\"2\":0},\"15\":\"Arial\"}' data-sheets-value='{\"1\":2,\"2\":\"Flexlane is an online wholesale marketplace that transforms the way local retailers in Asia buy for their stores. We combine machine learning and actual human expertise to connect local retailers with the most relevant brands of products that we guarantee will deliver sales and profits. \"}'>&nbsp;online wholesale marketplace that transforms the way local retailers in Asia buy for their stores.<\/span><\/p>\n<p dir=\"ltr\"><a href=\"http:\/\/www.bitsensing.com\/\">Bitsensing<\/a> &ndash; aims to design future safety in the era of Autonomous Vehicles.<\/p>\n<p>What&rsquo;s a pitch-off without a prize? One pitching startup will win a consulting session with <a href=\"https:\/\/www.cela.nyc\/\">cela. cela <\/a>connects early-stage startups to accelerators and incubators that can help them scale their businesses.<\/p>\n<p>And while the judges evaluate and provide feedback, it&rsquo;s the virtual audience (i.e., you) who determines the ultimate winner. That said, everyone who attends the event comes away with a stronger pitch and stands a greater chance of catching investor attention. Win-win.<\/p>\n<p>Keep your startup focused and on track. <a href=\"https:\/\/events.bizzabo.com\/226397\">Register for Pitches &amp; Pitchers<\/a> and join us next week, July 1 at 4pm ET \/ 1pm PT. If you want to be eligible to pitch your startup at Pitchers and Pitches<a href=\"https:\/\/techcrunch.com\/events\/disrupt-sf-2020\/startup-alley\/?utm_medium=&amp;utm_campaign=disruptsf2020&amp;utm_content=digitalstartupalley&amp;utm_source=tc&amp;promo=&amp;display=\">, purchase your Digital Startup Alley ticket<\/a> and opt in to being considered for our fourth installment of Pitchers and Pitches.<\/p>\n<p><em>Is your company interested in sponsoring or exhibiting at Disrupt 2020? Contact our sponsorship sales team by <a href=\"http:\/\/info.techcrunch.com\/SponsorshipsInterest.html?_ga=2.199846766.1929214232.1592341823-985484541.1566312242&amp;_gac=1.149571396.1592244932.CjwKCAjw5Ij2BRBdEiwA0Frc9YR31jc15Yzq_XjjX3a2eTrCt1FxCR6kTHNfe8adKhqIHGVbkQ4nIRoC4hcQAvD_BwE\">filling out this form<\/a>.<\/em><\/p>",
+				"excerpt": "Does your elevator pitch lack traction? Could it do with a serious makeover? We&rsquo;re here to help. Tune into Pitchers &amp; Pitches, an interactive pitch-off and feedback session, on July 1 at 4pm ET \/ 1pm PT. This event is 100% free &mdash; simply register here to attend. Pitchers &amp; Pitches &mdash; part pitch-off, part&hellip;",
+				"slug": "",
+				"status": "",
+				"password": "",
+				"parent": false,
+				"type": "",
+				"discussion": {
+					"comments_open": false,
+					"comment_status": "closed",
+					"pings_open": false,
+					"ping_status": "closed",
+					"comment_count": 0
+				},
+				"like_count": 0,
+				"i_like": false,
+				"is_reblogged": false,
+				"is_following": true,
+				"featured_image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/27265907143_731d2babf1_o.jpg",
+				"format": "standard",
+				"geo": false,
+				"publicize_URLs": {},
+				"tags": {
+					"Disrupt 2020": {
+						"ID": 576771694,
+						"name": "Disrupt 2020",
+						"slug": "disrupt-2020",
+						"description": "",
+						"post_count": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/tags\/slug:disrupt-2020",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/tags\/slug:disrupt-2020\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						},
+						"display_name": "disrupt-2020"
+					}
+				},
+				"categories": {
+					"Startups": {
+						"ID": 20429,
+						"name": "Startups",
+						"slug": "startups",
+						"description": "The newest companies that could change the world",
+						"post_count": 21566,
+						"parent": 0,
+						"meta": {
+							"links": {
+								"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/categories\/slug:startups",
+								"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/categories\/slug:startups\/help",
+								"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444"
+							}
+						}
+					}
+				},
+				"attachments": {},
+				"metadata": false,
+				"meta": {
+					"links": {
+						"feed": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577\/",
+						"site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/read\/sites\/136296444",
+						"amp": "https:\/\/techcrunch.com\/2020\/06\/24\/register-for-next-weeks-pitches-pitchers-session\/amp\/"
+					},
+					"data": {
+						"feed": {
+							"blog_ID": "136296444",
+							"feed_ID": "80112577",
+							"name": "TechCrunch",
+							"URL": "https:\/\/techcrunch.com\/",
+							"feed_URL": "http:\/\/techcrunch.com",
+							"subscribers_count": 41583,
+							"is_following": true,
+							"last_update": "2020-06-24T19:00:04+00:00",
+							"last_checked": "2020-06-24T19:17:08+00:00",
+							"marked_for_refresh": false,
+							"next_refresh_time": null,
+							"organization_id": 0,
+							"unseen_count": 0,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/feed\/80112577",
+									"site": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/read\/sites\/136296444"
+								}
+							},
+							"resolved_feed_url": "https:\/\/techcrunch.com\/",
+							"image": "https:\/\/techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=32",
+							"description": "Startup and Technology News"
+						},
+						"site": {
+							"ID": 136296444,
+							"name": "TechCrunch",
+							"description": "Startup and Technology News",
+							"URL": "https:\/\/techcrunch.com",
+							"jetpack": true,
+							"post_count": 150193,
+							"subscribers_count": 41583,
+							"locale": "en-US",
+							"icon": {
+								"img": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png",
+								"ico": "https:\/\/beta.techcrunch.com\/wp-content\/uploads\/2015\/02\/cropped-cropped-favicon-gradient.png?w=16"
+							},
+							"logo": {
+								"id": 0,
+								"sizes": [],
+								"url": ""
+							},
+							"visible": true,
+							"is_private": false,
+							"is_coming_soon": false,
+							"is_following": true,
+							"meta": {
+								"links": {
+									"self": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444",
+									"help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/help",
+									"posts": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/136296444\/posts\/",
+									"comments": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/136296444\/comments\/",
+									"xmlrpc": "https:\/\/techcrunch.com\/xmlrpc.php"
+								}
+							},
+							"launch_status": false,
+							"site_migration": null,
+							"is_fse_active": false,
+							"is_fse_eligible": false,
+							"is_core_site_editor_enabled": false,
+							"capabilities": {
+								"edit_pages": false,
+								"edit_posts": false,
+								"edit_others_posts": false,
+								"edit_theme_options": false,
+								"list_users": false,
+								"manage_categories": false,
+								"manage_options": false,
+								"publish_posts": false,
+								"upload_files": false,
+								"view_stats": false
+							},
+							"is_multi_author": true,
+							"feed_ID": 80112577,
+							"feed_URL": "http:\/\/techcrunch.com",
+							"prefer_feed": true,
+							"header_image": false,
+							"owner": {
+								"ID": 22573739,
+								"login": "wpcomvip",
+								"name": "WordPress.com VIP",
+								"first_name": "WordPress.com VIP",
+								"last_name": "",
+								"nice_name": "wpcomvip",
+								"URL": "https:\/\/vip.wordpress.com",
+								"avatar_URL": "https:\/\/1.gravatar.com\/avatar\/dcd97d06942b5bcff00f77699961700e?s=96&d=identicon&r=G",
+								"profile_URL": "https:\/\/en.gravatar.com\/wpcomvip",
+								"ip_address": false,
+								"site_visible": false,
+								"has_avatar": true
+							},
+							"subscription": {
+								"delivery_methods": {
+									"email": null,
+									"notification": {
+										"send_posts": true
+									}
+								}
+							},
+							"is_blocked": false,
+							"organization_id": 0,
+							"unseen_count": 0
+						}
+					}
+				},
+				"word_count": 386,
+				"pseudo_ID": "f7781d0a18ff46d584bb45131e1864cf",
+				"global_ID": "f7781d0a18ff46d584bb45131e1864cf",
+				"site_ID": 136296444,
+				"site_name": "TechCrunch",
+				"site_URL": "https:\/\/techcrunch.com\/",
+				"site_is_private": false,
+				"featured_media": {},
+				"is_external": false,
+				"is_jetpack": true,
+				"likes_enabled": false,
+				"is_following_conversation": false,
+				"post_thumbnail": {
+					"ID": 2006810,
+					"URL": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/27265907143_731d2babf1_o.jpg",
+					"guid": "https:\/\/techcrunch.com\/wp-content\/uploads\/2020\/06\/27265907143_731d2babf1_o.jpg",
+					"mime_type": "image\/jpeg",
+					"width": 5760,
+					"height": 3840
+				},
+				"capabilities": {
+					"publish_post": false,
+					"delete_post": false,
+					"edit_post": false
+				},
+				"reblogs_enabled": false,
+				"use_excerpt": false,
+				"feed_ID": 80112577,
+				"feed_URL": "http:\/\/techcrunch.com",
+				"feed_item_ID": 2774589069,
+				"is_seen": false
+			}
+		}
+	]
+}

--- a/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
@@ -40,6 +40,22 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
+    // All cards have the correct type
+    //
+    func testReturnCorrectCardType() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("read/tags/cards?tags%5B%5D=cats", filename: "reader-cards-success.json", contentType: .ApplicationJSON)
+
+        readerPostServiceRemote.fetchCards(for: ["cats"], success: { cards in
+            let postTypes = cards.map { $0.type }
+            let expectedPostTypes: [RemoteReaderCard.CardType] = [.interests, .unknown, .post, .post, .post, .post, .post, .post, .post, .post]
+            XCTAssertTrue(postTypes == expectedPostTypes)
+            expect.fulfill()
+        }, failure: { _ in })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
     // Calls the failure block when an error happens
     //
     func testReturnError() {

--- a/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
@@ -20,7 +20,7 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
         readerPostServiceRemote.fetchCards(for: ["dogs"], success: { cards in
             XCTAssertTrue(cards.count == 10)
             expect.fulfill()
-        })
+        }, failure: { _ in })
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -34,6 +34,20 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
         readerPostServiceRemote.fetchCards(for: ["cats"], success: { cards in
             let postCards = cards.filter { $0.type == .post }
             XCTAssertTrue(postCards.allSatisfy { $0.post != nil })
+            expect.fulfill()
+        }, failure: { _ in })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    // Calls the failure block when an error happens
+    //
+    func testReturnError() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("read/tags/cards?tags%5B%5D=cats", filename: "reader-cards-success.json", contentType: .ApplicationJSON, status: 503)
+
+        readerPostServiceRemote.fetchCards(for: ["cats"], success: { _ in }, failure: { error in
+            XCTAssertNotNil(error)
             expect.fulfill()
         })
 

--- a/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+@testable import WordPressKit
+
+class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
+    let mockRemoteApi = MockWordPressComRestApi()
+    var readerPostServiceRemote: ReaderPostServiceRemote!
+
+    override func setUp() {
+        super.setUp()
+        readerPostServiceRemote = ReaderPostServiceRemote(wordPressComRestApi: getRestApi())
+    }
+
+    // Return an array of cards
+    //
+    func testReturnCards() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("read/cards", filename: "reader-cards-success.json", contentType: .ApplicationJSON)
+
+        readerPostServiceRemote.fetchCards(success: { cards in
+            XCTAssertTrue(cards.count == 10)
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    // All Post Cards contains a Post
+    //
+    func testReturnPosts() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("read/cards", filename: "reader-cards-success.json", contentType: .ApplicationJSON)
+
+        readerPostServiceRemote.fetchCards(success: { cards in
+            let postCards = cards.filter { $0.type == .post }
+            XCTAssertTrue(postCards.allSatisfy { $0.post != nil })
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+}

--- a/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
@@ -15,9 +15,9 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
     //
     func testReturnCards() {
         let expect = expectation(description: "Get cards successfully")
-        stubRemoteResponse("read/cards", filename: "reader-cards-success.json", contentType: .ApplicationJSON)
+        stubRemoteResponse("read/tags/cards?tags%5B%5D=dogs", filename: "reader-cards-success.json", contentType: .ApplicationJSON)
 
-        readerPostServiceRemote.fetchCards(success: { cards in
+        readerPostServiceRemote.fetchCards(for: ["dogs"], success: { cards in
             XCTAssertTrue(cards.count == 10)
             expect.fulfill()
         })
@@ -29,9 +29,9 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
     //
     func testReturnPosts() {
         let expect = expectation(description: "Get cards successfully")
-        stubRemoteResponse("read/cards", filename: "reader-cards-success.json", contentType: .ApplicationJSON)
+        stubRemoteResponse("read/tags/cards?tags%5B%5D=cats", filename: "reader-cards-success.json", contentType: .ApplicationJSON)
 
-        readerPostServiceRemote.fetchCards(success: { cards in
+        readerPostServiceRemote.fetchCards(for: ["cats"], success: { cards in
             let postCards = cards.filter { $0.type == .post }
             XCTAssertTrue(postCards.allSatisfy { $0.post != nil })
             expect.fulfill()


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/14399

Review after #255 is merged

### Description

This PR adds the service to retrieve Cards from the Reader API.

So far it's able to parse Cards that represent a post or a collection of interests.

### How to test

The best way is to check `ReaderPostServiceRemoteCardTests`. The service API and the results can be debugged there.