### PR TITLE
Activities requests: format using date and hour

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.23.0-beta.1"
+  s.version       = "4.23.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -49,9 +49,9 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         }
 
         if let after = after, let before = before,
-           let beforeMinusOneSecond = Calendar.current.date(byAdding: .second, value: -1, to: before) {
+           let lastSecondOfBeforeDay = Calendar.current.date(byAdding: .second, value: 86399, to: before) {
             parameters["after"] = formatter.string(from: after) as AnyObject
-            parameters["before"] = formatter.string(from: beforeMinusOneSecond) as AnyObject
+            parameters["before"] = formatter.string(from: lastSecondOfBeforeDay) as AnyObject
         } else if let on = after ?? before {
             parameters["on"] = formatter.string(from: on) as AnyObject
         }
@@ -95,9 +95,9 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         var parameters: [String: AnyObject] = [:]
 
         if let after = after, let before = before,
-           let beforeMinusOneSecond = Calendar.current.date(byAdding: .second, value: -1, to: before) {
+           let lastSecondOfBeforeDay = Calendar.current.date(byAdding: .second, value: 86399, to: before) {
             parameters["after"] = formatter.string(from: after) as AnyObject
-            parameters["before"] = formatter.string(from: beforeMinusOneSecond) as AnyObject
+            parameters["before"] = formatter.string(from: lastSecondOfBeforeDay) as AnyObject
         } else if let on = after ?? before {
             parameters["on"] = formatter.string(from: on) as AnyObject
         }

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -10,7 +10,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
 
     private lazy var formatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = ("yyyy-MM-dd")
+        formatter.dateFormat = ("yyyy-MM-dd HH:mm:ss")
         return formatter
     }()
 
@@ -48,9 +48,10 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
             parameters["group[]"] = group.joined(separator: ",") as AnyObject
         }
 
-        if let after = after, let before = before {
+        if let after = after, let before = before,
+           let beforeMinusOneSecond = Calendar.current.date(byAdding: .second, value: -1, to: before) {
             parameters["after"] = formatter.string(from: after) as AnyObject
-            parameters["before"] = formatter.string(from: before) as AnyObject
+            parameters["before"] = formatter.string(from: beforeMinusOneSecond) as AnyObject
         } else if let on = after ?? before {
             parameters["on"] = formatter.string(from: on) as AnyObject
         }
@@ -93,9 +94,10 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
         var parameters: [String: AnyObject] = [:]
 
-        if let after = after, let before = before {
+        if let after = after, let before = before,
+           let beforeMinusOneSecond = Calendar.current.date(byAdding: .second, value: -1, to: before) {
             parameters["after"] = formatter.string(from: after) as AnyObject
-            parameters["before"] = formatter.string(from: before) as AnyObject
+            parameters["before"] = formatter.string(from: beforeMinusOneSecond) as AnyObject
         } else if let on = after ?? before {
             parameters["on"] = formatter.string(from: on) as AnyObject
         }

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -11,6 +11,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
     private lazy var formatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = ("yyyy-MM-dd HH:mm:ss")
+        formatter.timeZone = NSTimeZone(forSecondsFromGMT: 0) as TimeZone
         return formatter
     }()
 

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -43,12 +43,16 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         let v2RestApi = WordPressComRestApi(localeKey: WordPressComRestApi.LocaleKeyV2)
         remote = ActivityServiceRemote(wordPressComRestApi: v2RestApi)
+
+        NSTimeZone.default = NSTimeZone(forSecondsFromGMT: 0) as TimeZone
     }
 
     override func tearDown() {
         super.tearDown()
 
         remote = nil
+
+        NSTimeZone.default = NSTimeZone.local
     }
 
     /// MARK: - Get Activity Tests
@@ -113,7 +117,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity for site success when calling with after, before, and group")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("after=1970-01-01%2007%3A44%3A00&before=1970-01-03%2007%3A43%3A59&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("after=1970-01-01%2010%3A44%3A00&before=1970-01-03%2010%3A43%3A59&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
         remote.getActivityForSite(siteID,
                                   offset: 100,
                                   count: 20,
@@ -136,7 +140,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity for site success when calling with after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("number=20&on=1970-01-01%2007%3A44%3A00&page=1", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("number=20&on=1970-01-01%2010%3A44%3A00&page=1", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
         remote.getActivityForSite(siteID,
                                   count: 20,
                                   after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
@@ -209,7 +213,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity groups for site success when calling with before, after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("1970-01-01%2007%3A44%3A00&before=1970-01-03%2007%3A43%3A59", filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("1970-01-01%2010%3A44%3A00&before=1970-01-03%2010%3A43%3A59", filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
         remote.getActivityGroupsForSite(siteID,
                                         after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
                                         before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -113,7 +113,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity for site success when calling with after, before, and group")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("after=1970-01-01%2007%3A44%3A00&before=1970-01-02%2007%3A43%3A59&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("after=1970-01-01%2007%3A44%3A00&before=1970-01-03%2007%3A43%3A59&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
         remote.getActivityForSite(siteID,
                                   offset: 100,
                                   count: 20,
@@ -209,7 +209,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity groups for site success when calling with before, after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("1970-01-01%2007%3A44%3A00&before=1970-01-02%2007%3A43%3A59", filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("1970-01-01%2007%3A44%3A00&before=1970-01-03%2007%3A43%3A59", filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
         remote.getActivityGroupsForSite(siteID,
                                         after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
                                         before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -113,7 +113,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity for site success when calling with after, before, and group")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("after=1970-01-01&before=1970-01-02&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("after=1970-01-01%2007%3A44%3A00&before=1970-01-02%2007%3A43%3A59&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
         remote.getActivityForSite(siteID,
                                   offset: 100,
                                   count: 20,
@@ -136,7 +136,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity for site success when calling with after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("number=20&on=1970-01-01&page=1", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("number=20&on=1970-01-01%2007%3A44%3A00&page=1", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
         remote.getActivityForSite(siteID,
                                   count: 20,
                                   after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
@@ -209,7 +209,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity groups for site success when calling with before, after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("after=1970-01-01&before=1970-01-02", filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("1970-01-01%2007%3A44%3A00&before=1970-01-02%2007%3A43%3A59", filename: getActivityGroupsSuccessMockFilename, contentType: .ApplicationJSON)
         remote.getActivityGroupsForSite(siteID,
                                         after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
                                         before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),


### PR DESCRIPTION
### Description

This PR adds logic to match .com when making requests to retrieve activities or groups.

### How to test

Please refer to this WPiOS PR to test: https://github.com/wordpress-mobile/WordPress-iOS/pull/15412