### PR TITLE
Activity log: fix activies request when using multiple groups

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.23.0-beta.5"
+  s.version       = "4.23.0-beta.6"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.23.0-beta.4"
+  s.version       = "4.23.0-beta.5"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -343,6 +343,7 @@
 		8B2F4BED24ABCAEF0056C08A /* Decodable+Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */; };
 		8B2F4BEF24ACCC120056C08A /* RemoteReaderCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */; };
 		8B2F4BF124ACE3C30056C08A /* RemoteReaderInterest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B2F4BF024ACE3C30056C08A /* RemoteReaderInterest.swift */; };
+		8B52B901257AC5A200221663 /* Date+endOfDay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B52B900257AC5A200221663 /* Date+endOfDay.swift */; };
 		8BB66DB02523C181000B29DA /* ReaderPostServiceRemote+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB66DAF2523C181000B29DA /* ReaderPostServiceRemote+V2.swift */; };
 		8BE67ED324AD05D3004DB4C9 /* Decodable+DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */; };
 		8C5734F925681A6A005E61EE /* Enum+UnknownCaseRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C5734F825681A6A005E61EE /* Enum+UnknownCaseRepresentable.swift */; };
@@ -900,6 +901,7 @@
 		8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+Dictionary.swift"; sourceTree = "<group>"; };
 		8B2F4BEE24ACCC120056C08A /* RemoteReaderCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReaderCard.swift; sourceTree = "<group>"; };
 		8B2F4BF024ACE3C30056C08A /* RemoteReaderInterest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReaderInterest.swift; sourceTree = "<group>"; };
+		8B52B900257AC5A200221663 /* Date+endOfDay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+endOfDay.swift"; sourceTree = "<group>"; };
 		8BB66DAF2523C181000B29DA /* ReaderPostServiceRemote+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostServiceRemote+V2.swift"; sourceTree = "<group>"; };
 		8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+DictionaryTests.swift"; sourceTree = "<group>"; };
 		8C5734F825681A6A005E61EE /* Enum+UnknownCaseRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Enum+UnknownCaseRepresentable.swift"; sourceTree = "<group>"; };
@@ -1362,6 +1364,7 @@
 				7E3E7A4B20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift */,
 				8B2F4BEC24ABCAEF0056C08A /* Decodable+Dictionary.swift */,
 				8C5734F825681A6A005E61EE /* Enum+UnknownCaseRepresentable.swift */,
+				8B52B900257AC5A200221663 /* Date+endOfDay.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -2684,6 +2687,7 @@
 				74C473AC1EF2F75E009918F2 /* SiteManagementServiceRemote.swift in Sources */,
 				74585B971F0D54B400E7E667 /* RemoteDomain.swift in Sources */,
 				74A44DD01F13C64B006CD8F4 /* RemoteNotification.swift in Sources */,
+				8B52B901257AC5A200221663 /* Date+endOfDay.swift in Sources */,
 				E1D6B558200E473A00325669 /* TimeZoneServiceRemote.swift in Sources */,
 				1769DEAA24729AFF00F42EFC /* HomepageSettingsServiceRemote.swift in Sources */,
 				93BD273D1EE73282002BB00B /* AccountServiceRemoteREST.m in Sources */,

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -42,7 +42,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
 
         path?.queryItems = group.map { URLQueryItem(name: "group[]", value: $0) }
 
-        let pageNumber = (offset / count + 1)
+        let pageNumber = (offset / count) + 1
         path?.queryItems?.append(URLQueryItem(name: "number", value: "\(count)"))
         path?.queryItems?.append(URLQueryItem(name: "page", value: "\(pageNumber)"))
 

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -47,7 +47,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         path?.queryItems?.append(URLQueryItem(name: "page", value: "\(pageNumber)"))
 
         if let after = after, let before = before,
