### PR TITLE
Parse `address2` field in `ValidateDomainContactInformationResponse`

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.12.1-beta.1"
+  s.version       = "4.13.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/DomainContactInformation.swift
+++ b/WordPressKit/DomainContactInformation.swift
@@ -8,6 +8,7 @@ public struct ValidateDomainContactInformationResponse: Codable {
         public var countryCode: [String]?
         public var city: [String]?
         public var address1: [String]?
+        public var address2: [String]?
         public var firstName: [String]?
         public var lastName: [String]?
         public var state: [String]?


### PR DESCRIPTION
### Description

Add `address2` field to `ValidateDomainContactInformationResponse` messages

### Testing Details

Test Using: https://github.com/wordpress-mobile/WordPress-iOS/pull/14482

- [x] Please check here if your pull request includes additional test coverage.
