### PR TITLE
Remove `-en` from the reader interests slug key

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.12.0"
+  s.version       = "4.12.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/RemoteReaderInterest.swift
+++ b/WordPressKit/RemoteReaderInterest.swift
@@ -10,7 +10,7 @@ public struct RemoteReaderInterest: Decodable {
 
     private enum CodingKeys: String, CodingKey {
         case title
-        case slug = "slug-en"
+        case slug = "slug"
     }
 
     public init(from decoder: Decoder) throws {

--- a/WordPressKitTests/Mock Data/reader-cards-success.json
+++ b/WordPressKitTests/Mock Data/reader-cards-success.json
@@ -8,11 +8,11 @@
 			"type": "interests_you_may_like",
 			"data": [{
 					"title": "Activism",
-					"slug-en": "activism"
+					"slug": "activism"
 				},
 				{
 					"title": "Advice",
-					"slug-en": "advice"
+					"slug": "advice"
 				}
 			]
 		},

--- a/WordPressKitTests/Mock Data/reader-interests-success.json
+++ b/WordPressKitTests/Mock Data/reader-interests-success.json
@@ -1,7 +1,7 @@
 {"success":true,"interests":[
-    {"title":"One","slug-en":"one"},
-    {"title":"Two","slug-en":"two"},
-    {"title":"Three","slug-en":"three"},
-    {"title":"Four","slug-en":"four"},
-    {"title":"Five","slug-en":"five"}
+    {"title":"One","slug":"one"},
+    {"title":"Two","slug":"two"},
+    {"title":"Three","slug":"three"},
+    {"title":"Four","slug":"four"},
+    {"title":"Five","slug":"five"}
 ]}


### PR DESCRIPTION
### Description
Removes the `-en` from the Reader Interests slug key to adhere to the API update

### Testing Details
Test using PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14469

- [x] Please check here if your pull request includes additional test coverage.
