### PR TITLE
Weak self references in SessionDelegate properties

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.13.0-beta.2"
+  s.version       = "4.13.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -50,13 +50,13 @@ open class WordPressOrgXMLRPCApi: NSObject {
         sessionConfiguration.httpAdditionalHeaders = additionalHeaders
         let sessionManager = Alamofire.SessionManager(configuration: sessionConfiguration)
 
-        let sessionDidReceiveChallengeWithCompletion: ((URLSession, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { session, authenticationChallenge, completionHandler in
-            return self.urlSession(session, didReceive: authenticationChallenge, completionHandler: completionHandler)
+        let sessionDidReceiveChallengeWithCompletion: ((URLSession, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [weak self] session, authenticationChallenge, completionHandler in
+            return self?.urlSession(session, didReceive: authenticationChallenge, completionHandler: completionHandler)
         }
         sessionManager.delegate.sessionDidReceiveChallengeWithCompletion = sessionDidReceiveChallengeWithCompletion
 
-        let  taskDidReceiveChallengeWithCompletion: ((URLSession, URLSessionTask, URLAuthenticationChallenge,  @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { session, task, authenticationChallenge, completionHandler in
-            return self.urlSession(session, task: task, didReceive: authenticationChallenge, completionHandler: completionHandler)
+        let  taskDidReceiveChallengeWithCompletion: ((URLSession, URLSessionTask, URLAuthenticationChallenge,  @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [weak self] session, task, authenticationChallenge, completionHandler in
+            return self?.urlSession(session, task: task, didReceive: authenticationChallenge, completionHandler: completionHandler)
         }
         sessionManager.delegate.taskDidReceiveChallengeWithCompletion = taskDidReceiveChallengeWithCompletion
         return sessionManager


### PR DESCRIPTION
WordPress-iOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14490

### Description

The memory graph debugger shows a leak of `Alamofire.SessionDelegate` which seems to be caused by retain cycles related to these two challenge blocks:

![Screen Shot 2020-07-17 at 4 02 35 PM](https://user-images.githubusercontent.com/3250/87946500-58476800-ca5f-11ea-8f55-b4a98698a2cb.png)

The change here is to just use a weak reference on `self`. These methods don't actually access anything on `self` (they are self contained so could be class methods or otherwise moved out of the object) but it seemed easiest to just change the reference rather than move them.

### Testing Details

Because this is a relationship on XMLRPCApi, you will need to test using a self-hosted site.

1. Create a site on `jurassic.ninja` if you do not already have one
2. Log in to the self-hosted site
3. Logging in should lead to several leaks. These can be seen in the Memory Graph Debugger as shown above or in the Leaks Instrument. **No SessionDelegate leaks should show up after the change.**

- [ ] Please check here if your pull request includes additional test coverage.
