### PR TITLE
Add support for fetching remote feature flags

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -471,6 +471,9 @@
 		F194E1232417ED9F00874408 /* AtomicAuthenticationServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F194E1222417ED9F00874408 /* AtomicAuthenticationServiceRemoteTests.swift */; };
 		F194E1252417EE7E00874408 /* atomic-get-auth-cookie-success.json in Resources */ = {isa = PBXBuildFile; fileRef = F194E1242417EE7E00874408 /* atomic-get-auth-cookie-success.json */; };
 		F1BB7806240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BB7805240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift */; };
+		F9E56DF624EB11EF00916770 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DF524EB11EF00916770 /* FeatureFlag.swift */; };
+		F9E56DF824EB125600916770 /* FeatureFlagRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */; };
+		F9E56DFB24EB18C300916770 /* FeatureFlagRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */; };
 		FA87FE0724EB39C4003FBEE3 /* ReaderPostServiceRemote+SubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA87FE0624EB39C4003FBEE3 /* ReaderPostServiceRemote+SubscriptionTests.swift */; };
 		FA87FE0924EB3FEF003FBEE3 /* reader-post-comments-subscription-status-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FA87FE0824EB3FEF003FBEE3 /* reader-post-comments-subscription-status-success.json */; };
 		FA87FE0B24EB4419003FBEE3 /* reader-post-comments-subscribe-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FA87FE0A24EB4419003FBEE3 /* reader-post-comments-subscribe-success.json */; };
@@ -987,6 +990,9 @@
 		F194E1222417ED9F00874408 /* AtomicAuthenticationServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicAuthenticationServiceRemoteTests.swift; sourceTree = "<group>"; };
 		F194E1242417EE7E00874408 /* atomic-get-auth-cookie-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "atomic-get-auth-cookie-success.json"; sourceTree = "<group>"; };
 		F1BB7805240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicAuthenticationServiceRemote.swift; sourceTree = "<group>"; };
+		F9E56DF524EB11EF00916770 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
+		F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemote.swift; sourceTree = "<group>"; };
+		F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemoteTests.swift; sourceTree = "<group>"; };
 		FA87FE0624EB39C4003FBEE3 /* ReaderPostServiceRemote+SubscriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostServiceRemote+SubscriptionTests.swift"; sourceTree = "<group>"; };
 		FA87FE0824EB3FEF003FBEE3 /* reader-post-comments-subscription-status-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-subscription-status-success.json"; sourceTree = "<group>"; };
 		FA87FE0A24EB4419003FBEE3 /* reader-post-comments-subscribe-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-subscribe-success.json"; sourceTree = "<group>"; };
@@ -1303,6 +1309,7 @@
 				93188D201F2264A80028ED4D /* Taxonomy */,
 				436D56362118DC2800CEAA33 /* Transactions */,
 				93F50A421F227CC400B5BEBA /* Users */,
+				F9E56DF924EB18A300916770 /* Utilities */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -1462,6 +1469,7 @@
 				E182BF691FD961810001D850 /* Endpoint.swift */,
 				17CD0CC220C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift */,
 				3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */,
+				F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -1544,6 +1552,7 @@
 				E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */,
 				17CE77F020C6EB41001DEA5A /* ReaderFeed.swift */,
 				32E1DD22236AA09A008914B0 /* RemotePostAutosave.swift */,
+				F9E56DF524EB11EF00916770 /* FeatureFlag.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -1880,6 +1889,14 @@
 				F194E1222417ED9F00874408 /* AtomicAuthenticationServiceRemoteTests.swift */,
 			);
 			name = Authentication;
+			sourceTree = "<group>";
+		};
+		F9E56DF924EB18A300916770 /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */,
+			);
+			path = Utilities;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2334,6 +2351,7 @@
 				74585B8E1F0D51A100E7E667 /* DomainsServiceRemote.swift in Sources */,
 				7430C9A41F1927180051B8E6 /* ReaderPostServiceRemote.m in Sources */,
 				408197882220A35000A298E4 /* StatsLastPostInsight.swift in Sources */,
