### PR TITLE
expose siteID read-only property in StatsServiceRemoteV2

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.16.0-beta.2"
+  s.version       = "4.16.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -10,7 +10,7 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
         case decodingFailure
     }
 
-    private let siteID: Int
+    public let siteID: Int
     private let siteTimezone: TimeZone
 
     private lazy var periodDataQueryDateFormatter: DateFormatter = {


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14801

exposes siteID so that it can be used in WPiOS to check if the current site has changed, and update stats accordingly.

- [ ] Please check here if your pull request includes additional test coverage.
