### PR TITLE
Fix JetpackScan model parsing errors

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.23.0-beta.2"
+  s.version       = "4.23.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/Jetpack Scan/JetpackCredentials.swift
+++ b/WordPressKit/Jetpack Scan/JetpackCredentials.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// A limited representation of the users Jetpack credentials
 public struct JetpackScanCredentials: Decodable {
-    public let host: String
-    public let port: Int
-    public let user: String
-    public let path: String
+    public let host: String?
+    public let port: Int?
+    public let user: String?
+    public let path: String?
     public let type: String
     public let role: String
     public let stillValid: Bool

--- a/WordPressKit/Jetpack Scan/JetpackScan.swift
+++ b/WordPressKit/Jetpack Scan/JetpackScan.swift
@@ -6,20 +6,18 @@ public struct JetpackScan: Decodable {
         case scanning
         case unavailable
         case provisioning
-        
+
         case unknown
         static let unknownCase: Self = .unknown
     }
 
     /// Whether the scan feature is available or not
-    public var isEnabled: Bool = false
+    public var isEnabled: Bool {
+        return (state != .unavailable) && (state != .unknown)
+    }
 
     /// The state of the current scan
-    public var state: JetpackScanState {
-        didSet {
-            isEnabled = (state != .unavailable) && (state != .unknown)
-        }
-    }
+    public var state: JetpackScanState
 
     /// If there is a scan in progress, this will return its status
     public var current: JetpackScanStatus?
@@ -57,7 +55,7 @@ public struct JetpackScanStatus: Decodable {
     /// If there was an error finishing the scan
     /// This will only be available for past scans
     public var didFail: Bool?
-    
+
     private enum CodingKeys: String, CodingKey {
         case startDate = "timestamp", didFail = "error"
         case duration, progress, isInitial

--- a/WordPressKit/Jetpack Scan/JetpackScanThreat.swift
+++ b/WordPressKit/Jetpack Scan/JetpackScanThreat.swift
@@ -105,7 +105,7 @@ public struct JetpackScanThreat: Decodable {
         // - an empty string
         // we can not just set to nil because the threat type logic needs to know if the
         // context attr was present or not
-        if let contextDict = try container.decodeIfPresent([String: Any].self, forKey: .context) {
+        if let contextDict = try? container.decodeIfPresent([String: Any].self, forKey: .context) {
             context = JetpackThreatContext(with: contextDict)
         } else if ((try container.decodeIfPresent(String.self, forKey: .context)) != nil) {
             context = JetpackThreatContext.emptyObject()


### PR DESCRIPTION
### Description

This PR fixes some issues while parsing the scan data: 
- The Jetpack Scan credentials may not include all the fields so I made them optional
- The context parsing was throwing when `context: ""` (context is an empty string)
- `isEnabled` is always false because `didSet` is not called on initialization

You can test it using the following WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15427

### Testing Details
Follow the testing steps on the PR here: https://github.com/wordpress-mobile/WordPress-iOS/pull/15427

- [ ] Please check here if your pull request includes additional test coverage.
