### PR TITLE
Expose title/slug properties on the ReaderRemoteInterest

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.12.0-beta.2"
+  s.version       = "4.12.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/RemoteReaderInterest.swift
+++ b/WordPressKit/RemoteReaderInterest.swift
@@ -5,8 +5,8 @@ struct ReaderInterestEnvelope: Decodable {
 }
 
 public struct RemoteReaderInterest: Decodable {
-    var title: String
-    var slug: String
+    public var title: String
+    public var slug: String
 
     private enum CodingKeys: String, CodingKey {
         case title


### PR DESCRIPTION
### Description
Changes the title and slug properties to public

### Testing Details

Test Using: https://github.com/wordpress-mobile/WordPress-iOS/pull/14439
- [x] Please check here if your pull request includes additional test coverage.