-           let lastSecondOfBeforeDay = Calendar.current.date(byAdding: .second, value: 86399, to: before) {
+           let lastSecondOfBeforeDay = before.endOfDay() {
             path?.queryItems?.append(URLQueryItem(name: "after", value: formatter.string(from: after)))
             path?.queryItems?.append(URLQueryItem(name: "before", value: formatter.string(from: lastSecondOfBeforeDay)))
         } else if let on = after ?? before {
@@ -99,7 +99,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
         var parameters: [String: AnyObject] = [:]
 
         if let after = after, let before = before,
-           let lastSecondOfBeforeDay = Calendar.current.date(byAdding: .second, value: 86399, to: before) {
+           let lastSecondOfBeforeDay = before.endOfDay() {
             parameters["after"] = formatter.string(from: after) as AnyObject
             parameters["before"] = formatter.string(from: lastSecondOfBeforeDay) as AnyObject
         } else if let on = after ?? before {

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -37,28 +37,31 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
                                    group: [String] = [],
                                    success: @escaping (_ activities: [Activity], _ hasMore: Bool) -> Void,
                                    failure: @escaping (Error) -> Void) {
-        let endpoint = "sites/\(siteID)/activity"
-        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
-        let pageNumber = (offset / count + 1)
-        var parameters: [String: AnyObject] = [
-            "number": count as AnyObject,
-            "page": pageNumber as AnyObject
-        ]
 
-        if !group.isEmpty {
-            parameters["group[]"] = group.joined(separator: ",") as AnyObject
-        }
+        var path = URLComponents(string: "sites/\(siteID)/activity")
+
+        path?.queryItems = group.map { URLQueryItem(name: "group[]", value: $0) }
+
+        let pageNumber = (offset / count + 1)
+        path?.queryItems?.append(URLQueryItem(name: "number", value: "\(count)"))
+        path?.queryItems?.append(URLQueryItem(name: "page", value: "\(pageNumber)"))
 
         if let after = after, let before = before,
            let lastSecondOfBeforeDay = Calendar.current.date(byAdding: .second, value: 86399, to: before) {
-            parameters["after"] = formatter.string(from: after) as AnyObject
-            parameters["before"] = formatter.string(from: lastSecondOfBeforeDay) as AnyObject
+            path?.queryItems?.append(URLQueryItem(name: "after", value: formatter.string(from: after)))
+            path?.queryItems?.append(URLQueryItem(name: "before", value: formatter.string(from: lastSecondOfBeforeDay)))
         } else if let on = after ?? before {
-            parameters["on"] = formatter.string(from: on) as AnyObject
+            path?.queryItems?.append(URLQueryItem(name: "on", value: formatter.string(from: on)))
         }
 
-        wordPressComRestApi.GET(path,
-                                parameters: parameters,
+        guard let endpoint = path?.string else {
+            return
+        }
+
+        let finalPath = self.path(forEndpoint: endpoint, withVersion: ._2_0)
+
+        wordPressComRestApi.GET(finalPath,
+                                parameters: nil,
                                 success: { response, _ in
                                     do {
                                         let (activities, totalItems) = try self.mapActivitiesResponse(response)

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -192,9 +192,12 @@ private extension ActivityServiceRemote {
     }
     
     func mapActivityGroupsResponse(_ response: AnyObject) throws -> ([ActivityGroup]) {
-        
         guard let json = response as? [String: AnyObject],
-              let rawGroups = json["groups"] as? [String: AnyObject] else {
+              let totalItems = json["totalItems"] as? Int, totalItems > 0 else {
+            return []
+        }
+        
+        guard let rawGroups = json["groups"] as? [String: AnyObject] else {
                 throw ActivityServiceRemote.ResponseError.decodingFailure
         }
         

--- a/WordPressKit/Date+endOfDay.swift
+++ b/WordPressKit/Date+endOfDay.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension Date {
+    /// Returns a Date representing the last second of the given day
+    ///
+    func endOfDay() -> Date? {
+        Calendar.current.date(byAdding: .second, value: 86399, to: self)
+    }
+}

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -117,7 +117,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity for site success when calling with after, before, and group")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("after=1970-01-01%2010%3A44%3A00&before=1970-01-03%2010%3A43%3A59&group%5B%5D=post%2Cuser&number=20&page=6", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("group%5B%5D=post&group%5B%5D=user&number=20&page=6&after=1970-01-01%2010:44:00&before=1970-01-03%2010:43:59", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
         remote.getActivityForSite(siteID,
                                   offset: 100,
                                   count: 20,
@@ -140,7 +140,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get activity for site success when calling with after")
         let dateFormatter = ISO8601DateFormatter()
 
-        stubRemoteResponse("number=20&on=1970-01-01%2010%3A44%3A00&page=1", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
+        stubRemoteResponse("wpcom/v2/sites/321/activity?number=20&page=1&on=1970-01-01%2010:44:00", filename: getActivitySuccessThreeMockFilename, contentType: .ApplicationJSON)
         remote.getActivityForSite(siteID,
                                   count: 20,
                                   after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),


### PR DESCRIPTION
### Description

This PR changes how the request to retrieve activities is made to split the groups into multiple `groups[]` params.

It also fixes a decoding error from the group's endpoint that should be treated as empty results.

You can test the PR here: https://github.com/wordpress-mobile/WordPress-iOS/pull/15440