### PR TITLE
Issue/posts api subscribe

### DIFF
--- a/WordPressKit/ReaderPostServiceRemote.h
+++ b/WordPressKit/ReaderPostServiceRemote.h
@@ -76,6 +76,32 @@ Fetches the subscription status of the specified post for the current user.
                                failure:(void (^)(NSError *))failure;
 
 /**
+ Mark a post as subscribed by the user.
+
+ @param postID The ID of the post.
+ @param siteID The ID of the site.
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)subscribeToPost:(NSUInteger)postID
+                forSite:(NSUInteger)siteID
+                success:(void (^)(void))success
+                failure:(void (^)(NSError *error))failure;
+
+/**
+ Mark a post as unsubscribed by the user.
+
+ @param postID The ID of the post.
+ @param siteID The ID of the site.
+ @param success block called on a successful fetch.
+ @param failure block called if there is any error. `error` can be any underlying network error.
+ */
+- (void)unsubscribeFromPost:(NSUInteger)postID
+                    forSite:(NSUInteger)siteID
+                    success:(void (^)(void))success
+                    failure:(void (^)(NSError *error))failure;
+
+/**
  Mark a post as liked by the user.
 
  @param postID The ID of the post.

--- a/WordPressKit/ReaderPostServiceRemote.h
+++ b/WordPressKit/ReaderPostServiceRemote.h
@@ -63,6 +63,19 @@
                failure:(void (^)(NSError *error))failure;
 
 /**
+Fetches the subscription status of the specified post for the current user.
+
+@param postID The ID of the post.
+@param siteID The ID of the site.
+@param success block called on a successful fetch.
+@param failure block called if there is any error. `error` can be any underlying network error.
+*/
+- (void)fetchSubscriptionStatusForPost:(NSUInteger)postID
+                              fromSite:(NSUInteger)siteID
+                               success:(void (^)(BOOL isSubscribed))success
+                               failure:(void (^)(NSError *))failure;
+
+/**
  Mark a post as liked by the user.
 
  @param postID The ID of the post.

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -135,6 +135,28 @@ NSString * const ParamKeyMetaValue = @"site,feed";
                           }];
 }
 
+- (void)fetchSubscriptionStatusForPost:(NSUInteger)postID
+                              fromSite:(NSUInteger)siteID
+                               success:(void (^)(BOOL isSubscribed))success
+                               failure:(void (^)(NSError *))failure
+{
+    NSString *path = [NSString stringWithFormat:@"sites/%lu/posts/%lu/subscribers/mine", (unsigned long)siteID, (unsigned long)postID];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    
+    [self.wordPressComRestApi GET:requestUrl
+                       parameters:nil
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+        if (success) {
+            success([responseObject[@"i_subscribe"] boolValue]);
+        }
+    } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+}
+
 - (void)likePost:(NSUInteger)postID
          forSite:(NSUInteger)siteID
          success:(void (^)(void))success

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -143,7 +143,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
     NSString *path = [NSString stringWithFormat:@"sites/%lu/posts/%lu/subscribers/mine", (unsigned long)siteID, (unsigned long)postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
-    
+
     [self.wordPressComRestApi GET:requestUrl
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
@@ -156,6 +156,47 @@ NSString * const ParamKeyMetaValue = @"site,feed";
         }
     }];
 }
+
+- (void)subscribeToPost:(NSUInteger)postID
+                forSite:(NSUInteger)siteID
+                success:(void (^)(void))success
+                failure:(void (^)(NSError *))failure
+{
+    NSString *path = [NSString stringWithFormat:@"sites/%lu/posts/%lu/subscribers/new", (unsigned long)siteID, (unsigned long)postID];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+
+    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+        if (success) {
+            success();
+        }
+    } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+}
+
+- (void)unsubscribeFromPost:(NSUInteger)postID
+                    forSite:(NSUInteger)siteID
+                    success:(void (^)(void))success
+                    failure:(void (^)(NSError *))failure
+{
+    NSString *path = [NSString stringWithFormat:@"sites/%lu/posts/%lu/subscribers/mine/delete", (unsigned long)siteID, (unsigned long)postID];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+
+    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+        if (success) {
+            success();
+        }
+    } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+}
+
 
 - (void)likePost:(NSUInteger)postID
          forSite:(NSUInteger)siteID


### PR DESCRIPTION
### Description

This PR adds the following endpoints:

- [Get subscription state](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post/subscribers/mine/)
- [Subscribe to a post comments stream](https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/posts/%24post/subscribers/new/)
- [Unsubscribe from a post comments stream](https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/posts/%24post/subscribers/mine/delete/)

### Testing Details
You can review this PR's functionality in the parent WordPress-iOS issue:
- https://github.com/wordpress-mobile/WordPress-iOS/issues/14574
