### PR TITLE
Adds API call to follow multiple tags/interests

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.12.1-beta.1"
+  s.version       = "4.12.1-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/ReaderTopicServiceRemote+Interests.swift
+++ b/WordPressKit/ReaderTopicServiceRemote+Interests.swift
@@ -28,4 +28,28 @@ extension ReaderTopicServiceRemote {
             failure(error)
         })
     }
+
+    /// Follows multiple tags/interests at once using their slugs
+    public func followInterests(withSlugs: [String],
+                                success: @escaping () -> Void,
+                                failure: @escaping (Error) -> Void) {
+        let path = self.path(forEndpoint: "read/tags/mine/new", withVersion: ._1_2)
+        let parameters = ["tags": withSlugs] as [String: AnyObject]
+
+        wordPressComRestApi.POST(path, parameters: parameters, success: { response, _ in
+            success()
+        }) { error, _ in
+            DDLogError("Error fetching reader interests: \(error)")
+
+            failure(error)
+        }
+    }
+
+    /// Returns an API path for the given tag/topic/interest slug
+    /// - Returns: https://_api_/read/tags/_slug_/posts
+    public func pathForTopic(slug: String) -> String {
+        let endpoint = path(forEndpoint: "read/tags/\(slug)/posts", withVersion: ._1_2)
+
+        return wordPressComRestApi.baseURLString.appending(endpoint)
+    }
 }


### PR DESCRIPTION
### Description
Adds 2 new methods:
1. API call to follow multiple interests at once
2. Helper method to generate an API path for a topic

### Testing Details

You can test using: https://github.com/wordpress-mobile/WordPress-iOS/pull/14487

- [x] Please check here if your pull request includes additional test coverage.
