### PR TITLE
Updates WPShared to 1.10-beta.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,7 @@ platform :ios, '11.0'
 def wordpresskit_pods
   pod 'Alamofire', '~> 4.8.0'
   pod 'CocoaLumberjack', '3.4.2'
-  pod 'WordPressShared', '~> 1.9'
+  pod 'WordPressShared', '~> 1.10-beta'
   pod 'NSObject-SafeExpectations', '~> 0.0.4'
   pod 'wpxmlrpc', '0.8.5'
   #pod 'wpxmlrpc', :git => 'https://github.com/wordpress-mobile/wpxmlrpc.git', :branch => 'feature/update-xcode-settings'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - OHHTTPStubs/Swift (9.0.0):
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (1.4.0)
-  - WordPressShared (1.9.0):
+  - WordPressShared (1.10.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
   - wpxmlrpc (0.8.5)
@@ -40,7 +40,7 @@ DEPENDENCIES:
   - OHHTTPStubs (= 9.0)
   - OHHTTPStubs/Swift (= 9.0)
   - UIDeviceIdentifier (~> 1)
-  - WordPressShared (~> 1.9)
+  - WordPressShared (~> 1.10-beta)
   - wpxmlrpc (= 0.8.5)
 
 SPEC REPOS:
@@ -63,9 +63,9 @@ SPEC CHECKSUMS:
   OCMock: 43565190abc78977ad44a61c0d20d7f0784d35ab
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressShared: b887b17aa949e4b142a1421fd479de495db9a054
+  WordPressShared: b77083325416b075c99155ab2770f0dff8ba04eb
   wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
 
-PODFILE CHECKSUM: c09ccb544ae10f289c1aa6d1193d4735698faee6
+PODFILE CHECKSUM: 7dc8665165790a883e0c5763e2bb4fd2133131c2
 
 COCOAPODS: 1.8.4

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.13.0-beta.4"
+  s.version       = "4.13.0-beta.5"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.8.0'
   s.dependency 'CocoaLumberjack', '~> 3.4'
-  s.dependency 'WordPressShared', '~> 1.9'
+  s.dependency 'WordPressShared', '~> 1.10-beta'
   s.dependency 'NSObject-SafeExpectations', '0.0.4'
   s.dependency 'wpxmlrpc', '0.8.5'
   s.dependency 'UIDeviceIdentifier', '~> 1'

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.13.0-beta.5"
+  s.version       = "4.14.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

Updates WPShared to 1.10-beta.

### Testing Details

1. Check out WPAuth branch: `try/implement-tracking-for-unified-google-flow`.
2. Install the pods and make sure there is no conflict.
3. Build the library and make sure there are no integration errors.

- [ ] Please check here if your pull request includes additional test coverage.
