### PR TITLE
Fix error when toggling Jetpack security settings.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.15.0-beta.2"
+  s.version       = "4.15.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/BlogJetpackSettingsServiceRemote.swift
+++ b/WordPressKit/BlogJetpackSettingsServiceRemote.swift
@@ -211,15 +211,18 @@ private extension BlogJetpackSettingsServiceRemote {
                                                 serveImagesFromOurServers: serveImagesFromOurServersValue)
     }
 
-    func dictionaryFromJetpackSettings(_ settings: RemoteBlogJetpackSettings) -> [String: AnyObject] {
+    func dictionaryFromJetpackSettings(_ settings: RemoteBlogJetpackSettings) -> [String: Any] {
         let joinedIPs = settings.loginWhiteListedIPAddresses.joined(separator: ", ")
-        return [Keys.monitorEnabled: settings.monitorEnabled as AnyObject,
-                Keys.blockMaliciousLoginAttempts: settings.blockMaliciousLoginAttempts as AnyObject,
-                Keys.whiteListedIPAddresses: joinedIPs as AnyObject,
-                Keys.ssoEnabled: settings.ssoEnabled as AnyObject,
-                Keys.ssoMatchAccountsByEmail: settings.ssoMatchAccountsByEmail as AnyObject,
-                Keys.ssoRequireTwoStepAuthentication: settings.ssoRequireTwoStepAuthentication as AnyObject]
-
+        let shouldSendWhitelist = settings.blockMaliciousLoginAttempts
+        let settingsDictionary: [String: Any?] = [
+            Keys.monitorEnabled: settings.monitorEnabled,
+            Keys.blockMaliciousLoginAttempts: settings.blockMaliciousLoginAttempts,
+            Keys.whiteListedIPAddresses: shouldSendWhitelist ? joinedIPs : nil,
+            Keys.ssoEnabled: settings.ssoEnabled,
+            Keys.ssoMatchAccountsByEmail: settings.ssoMatchAccountsByEmail,
+            Keys.ssoRequireTwoStepAuthentication: settings.ssoRequireTwoStepAuthentication,
+        ]
+        return settingsDictionary.compactMapValues { $0 }
     }
 
     func dictionaryFromJetpackMonitorSettings(_ settings: RemoteBlogJetpackMonitorSettings) -> [String: AnyObject] {


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14590

Avoid sending `jetpack_protect_global_whitelist` if `protect` module is disabled.

Doing so, the server responds with a 500 error.

### Description

#### Problem:

When "Block malicious login attempts" is disabled, sending `jetpack_protect_global_whitelist` key in the body results on a server 500 error, even though all other settings are set properly.

We receive this error and display it to the user:

<img src="https://user-images.githubusercontent.com/9772967/89433852-1bf45700-d743-11ea-84a6-eab1ed92113b.png" width="300">

#### Solution:

Filtering the request body to not add the `jetpack_protect_global_whitelist` key if `Block malicious login attempts` is disabled solves the problem.


### Testing Details

- Have a Jetpack-connected self-hosted site.
- Go to Settings -> [Jetpack] Security.
- With `Block malicious login attempts` disabled, toggle `Allow WordPress.com login on and off.
  - Check that there are no error alerts.
- Enable `Block malicious login attempts`.
- Go to `Whitelisted IP addressed`
- Add an IP to the list.
  - Check on web that the IP was synchronised property.


- [ ] Please check here if your pull request includes additional test coverage.
