### PR TITLE
Add additional parameters in getActivityForSite

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.21.0-beta.1"
+  s.version       = "4.21.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -106,6 +106,28 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
+    func testGetActivityWithParameters() {
+        let expect = expectation(description: "Get activity for site success when calling with after, before, and group")
+
+        stubRemoteResponse("after=1970-01-01&before=1970-01-02&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        remote.getActivityForSite(siteID,
+                                  offset: 100,
+                                  count: 20,
+                                  after: Date(timeIntervalSince1970: 60 * 60 * 24),
+                                  before: Date(timeIntervalSince1970: 60 * 60 * 24 * 2),
+                                  group: ["post", "user"],
+                                  success: { (activities, hasMore) in
+                                      XCTAssertEqual(activities.count, 19, "The activity count should be 19")
+                                      XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
+                                      expect.fulfill()
+                                  }, failure: { error in
+                                      XCTFail("This callback shouldn't get called")
+                                      expect.fulfill()
+                                  })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
     func testGetActivityWithBadAuthFails() {
         let expect = expectation(description: "Get activity with bad auth failure")
 

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -108,13 +108,14 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     func testGetActivityWithParameters() {
         let expect = expectation(description: "Get activity for site success when calling with after, before, and group")
+        let dateFormatter = ISO8601DateFormatter()
 
         stubRemoteResponse("after=1970-01-01&before=1970-01-02&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
         remote.getActivityForSite(siteID,
                                   offset: 100,
                                   count: 20,
-                                  after: Date(timeIntervalSince1970: 60 * 60 * 24),
-                                  before: Date(timeIntervalSince1970: 60 * 60 * 24 * 2),
+                                  after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
+                                  before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),
                                   group: ["post", "user"],
                                   success: { (activities, hasMore) in
                                       XCTAssertEqual(activities.count, 19, "The activity count should be 19")


### PR DESCRIPTION
Added 3 new parameters in getActivityForSite:

* `after`
* `before`
* `group`

These will be used in the new filters for Activity Log in WPiOS. Documentation about each parameter can be found in the code.