+				F9E56DF624EB11EF00916770 /* FeatureFlag.swift in Sources */,
 				8B2F4BE724ABC8A90056C08A /* ReaderPostServiceRemote+Cards.swift in Sources */,
 				74E2294E1F1E73FE0085F7F2 /* RemotePublicizeService.swift in Sources */,
 				9F3E0BA22087345F009CB5BA /* ServiceRequest.swift in Sources */,
@@ -2470,6 +2488,7 @@
 				74DA563B1F06EB3000FE9BF4 /* RemoteMedia.m in Sources */,
 				9311A6861F22625A00704AC9 /* RemoteTaxonomyPaging.m in Sources */,
 				93BD27821EE73944002BB00B /* WordPressOrgXMLRPCValidator.swift in Sources */,
+				F9E56DF824EB125600916770 /* FeatureFlagRemote.swift in Sources */,
 				40247DFC2120E69600AE1C3C /* AutomatedTransferStatus.swift in Sources */,
 				730E869F21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift in Sources */,
 				740B23C51F17EE8000067A2A /* RemotePost.m in Sources */,
@@ -2557,6 +2576,7 @@
 				E1787DB2200E5690004CB3AF /* TimeZoneServiceRemoteTests.swift in Sources */,
 				FFA4D4AB2423B10A00BF5180 /* AuthenticatorTests.swift in Sources */,
 				740B23D21F17F6BB00067A2A /* PostServiceRemoteRESTTests.m in Sources */,
+				F9E56DFB24EB18C300916770 /* FeatureFlagRemoteTests.swift in Sources */,
 				D813437621F6D70D0060D99A /* SiteSegmentsResponseDecodingTests.swift in Sources */,
 				436D56382118DC4B00CEAA33 /* TransactionsServiceRemoteTests.swift in Sources */,
 				9F3E0BA82087355E009CB5BA /* RemoteReaderSiteInfoSubscriptionTests.swift in Sources */,

--- a/WordPressKit/FeatureFlag.swift
+++ b/WordPressKit/FeatureFlag.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct FeatureFlag {
+    let title: String
+    let value: Bool
+}
+
+// Codable Conformance is used to create mock objects in testing
+extension FeatureFlag: Codable {
+
+    struct DynamicKey: CodingKey {
+        var stringValue: String
+        init(stringValue: String) {
+            self.stringValue = stringValue
+        }
+
+        var intValue: Int?
+
+        init(intValue: Int) {
+            self.intValue = intValue
+            self.stringValue = "\(intValue)"
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: DynamicKey.self)
+        try container.encode(self.value, forKey: DynamicKey(stringValue: self.title))
+    }
+}
+
+// Equatable Conformance is used to compare mock objects in testing
+extension FeatureFlag: Equatable {}
+
+public typealias FeatureFlagList = [FeatureFlag]

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -1,0 +1,54 @@
+import UIKit
+
+public class FeatureFlagRemote: ServiceRemoteWordPressComREST {
+
+    public typealias FeatureFlagResponseCallback = (Result<FeatureFlagList, Error>) -> Void
+
+    public enum FeatureFlagRemoteError: Error {
+        case InvalidDataError
+    }
+
+    public func getRemoteFeatureFlags(forDeviceId deviceId: String, callback: @escaping FeatureFlagResponseCallback) {
+
+        let endpoint = "mobile-feature-flags"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
+
+        let parameters: [String: AnyObject] = [
+            "device_id": deviceId as NSString,
+            "platform": "apple" as NSString,
+            "build_number": NSString(string: Bundle.main.infoDictionary?["CFBundleName"] as? String ?? "Unknown"),
+            "marketing_version": NSString(string: Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "Unknown"),
+        ]
+        
+        wordPressComRestApi.GET(path,
+                                parameters: parameters,
+                                success: { response, _ in
+                                    
+                                    if let featureFlagList = response as? NSArray {
+                                        callback(.success(featureFlagList.compactMap { row -> FeatureFlag? in
+                                            guard let row = row as? NSDictionary,
+                                                let key = row.allKeys.first as? String,
+                                                let value = row.allValues.first as? Bool,
+                                                row.count == 1
+                                                else {
+                                                    return nil
+                                                }
+
+                                            return FeatureFlag(title: key, value: value)
+                                        }))
+                                    } else {
+                                        callback(.failure(FeatureFlagRemoteError.InvalidDataError))
+                                    }
+
+                                }, failure: { error, response in
+                                    DDLogError("Error retrieving remote feature flags")
+                                    DDLogError("\(error)")
+
+                                    if let response = response {
+                                        DDLogDebug("Response Code: \(response.statusCode)")
+                                    }
+
+                                    callback(.failure(error))
+                                })
+    }
+}

