### PR TITLE
Add new reader read/interests endpoint

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -19,6 +19,9 @@
 		17D936252475D8AB008B2205 /* RemoteHomepageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D936242475D8AB008B2205 /* RemoteHomepageType.swift */; };
 		1A4F98672279A87D00D86E8E /* WPKit-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4F98662279A87D00D86E8E /* WPKit-Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		240315B0A1D6C2B981572B5B /* Pods_WordPressKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED05C8FF3E61D93CE5BA527E /* Pods_WordPressKitTests.framework */; };
+		3236F77824AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */; };
+		3236F79A24AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */; };
+		3236F79C24AE413A0088E8F3 /* reader-interests-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 3236F79B24AE413A0088E8F3 /* reader-interests-success.json */; };
 		32A29A1F236BE4CC009488C2 /* post-autosave-mapping-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 32A29A1E236BE4CC009488C2 /* post-autosave-mapping-success.json */; };
 		32AF21E3236DEB3C001C6502 /* PostServiceRemoteRESTAutosaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32AF21E2236DEB3C001C6502 /* PostServiceRemoteRESTAutosaveTests.swift */; };
 		32E1DD23236AA09A008914B0 /* RemotePostAutosave.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E1DD22236AA09A008914B0 /* RemotePostAutosave.swift */; };
@@ -513,6 +516,9 @@
 		17D936242475D8AB008B2205 /* RemoteHomepageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHomepageType.swift; sourceTree = "<group>"; };
 		1A4F98662279A87D00D86E8E /* WPKit-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPKit-Swift.h"; sourceTree = "<group>"; };
 		264F5C834541BBF2018F4964 /* Pods-WordPressKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemote+Interests.swift"; sourceTree = "<group>"; };
+		3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemote+InterestsTests.swift"; sourceTree = "<group>"; };
+		3236F79B24AE413A0088E8F3 /* reader-interests-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-interests-success.json"; sourceTree = "<group>"; };
 		32A29A1E236BE4CC009488C2 /* post-autosave-mapping-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "post-autosave-mapping-success.json"; sourceTree = "<group>"; };
 		32AF21E2236DEB3C001C6502 /* PostServiceRemoteRESTAutosaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceRemoteRESTAutosaveTests.swift; sourceTree = "<group>"; };
 		32E1DD22236AA09A008914B0 /* RemotePostAutosave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePostAutosave.swift; sourceTree = "<group>"; };
@@ -1107,6 +1113,7 @@
 				17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */,
 				8B2F4BE424ABB3C70056C08A /* RemoteReaderPostTests.m */,
 				8B2F4BE824ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift */,
+				3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */,
 			);
 			name = Reader;
 			sourceTree = "<group>";
@@ -1442,6 +1449,7 @@
 				40A71C6D220E1D8E002E3D25 /* StatsServiceRemoteV2.swift */,
 				E182BF691FD961810001D850 /* Endpoint.swift */,
 				17CD0CC220C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift */,
+				3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -1657,6 +1665,7 @@
 				17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */,
 				8B2F4BEA24ABCA6F0056C08A /* reader-cards-success.json */,
 				74A44DD71F13C7AC006CD8F4 /* remote-notification.json */,
+				3236F79B24AE413A0088E8F3 /* reader-interests-success.json */,
 				74B040711EF8B366002C6258 /* rest-site-settings.json */,
 				74C473CA1EF33696009918F2 /* site-active-purchases-auth-failure.json */,
 				74C473CC1EF336BD009918F2 /* site-active-purchases-bad-json-failure.json */,
@@ -2032,6 +2041,7 @@
 				436D5643211B7F9B00CEAA33 /* validate-domain-contact-information-response-fail.json in Resources */,
 				74FC6F401F191C1D00112505 /* notifications-mark-as-read.json in Resources */,
 				74D67F3A1F15C3740010C5ED /* site-viewers-delete-failure.json in Resources */,
+				3236F79C24AE413A0088E8F3 /* reader-interests-success.json in Resources */,
 				93BD275C1EE73442002BB00B /* is-available-username-success.json in Resources */,
 				74D67F331F15C3740010C5ED /* site-users-delete-auth-failure.json in Resources */,
 				40819785221F74B200A298E4 /* stats-post-details.json in Resources */,
@@ -2379,6 +2389,7 @@
 				9F3E0B9B208732B3009CB5BA /* RemoteReaderSiteInfoSubscription.swift in Sources */,
 				7403A2E41EF06ED500DED7DC /* AccountSettingsRemote.swift in Sources */,
 				93C674E81EE8345300BFAF05 /* RemoteBlog.m in Sources */,
+				3236F77824AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift in Sources */,
 				93BD27831EE73944002BB00B /* WordPressRSDParser.swift in Sources */,
 				7328420421CD786C00126755 /* WordPressComServiceRemote+SiteCreation.swift in Sources */,
 				826016F31F9FA17B00533B6C /* Activity.swift in Sources */,
@@ -2489,6 +2500,7 @@
 				736C971021E80D48007A4200 /* SiteVerticalsPromptResponseDecodingTests.swift in Sources */,
 				74B335D81F06F1CA0053A184 /* MockWordPressComRestApi.swift in Sources */,
 				32AF21E3236DEB3C001C6502 /* PostServiceRemoteRESTAutosaveTests.swift in Sources */,
