### PR TITLE
Reader Improvements: Extracts model logic to RemoteReaderSiteInfo

### DIFF
--- a/WordPressKit/RemoteReaderSiteInfo.h
+++ b/WordPressKit/RemoteReaderSiteInfo.h
@@ -6,20 +6,24 @@
 
 
 @interface RemoteReaderSiteInfo: NSObject
-@property (nonatomic, strong) NSNumber *feedID;
-@property (nonatomic, strong) NSString *feedURL;
+@property (nonatomic, copy) NSNumber *feedID;
+@property (nonatomic, copy) NSString *feedURL;
 @property (nonatomic) BOOL isFollowing;
 @property (nonatomic) BOOL isJetpack;
 @property (nonatomic) BOOL isPrivate;
 @property (nonatomic) BOOL isVisible;
-@property (nonatomic, strong) NSNumber *postCount;
-@property (nonatomic, strong) NSString *siteBlavatar;
-@property (nonatomic, strong) NSString *siteDescription;
-@property (nonatomic, strong) NSNumber *siteID;
-@property (nonatomic, strong) NSString *siteName;
-@property (nonatomic, strong) NSString *siteURL;
-@property (nonatomic, strong) NSNumber *subscriberCount;
-@property (nonatomic, strong) NSString *postsEndpoint;
+@property (nonatomic, copy) NSNumber *postCount;
+@property (nonatomic, copy) NSString *siteBlavatar;
+@property (nonatomic, copy) NSString *siteDescription;
+@property (nonatomic, copy) NSNumber *siteID;
+@property (nonatomic, copy) NSString *siteName;
+@property (nonatomic, copy) NSString *siteURL;
+@property (nonatomic, copy) NSNumber *subscriberCount;
+@property (nonatomic, copy) NSString *postsEndpoint;
+@property (nonatomic, copy) NSString *endpointPath;
+
 @property (nonatomic, strong) RemoteReaderSiteInfoSubscriptionPost *postSubscription;
 @property (nonatomic, strong) RemoteReaderSiteInfoSubscriptionEmail *emailSubscription;
+
++ (instancetype)siteInfoForSiteResponse:(NSDictionary *)response isFeed:(BOOL)isFeed;
 @end

--- a/WordPressKit/RemoteReaderSiteInfo.m
+++ b/WordPressKit/RemoteReaderSiteInfo.m
@@ -1,5 +1,133 @@
 #import "RemoteReaderSiteInfo.h"
+#import "WPKit-Swift.h"
+
+@import NSObject_SafeExpectations;
+
+// Site Topic Keys
+static NSString * const SiteDictionaryFeedIDKey = @"feed_ID";
+static NSString * const SiteDictionaryFeedURLKey = @"feed_URL";
+static NSString * const SiteDictionaryFollowingKey = @"is_following";
+static NSString * const SiteDictionaryJetpackKey = @"is_jetpack";
+static NSString * const SiteDictionaryPrivateKey = @"is_private";
+static NSString * const SiteDictionaryVisibleKey = @"visible";
+static NSString * const SiteDictionaryPostCountKey = @"post_count";
+static NSString * const SiteDictionaryIconPathKey = @"icon.img";
+static NSString * const SiteDictionaryDescriptionKey = @"description";
+static NSString * const SiteDictionaryIDKey = @"ID";
+static NSString * const SiteDictionaryNameKey = @"name";
+static NSString * const SiteDictionaryURLKey = @"URL";
+static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
+static NSString * const SiteDictionarySubscriptionKey = @"subscription";
+
+// Subscription keys
+static NSString * const SubscriptionDeliveryMethodsKey = @"delivery_methods";
+
+// Delivery methods keys
+static NSString * const DeliveryMethodEmailKey = @"email";
+static NSString * const DeliveryMethodNotificationKey = @"notification";
 
 @implementation RemoteReaderSiteInfo
 
