### PR TITLE
Upgrade xmlrpc to remove Xcode 12 build warning

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,7 +10,7 @@ def wordpresskit_pods
   pod 'CocoaLumberjack', '~> 3.4'
   pod 'WordPressShared', '~> 1.10-beta'
   pod 'NSObject-SafeExpectations', '~> 0.0.4'
-  pod 'wpxmlrpc', '0.8.5'
+  pod 'wpxmlrpc', '~> 0.9.0-beta'
   #pod 'wpxmlrpc', :git => 'https://github.com/wordpress-mobile/wpxmlrpc.git', :branch => 'feature/update-xcode-settings'
   pod 'UIDeviceIdentifier', '~> 1'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -27,7 +27,7 @@ PODS:
   - WordPressShared (1.10.0-beta.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (= 1.8.2)
-  - wpxmlrpc (0.8.5)
+  - wpxmlrpc (0.9.0-beta.1)
 
 DEPENDENCIES:
   - Alamofire (~> 4.8.0)
@@ -38,7 +38,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (= 9.0)
   - UIDeviceIdentifier (~> 1)
   - WordPressShared (~> 1.10-beta)
-  - wpxmlrpc (= 0.8.5)
+  - wpxmlrpc (~> 0.9.0-beta)
 
 SPEC REPOS:
   trunk:
@@ -61,8 +61,8 @@ SPEC CHECKSUMS:
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
   UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
   WordPressShared: b77083325416b075c99155ab2770f0dff8ba04eb
-  wpxmlrpc: 6a9bdd6ab9d1b159b384b0df0f3f39de9af4fecf
+  wpxmlrpc: 54196a1c23d1298f05895cc375a8f91385106fd0
 
-PODFILE CHECKSUM: 4bd2097d1ae0b623b1e7b8dd2dd09739cd13d227
+PODFILE CHECKSUM: d59ba311742eff68acaeac24ade4b7cf3136c915
 
 COCOAPODS: 1.9.3

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -23,6 +23,6 @@ Pod::Spec.new do |s|
   s.dependency 'CocoaLumberjack', '~> 3.4'
   s.dependency 'WordPressShared', '~> 1.10-beta'
   s.dependency 'NSObject-SafeExpectations', '0.0.4'
-  s.dependency 'wpxmlrpc', '0.8.5'
+  s.dependency 'wpxmlrpc', '~> 0.9.0-beta'
   s.dependency 'UIDeviceIdentifier', '~> 1'
 end

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.17.0"
+  s.version       = "4.18.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

This upgrades the wpxmlrpc dependency to 0.9.0-beta.1 to fix this warning when building with Xcode 12:

<img src="https://user-images.githubusercontent.com/198826/94035362-354b7400-fd80-11ea-80c5-13ac7cb5a526.png" width="340">

The [changes in wpxmlrpc](https://github.com/wordpress-mobile/wpxmlrpc/compare/0.8.5...0.9.0-beta.1) are only for setting the minimum deployment to 9.0 (https://github.com/wordpress-mobile/wpxmlrpc/pull/52). 

### Testing Details

- Please confirm that the build passes. 
- Please confirm that the warning is no longer visible when compiling this project with Xcode 12. 

### Notes

We still have more warnings to fix. 😱 😱 😱 🙀 🙀 🙀 

### Checklist

- [ ] Please check here if your pull request includes additional test coverage.
