### PR TITLE
Update Announcement and Feature types to Codable to allow plist encoding

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.16.0-beta.6"
+  s.version       = "4.17.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AnnouncementServiceRemote.swift
+++ b/WordPressKit/AnnouncementServiceRemote.swift
@@ -93,7 +93,7 @@ public struct AnnouncementsContainer: Decodable {
     }
 }
 
-public struct Announcement: Decodable {
+public struct Announcement: Codable {
     public let appVersionName: String
     public let minimumAppVersion: String
     public let maximumAppVersion: String
@@ -105,7 +105,7 @@ public struct Announcement: Decodable {
     public let features: [Feature]
 }
 
-public struct Feature: Decodable {
+public struct Feature: Codable {
     public let title: String
     public let subtitle: String
     public let iconUrl: String


### PR DESCRIPTION
This change is needed to allow these types to be encoded to plist and stored in a plist file (e.g. UserDefaults)
Fixes #NA

can be tested with this WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/14847

- [ ] Please check here if your pull request includes additional test coverage.