--- a/WordPressKitTests/Utilities/FeatureFlagRemoteTests.swift
+++ b/WordPressKitTests/Utilities/FeatureFlagRemoteTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import WordPressKit
+
+class FeatureFlagRemoteTests: RemoteTestCase, RESTTestable {
+
+    private let endpoint = "/wpcom/v2/mobile-feature-flags"
+
+    func testThatResponsesAreHandledCorrectly() throws {
+        let flags = [
+            FeatureFlag(title: UUID().uuidString, value: true),
+            FeatureFlag(title: UUID().uuidString, value: false),
+        ]
+
+        let data = try JSONEncoder().encode(flags)
+        stubRemoteResponse(endpoint, data: data, contentType: .ApplicationJSON)
+
+        let expectation = XCTestExpectation()
+
+        FeatureFlagRemote(wordPressComRestApi: getRestApi()).getRemoteFeatureFlags(forDeviceId: "Test") { result in
+            let list = try! result.get()
+            XCTAssertEqual(2, list.count)
+            XCTAssertEqual(flags.first!, list.first!)
+            XCTAssertEqual(flags.last!, list.last!)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testThatEmptyResponsesAreHandledCorrectly() throws {
+
+        let data = try JSONEncoder().encode(FeatureFlagList())
+        stubRemoteResponse(endpoint, data: data, contentType: .ApplicationJSON)
+
+        let expectation = XCTestExpectation()
+
+        FeatureFlagRemote(wordPressComRestApi: getRestApi()).getRemoteFeatureFlags(forDeviceId: "Test") { result in
+            XCTAssertEqual(0, try! result.get().count)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testThatMalformedResponsesReturnEmptyArray() throws {
+        let data = try toJSON(object: [
+            [
+                "key": "foo",
+                "value": true,
+            ]
+        ])
+        stubRemoteResponse(endpoint, data: data, contentType: .ApplicationJSON)
+
+        let expectation = XCTestExpectation()
+
+        FeatureFlagRemote(wordPressComRestApi: getRestApi()).getRemoteFeatureFlags(forDeviceId: "Test") { result in
+            XCTAssertEqual(0, try! result.get().count)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testThatRequestErrorReturnsFailureResponse() {
+        stubRemoteResponse(endpoint, data: Data(), contentType: .NoContentType, status: 400)
+
+        let expectation = XCTestExpectation()
+
+        FeatureFlagRemote(wordPressComRestApi: getRestApi()).getRemoteFeatureFlags(forDeviceId: "Test") { result in
+            if case .success(_) = result {
+                XCTFail()
+            }
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    private func toJSON(object: Any) throws -> Data {
+        return try JSONSerialization.data(withJSONObject: object, options: .prettyPrinted)
+    }
+}


### PR DESCRIPTION
### Description
Adds support for fetching remote feature flags.

### Testing Details
The API is covered by unit tests, which should be sufficient to validate the approach.

- [x] Please check here if your pull request includes additional test coverage.
