### PR TITLE
Support for Reader P2 menu option

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.23.0-beta.4"
+  s.version       = "4.23.0-beta.5"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -26,7 +26,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 {
     NSString *path = @"read/menu";
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_3];
 
     [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(NSDictionary *response, NSHTTPURLResponse *httpResponse) {
         if (!success) {

--- a/WordPressKit/RemoteReaderPost.h
+++ b/WordPressKit/RemoteReaderPost.h
@@ -26,6 +26,7 @@
 @property (nonatomic) BOOL isLiked;
 @property (nonatomic) BOOL isReblogged;
 @property (nonatomic) BOOL isWPCom;
+@property (nonatomic) BOOL isWPForTeams;
 @property (nonatomic, strong) NSNumber *likeCount;
 @property (nonatomic, strong) NSNumber *score;
 @property (nonatomic, strong) NSNumber *siteID;

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -55,6 +55,14 @@ NSString * const PostRESTKeyURL = @"URL";
 NSString * const PostRESTKeyWordCount = @"word_count";
 NSString * const PostRESTKeyRailcar = @"railcar";
 
+// isWPForTeams keys
+NSString * const PostRESTKeyMeta = @"meta";
+NSString * const PostRESTKeyData = @"data";
+NSString * const PostRESTKeySite = @"site";
+NSString * const PostRESTKeyOptions = @"options";
+NSString * const PostRESTKeyWPForTeams = @"is_wpforteams_site";
+
+
 // Tag dictionary keys
 NSString * const TagKeyPrimary = @"primaryTag";
 NSString * const TagKeyPrimarySlug = @"primaryTagSlug";
@@ -124,6 +132,13 @@ static const NSUInteger ReaderPostTitleLength = 30;
     self.isSharingEnabled = [[dict numberForKey:PostRESTKeySharingEnabled] boolValue];
     self.isLikesEnabled = [[dict numberForKey:PostRESTKeyLikesEnabled] boolValue];
 
+    // Get isWPForTeams from site options
+    NSDictionary *metaDict = [dict dictionaryForKey:PostRESTKeyMeta];
+    NSDictionary *dataDict = [metaDict dictionaryForKey:PostRESTKeyData];
+    NSDictionary *siteDict = [dataDict dictionaryForKey:PostRESTKeySite];
+    NSDictionary *optionsDict = [siteDict dictionaryForKey:PostRESTKeyOptions];
+    self.isWPForTeams = [[optionsDict numberForKey:PostRESTKeyWPForTeams] boolValue];
+    
     // Construct a title if necessary.
     if ([self.postTitle length] == 0 && [self.summary length] > 0) {
         self.postTitle = [self titleFromSummary:self.summary];

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -54,14 +54,7 @@ NSString * const POSTRESTKeyTagDisplayName = @"display_name";
 NSString * const PostRESTKeyURL = @"URL";
 NSString * const PostRESTKeyWordCount = @"word_count";
 NSString * const PostRESTKeyRailcar = @"railcar";
-
-// isWPForTeams keys
-NSString * const PostRESTKeyMeta = @"meta";
-NSString * const PostRESTKeyData = @"data";
-NSString * const PostRESTKeySite = @"site";
-NSString * const PostRESTKeyOptions = @"options";
-NSString * const PostRESTKeyWPForTeams = @"is_wpforteams_site";
-
+NSString * const PostRESTKeyWPForTeams = @"meta.data.site.options.is_wpforteams_site";
 
 // Tag dictionary keys
 NSString * const TagKeyPrimary = @"primaryTag";
@@ -131,13 +124,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     self.tags = [self tagsFromPostDictionary:dict];
     self.isSharingEnabled = [[dict numberForKey:PostRESTKeySharingEnabled] boolValue];
     self.isLikesEnabled = [[dict numberForKey:PostRESTKeyLikesEnabled] boolValue];
-
-    // Get isWPForTeams from site options
-    NSDictionary *metaDict = [dict dictionaryForKey:PostRESTKeyMeta];
-    NSDictionary *dataDict = [metaDict dictionaryForKey:PostRESTKeyData];
-    NSDictionary *siteDict = [dataDict dictionaryForKey:PostRESTKeySite];
-    NSDictionary *optionsDict = [siteDict dictionaryForKey:PostRESTKeyOptions];
-    self.isWPForTeams = [[optionsDict numberForKey:PostRESTKeyWPForTeams] boolValue];
+    self.isWPForTeams = [[dict numberForKeyPath:PostRESTKeyWPForTeams] boolValue];
     
     // Construct a title if necessary.
     if ([self.postTitle length] == 0 && [self.summary length] > 0) {


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15343
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15442

This does two things:
- Updates the API version for `read/menu` to get the P2 menu option for the Reader.
- Adds the site's `isWPForTeams` flag to `RemoteReaderPost` .

### Testing Details

Can be tested with the referenced WPiOS PR.

---
- [ ] Please check here if your pull request includes additional test coverage.
