### PR TITLE
Adds `cancelTasks` method and removes `allTasks`

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.13.0-beta.1"
+  s.version       = "4.13.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -76,15 +76,7 @@ open class WordPressComRestApi: NSObject {
         let sessionManager = self.makeSessionManager(configuration: sessionConfiguration)
         return sessionManager
     }()
-
-    @objc public var allTasks: [URLSessionTask] {
-        var result = [URLSessionTask]()
-        sessionManager.session.getAllTasks { (tasks) in
-            result = tasks
-        }
-        return result
-    }
-
+    
     private lazy var uploadSessionManager: Alamofire.SessionManager = {
         if self.backgroundUploads {
             let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: self.backgroundSessionIdentifier)
@@ -157,6 +149,13 @@ open class WordPressComRestApi: NSObject {
     deinit {
         sessionManager.session.finishTasksAndInvalidate()
         uploadSessionManager.session.finishTasksAndInvalidate()
+    }
+    
+    /// Cancels all outgoing tasks asynchronously without invalidating the session.
+    public func cancelTasks() {
+        sessionManager.session.getAllTasks { tasks in
+            tasks.forEach({ $0.cancel() })
+        }
     }
 
     /**


### PR DESCRIPTION
### Description

Part of https://github.com/wordpress-mobile/WordPress-iOS/pull/14481

This adds a method to cancel tasks on the `WordPressComRestApi`'s URLSession without invalidating it.
It also removes an unused `allTasks` which seemed to asynchronously request the sessions' tasks but not wait for the completion block before returning.

### Testing Details

Ensure that URL requests are made and complete and that calling `cancelTasks` works (as described in https://github.com/wordpress-mobile/WordPress-iOS/pull/14481`)

- [ ] Please check here if your pull request includes additional test coverage.