++ (instancetype)siteInfoForSiteResponse:(NSDictionary *)response isFeed:(BOOL)isFeed
+{
+    if (isFeed) {
+        return [self siteInfoForFeedResponse:response];
+    }
+
+    RemoteReaderSiteInfo *siteInfo = [RemoteReaderSiteInfo new];
+    siteInfo.feedID = [response numberForKey:SiteDictionaryFeedIDKey];
+    siteInfo.feedURL = [response stringForKey:SiteDictionaryFeedURLKey];
+    siteInfo.isFollowing = [[response numberForKey:SiteDictionaryFollowingKey] boolValue];
+    siteInfo.isJetpack = [[response numberForKey:SiteDictionaryJetpackKey] boolValue];
+    siteInfo.isPrivate = [[response numberForKey:SiteDictionaryPrivateKey] boolValue];
+    siteInfo.isVisible = [[response numberForKey:SiteDictionaryVisibleKey] boolValue];
+    siteInfo.postCount = [response numberForKey:SiteDictionaryPostCountKey];
+    siteInfo.siteBlavatar = [response stringForKeyPath:SiteDictionaryIconPathKey];
+    siteInfo.siteDescription = [response stringForKey:SiteDictionaryDescriptionKey];
+    siteInfo.siteID = [response numberForKey:SiteDictionaryIDKey];
+    siteInfo.siteName = [response stringForKey:SiteDictionaryNameKey];
+    siteInfo.siteURL = [response stringForKey:SiteDictionaryURLKey];
+    siteInfo.subscriberCount = [response numberForKey:SiteDictionarySubscriptionsKey] ?: @0;
+
+    if (![siteInfo.siteName length] && [siteInfo.siteURL length] > 0) {
+        siteInfo.siteName = [[NSURL URLWithString:siteInfo.siteURL] host];
+    }
+
+    siteInfo.endpointPath = [NSString stringWithFormat:@"read/sites/%@/posts/", siteInfo.siteID];
+
+    NSDictionary *subscription = response[SiteDictionarySubscriptionKey];
+    siteInfo.postSubscription = [self.class postSubscriptionFor:subscription];
+    siteInfo.emailSubscription = [self.class emailSubscriptionFor:subscription];
+
+    return siteInfo;
+}
+
++ (instancetype)siteInfoForFeedResponse:(NSDictionary *)response
+{
+    RemoteReaderSiteInfo *siteInfo = [RemoteReaderSiteInfo new];
+    siteInfo.feedID = [response numberForKey:SiteDictionaryFeedIDKey];
+    siteInfo.feedURL = [response stringForKey:SiteDictionaryFeedURLKey];
+    siteInfo.isFollowing = [[response numberForKey:SiteDictionaryFollowingKey] boolValue];
+    siteInfo.isJetpack = NO;
+    siteInfo.isPrivate = NO;
+    siteInfo.isVisible = YES;
+    siteInfo.postCount = @0;
+    siteInfo.siteBlavatar = @"";
+    siteInfo.siteDescription = @"";
+    siteInfo.siteID = @0;
+    siteInfo.siteName = [response stringForKey:SiteDictionaryNameKey];
+    siteInfo.siteURL = [response stringForKey:SiteDictionaryURLKey];
+    siteInfo.subscriberCount = [response numberForKey:SiteDictionarySubscriptionsKey] ?: @0;
+
+    if (![siteInfo.siteName length] && [siteInfo.siteURL length] > 0) {
+        siteInfo.siteName = [[NSURL URLWithString:siteInfo.siteURL] host];
+    }
+    
+    siteInfo.endpointPath = [NSString stringWithFormat:@"read/feed/%@/posts/", siteInfo.feedID];
+
+    return siteInfo;
+}
+
+/**
+ Generate an Site Info Post Subscription object
+
+ @param subscription A dictionary object for the site subscription
+ @return A nullable Site Info Post Subscription
+ */
++ (RemoteReaderSiteInfoSubscriptionPost *)postSubscriptionFor:(NSDictionary *)subscription
+{
+    if (![subscription wp_isValidObject]) {
+        return nil;
+    }
+
+    NSDictionary *method = [[subscription dictionaryForKey: SubscriptionDeliveryMethodsKey] dictionaryForKey: DeliveryMethodNotificationKey];
+
+    if (![method wp_isValidObject]) {
+        return nil;
+    }
+
+    return [[RemoteReaderSiteInfoSubscriptionPost alloc] initWithDictionary:method];
+}
+
+/**
+ Generate an Site Info Email Subscription object
+
+ @param subscription A dictionary object for the site subscription
+ @return A nullable Site Info Email Subscription
+ */
+
++ (RemoteReaderSiteInfoSubscriptionEmail *)emailSubscriptionFor:(NSDictionary *)subscription
+{
+    if (![subscription wp_isValidObject]) {
+        return nil;
+    }
+
+    NSDictionary *method = [[subscription dictionaryForKey: SubscriptionDeliveryMethodsKey] dictionaryForKey: DeliveryMethodEmailKey];
+
+    if (![method wp_isValidObject]) {
+        return nil;
+    }
+
+    return [[RemoteReaderSiteInfoSubscriptionEmail alloc] initWithDictionary:method];
+}
 @end


### PR DESCRIPTION
Part of: https://github.com/wordpress-mobile/WordPress-iOS/issues/14766

### Description
Moves the `RemoteReaderSiteInfo` creation logic to the model instead of in `ReaderTopicServiceRemote`

### Notes
This PR adds a new property `endpointPath` to `RemoteReaderSiteInfo` since the creation logic used to set `postsEndpoint` directly using `-endpointUrlForPath:`. This property can be used to later by the service to set the remote endpoint URL in the service, this prevents the model from having unnecessary logic in it. 

### Testing Details
1. The build should be green
2. Go to WPiOS and point WPKit to your local instance (here: https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/Podfile#L50)
3. Run `bundle exec pod install`
4. Launch the app
5. Tap on the Reader
6. Tap on Following
7. Verify this view loads
8. Verify all your followed sites are present

- [ ] Please check here if your pull request includes additional test coverage.
