### PR TITLE
Reader Improvements: Add support for recommended blogs card type

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.19.0-beta.1"
+  s.version       = "4.19-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.18.0"
+  s.version       = "4.19.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/ReaderTopicServiceRemote.h
+++ b/WordPressKit/ReaderTopicServiceRemote.h
@@ -98,4 +98,7 @@ extern NSString * const WordPressComReaderEndpointURL;
  */
 - (NSString *)slugForTopicName:(NSString *)topicName;
 
+/// Returns a REST URL string for an endpoint path
+/// @param endpoint A partial path for the API
+- (NSString *)endpointUrlForPath:(NSString *)path;
 @end

--- a/WordPressKit/ReaderTopicServiceRemote.h
+++ b/WordPressKit/ReaderTopicServiceRemote.h
@@ -98,7 +98,9 @@ extern NSString * const WordPressComReaderEndpointURL;
  */
 - (NSString *)slugForTopicName:(NSString *)topicName;
 
-/// Returns a REST URL string for an endpoint path
-/// @param endpoint A partial path for the API
+/**
+ Returns a REST URL string for an endpoint path
+ @param path A partial path for the API call
+ */
 - (NSString *)endpointUrlForPath:(NSString *)path;
 @end

--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -213,18 +213,18 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 - (RemoteReaderSiteInfo *)siteInfoFromFollowedSiteDictionary:(NSDictionary *)dict
 {
     NSDictionary *meta = [dict dictionaryForKeyPath:@"meta.data.site"];
-    RemoteReaderSiteInfo *obj;
+    RemoteReaderSiteInfo *siteInfo;
 
     if (meta) {
-        obj = [RemoteReaderSiteInfo siteInfoForSiteResponse:meta isFeed:NO];
+        siteInfo = [RemoteReaderSiteInfo siteInfoForSiteResponse:meta isFeed:NO];
     } else {
         meta = [dict dictionaryForKeyPath:@"meta.data.feed"];
-        obj = [RemoteReaderSiteInfo siteInfoForSiteResponse:meta isFeed:YES];
+        siteInfo = [RemoteReaderSiteInfo siteInfoForSiteResponse:meta isFeed:YES];
     }
 
-    obj.postsEndpoint = [self endpointUrlForPath:obj.endpointPath];
+    siteInfo.postsEndpoint = [self endpointUrlForPath:siteInfo.endpointPath];
     
-    return obj;
+    return siteInfo;
 }
 
 - (NSString *)endpointUrlForPath:(NSString *)endpoint

--- a/WordPressKitTests/Mock Data/reader-cards-success.json
+++ b/WordPressKitTests/Mock Data/reader-cards-success.json
@@ -20,9 +20,32 @@
                 }
             ]
         },
-        {
-            "type": "recommended_blogs",
-            "data": []
+    {
+        "type": "recommended_blogs",
+        "data": [{
+            "description": "Lorem Ipsum Sit Dolor Amet",
+            "feed_ID": 123456789,
+            "feed_URL": "http://loremipsum.wordpress.com",
+            "icon": {
+                "img": "http://loremipsum.wordpress.com/wp-content/uploads/2020/10/example.png",
+                "ico": "http://loremipsum.wordpress.com/wp-content/uploads/2020/10/example.png?w=16",
+            },
+            "ID": 987654321,
+            "is_private": false,
+            "jetpack": false,
+            "name": "Lipsum's Blog",
+            "prefer_feed": false,
+            "subscribers_count": 123,
+            "subscription": {
+                "delivery_methods": {
+                    "email": null,
+                    "notification": {
+                        "send_posts": false
+                    },
+                }
+            },
+            "URL": "http://loremipsum.wordpress.com",
+        }]
         }, {
             "type": "post",
             "data": {

--- a/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
@@ -48,7 +48,7 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
 
         readerPostServiceRemote.fetchCards(for: ["cats"], success: { cards, _ in
             let postTypes = cards.map { $0.type }
-            let expectedPostTypes: [RemoteReaderCard.CardType] = [.interests, .unknown, .post, .post, .post, .post, .post, .post, .post, .post]
+            let expectedPostTypes: [RemoteReaderCard.CardType] = [.interests, .sites, .post, .post, .post, .post, .post, .post, .post, .post]
             XCTAssertTrue(postTypes == expectedPostTypes)
             expect.fulfill()
         }, failure: { _ in })


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/14766
Review after https://github.com/wordpress-mobile/WordPressKit-iOS/pull/292 is merged 

### Description
Add support for recommended blogs card type in `RemoteReaderCard`

### Testing Details
1. Run the `ReaderPostServiceRemoteCardTests` to verify the sites value is being parsed correctly

- [x] Please check here if your pull request includes additional test coverage.
