### PR TITLE
Prevent triggering lazy property initialization on deinitialization

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.17.0-beta.1"
+  s.version       = "4.17.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -26,21 +26,30 @@ open class WordPressOrgXMLRPCApi: NSObject {
     ///
     @objc public static let minimumSupportedVersion = "4.0"
 
-    private lazy var sessionManager: Alamofire.SessionManager = {
-        let sessionConfiguration = URLSessionConfiguration.default
-        let sessionManager = self.makeSessionManager(configuration: sessionConfiguration)
-        return sessionManager
-    }()
-
-    private lazy var uploadSessionManager: Alamofire.SessionManager = {
-        if self.backgroundUploads {
-            let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: self.backgroundSessionIdentifier)
+    private var _sessionManager: Alamofire.SessionManager?
+    private var sessionManager: Alamofire.SessionManager {
+        guard let sessionManager = _sessionManager else {
+            let sessionConfiguration = URLSessionConfiguration.default
             let sessionManager = self.makeSessionManager(configuration: sessionConfiguration)
+            _sessionManager = sessionManager
             return sessionManager
         }
+        return sessionManager
+    }
 
-        return self.sessionManager
-    }()
+    private var _uploadSessionManager: Alamofire.SessionManager?
+    private var uploadSessionManager: Alamofire.SessionManager {
+        if self.backgroundUploads {
+            guard let uploadSessionManager = _uploadSessionManager else {
+                let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: self.backgroundSessionIdentifier)
+                let sessionManager = self.makeSessionManager(configuration: sessionConfiguration)
+                _uploadSessionManager = sessionManager
+                return sessionManager
+            }
+            return uploadSessionManager
+        }
+        return sessionManager
+    }
 
     private func makeSessionManager(configuration sessionConfiguration: URLSessionConfiguration) -> Alamofire.SessionManager {
         var additionalHeaders: [String : AnyObject] = ["Accept-Encoding": "gzip, deflate" as AnyObject]
@@ -87,8 +96,8 @@ open class WordPressOrgXMLRPCApi: NSObject {
     }
 
     deinit {
-        sessionManager.session.finishTasksAndInvalidate()
-        uploadSessionManager.session.finishTasksAndInvalidate()
+        _sessionManager?.session.finishTasksAndInvalidate()
+        _uploadSessionManager?.session.finishTasksAndInvalidate()
     }
 
     /**


### PR DESCRIPTION
Attempt to fix crash (https://github.com/wordpress-mobile/WordPress-iOS/issues/14787) when `WordPressOrgXMLRPCApi` is being deinitialized.

### Description

The key piece of the crash report from the above issue is the following:

> Cannot form weak reference to instance (0x283b4e490) of class WordPressKit.WordPressOrgXMLRPCApi. It is possible that this object was over-released, or **is in the process of deallocation.**

The crashing lines point to the offending lazy `sessionManager` property and shows how it calls `makeSessionManager` from within `deinit`:

```
8   WordPress   0x203322f70   WordPressOrgXMLRPCApi.makeSessionManager (WordPressOrgXMLRPCApi.swift:53)
9   WordPress   0x203323908   [inlined] WordPressOrgXMLRPCApi.sessionManager.getter (WordPressOrgXMLRPCApi.swift:31)
10  WordPress   0x203323908   [inlined] WordPressOrgXMLRPCApi.sessionManager.getter (WordPressOrgXMLRPCApi.swift:29)
11  WordPress   0x203323908   WordPressOrgXMLRPCApi.__deallocating_deinit (WordPressOrgXMLRPCApi.swift:90)
```

The lazy vars are initialized from deinit, which is NOT what we want. If the vars have not been initialized already, we don't want to initialize them during deinitialization. This PR uses private optional variables with computed getters to lazily initialize and uses the optional variables in `deinit` to avoid initializing the properties while deinitialization of the parent is in progress.

This seems to be a common mistake as a question was asked about possibly adding a feature like this to properties in Swift: https://forums.swift.org/t/lazy-var-and-deinit/2291

### Testing Details

I have been unable to directly reproduce the crash but I've created a patch adding a new property which exhibits the same stack trace:
[XMLRPCAPI-Lazy-SessionManager.patch.zip](https://github.com/wordpress-mobile/WordPressKit-iOS/files/5211948/XMLRPCAPI-Lazy-SessionManager.patch.zip)

There are a few ways to reproduce using the patch:

### Logging In
1. Apply the patch to WordPressKit
2. Log in to a .org site with a fresh install
3. 💥 Crash

### Logged In
1. Log in to a .org site with a fresh install
2. Apply the patch to WordPressKit
3. Launch the app.
4. 💥 Crash

The following patch resolves the crash from the first patch using the same technique from the PR:
[FIXED-XMLRPCAPI-Lazy-SessionManager.patch.zip](https://github.com/wordpress-mobile/WordPressKit-iOS/files/5211988/FIXED-XMLRPCAPI-Lazy-SessionManager.patch.zip)

Please test the changes in this PR by ensuring that .org login and logout still works and all data is properly fetched and posted.
