### PR TITLE
Makes PluginState.directoryURL and optional to fix a crash.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.22.0-beta.1"
+  s.version       = "4.22.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/PluginState.swift
+++ b/WordPressKit/PluginState.swift
@@ -106,8 +106,8 @@ public extension PluginState {
         return url
     }
 
-    var directoryURL: URL {
-        return URL(string: "https://wordpress.org/plugins/\(slug)")!
+    var directoryURL: URL? {
+        return URL(string: "https://wordpress.org/plugins/\(slug)")
     }
 
     var deactivateAllowed: Bool {


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/15332

This PR makes PluginState.directoryURL an optional rather than implicitly unwrapping the returned URL.  This will help address the crash in https://github.com/wordpress-mobile/WordPress-iOS/issues/15332 .

### Testing Details
Run unit tests. Confirm they all pass.

Test WPiOS against this branch (or commit) for regressions as follows: 
Select a self-hosted + Jetpack site and navigate to My Site > Plugins > Popular See All > Any Plugin Row.  Confirm the detail screen appears and there is no crash.

@emilylaguna would you be game to help test this one? 
Whoops! Didn't realize Emily was unavailable. 🤦   @ScoutHarris could I trouble you? 