+				3236F79A24AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift in Sources */,
 				74B5F0DE1EF82A9600B411E7 /* BlogServiceRemoteRESTTests.m in Sources */,
 				74E2294B1F1E73340085F7F2 /* SharingServiceRemoteTests.m in Sources */,
 				73B3DAD621FBB20D00B2CF18 /* WordPressComRestApiTests+Locale.swift in Sources */,

--- a/WordPressKit/ReaderTopicServiceRemote+Interests.swift
+++ b/WordPressKit/ReaderTopicServiceRemote+Interests.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+extension ReaderTopicServiceRemote {
+    /// Returns a collection of RemoteReaderInterest
+    /// - Parameters:
+    /// - Parameter success: Called when the request succeeds and the data returned is valid
+    /// - Parameter failure: Called if the request fails for any reason, or the response data is invalid
+    public func fetchInterests(_ success: @escaping ([RemoteReaderInterest]) -> Void,
+                               failure: @escaping (Error) -> Void) {
+        let path = self.path(forEndpoint: "read/interests", withVersion: ._2_0)
+
+        wordPressComRestApi.GET(path,
+                                parameters: nil,
+                                success: { response, _ in
+                                    do {
+                                        let decoder = JSONDecoder()
+                                        let data = try JSONSerialization.data(withJSONObject: response, options: [])
+                                        let envelope = try decoder.decode(ReaderInterestEnvelope.self, from: data)
+
+                                        success(envelope.interests)
+                                    } catch {
+                                        DDLogError("Error parsing the reader interests response: \(error)")
+                                        failure(error)
+                                    }
+        }, failure: { error, _ in
+            DDLogError("Error fetching reader interests: \(error)")
+
+            failure(error)
+        })
+    }
+}

--- a/WordPressKit/RemoteReaderInterest.swift
+++ b/WordPressKit/RemoteReaderInterest.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+struct ReaderInterestEnvelope: Decodable {
+    var interests: [RemoteReaderInterest]
+}
+
 public struct RemoteReaderInterest: Decodable {
     var title: String
     var slug: String

--- a/WordPressKitTests/Mock Data/reader-interests-success.json
+++ b/WordPressKitTests/Mock Data/reader-interests-success.json
@@ -1,0 +1,7 @@
+{"success":true,"interests":[
+    {"title":"One","slug-en":"one"},
+    {"title":"Two","slug-en":"two"},
+    {"title":"Three","slug-en":"three"},
+    {"title":"Four","slug-en":"four"},
+    {"title":"Five","slug-en":"five"}
+]}

--- a/WordPressKitTests/ReaderTopicServiceRemote+InterestsTests.swift
+++ b/WordPressKitTests/ReaderTopicServiceRemote+InterestsTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+import XCTest
+
+@testable import WordPressKit
+
+class ReaderTopicServiceRemoteInterestsTests: RemoteTestCase, RESTTestable {
+    let mockRemoteApi = MockWordPressComRestApi()
+    var readerTopicServiceRemote: ReaderTopicServiceRemote!
+
+    override func setUp() {
+        super.setUp()
+
+        readerTopicServiceRemote = ReaderTopicServiceRemote(wordPressComRestApi: getRestApi())
+    }
+
+    // Return an array of interests
+    //
+    func testReturnInterests() {
+        let expect = expectation(description: "Get reader interests returns successfully")
+        stubRemoteResponse("read/interests", filename: "reader-interests-success.json", contentType: .ApplicationJSON)
+
+        readerTopicServiceRemote.fetchInterests({ (interests) in
+            XCTAssertTrue(interests.count == 5)
+            expect.fulfill()
+        }, failure: { _ in })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testValidInterestsOrder() {
+        let expect = expectation(description: "Get reader interests returns successfully")
+        stubRemoteResponse("read/interests", filename: "reader-interests-success.json", contentType: .ApplicationJSON)
+
+        // Title, slug
+        let expectedInterests = [
+            ["One", "one"],
+            ["Two", "two"],
+            ["Three", "three"],
+            ["Four", "four"],
+            ["Five", "five"]
+        ]
+        readerTopicServiceRemote.fetchInterests({ (interests) in
+            let mapped = interests.map { return [$0.title, $0.slug ]}
+
+            XCTAssertEqual(mapped, expectedInterests)
+
+            expect.fulfill()
+        }, failure: { _ in })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    // Test failure block is called correctly
+    //
+    func testReturnError() {
+        let expect = expectation(description: "Get reader interests fails")
+        stubRemoteResponse("read/interests", filename: "reader-interests-success.json", contentType: .ApplicationJSON, status: 503)
+
+        readerTopicServiceRemote.fetchInterests({ _ in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        }, failure: { error in
+            XCTAssertNotNil(error)
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+}


### PR DESCRIPTION
Main Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/14396

### Description
Adds a new `fetchInterests` method to call the `/read/interests/` endpoint from the `ReaderTopicServiceRemote`

### Testing Details
1. Run the unit tests for `ReaderTopicServiceRemoteInterestsTests`

- [X] Please check here if your pull request includes additional test coverage.
