### PR TITLE
Blog: Include unmapped_url key in blog options.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.18.0"
+  s.version       = "4.19-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/RemoteBlogOptionsHelper.m
+++ b/WordPressKit/RemoteBlogOptionsHelper.m
@@ -20,6 +20,7 @@
                                           @"active_modules",
                                           @"admin_url",
                                           @"login_url",
+                                          @"unmapped_url",
                                           @"image_default_link_type",
                                           @"software_version",
                                           @"videopress_enabled",


### PR DESCRIPTION
### Description

Refs #https://github.com/wordpress-mobile/WordPress-iOS/issues/14220

This PR includes the "unmapped_url" key and value in the blog options dictionary, for use in previewing posts on sites with mapped domains.

Version bump tbd.

### Testing Details

To test, run the related WPiOS issue: https://github.com/wordpress-mobile/WordPress-iOS/pull/15061

- [ ] Please check here if your pull request includes additional test coverage.
