### PR TITLE
Add support for base64 images in Feature

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.18.0-beta.1"
+  s.version       = "4.18.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AnnouncementServiceRemote.swift
+++ b/WordPressKit/AnnouncementServiceRemote.swift
@@ -109,5 +109,5 @@ public struct Feature: Codable {
     public let title: String
     public let subtitle: String
     public let iconUrl: String
-    public let iconBase64: Data?
+    public let iconBase64: String?
 }


### PR DESCRIPTION
The `Feature` type has an `iconBase64` property that was wrongly set to `Data`. This PR fixes it, changing it to `String`

can be tested with this WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15015

- [ ] Please check here if your pull request includes additional test coverage.
