### PR TITLE
Fix parsing passwordless response dictionary.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.16.0-beta.5"
+  s.version       = "4.16.0-beta.6"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -115,7 +115,7 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
                                   return;
                               }
                               NSDictionary *dict = (NSDictionary *)responseObject;
-                              BOOL passwordless = [[dict numberForKey:@"passwordlesss"] boolValue];
+                              BOOL passwordless = [[dict numberForKey:@"passwordless"] boolValue];
                               success(passwordless);
                               
                           } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/404

This fixes an issue where the `passwordless` API response dictionary was incorrectly parsed (`passwordless` was misspelled), causing the method to return an incorrect value.

### Testing Details

It is used by Auth PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/278
Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14825


- [ ] Please check here if your pull request includes additional test coverage.
