### PR TITLE
Reader: update to use site's organization_id

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.23.0-beta.6"
+  s.version       = "4.23.0-beta.7"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/RemoteReaderPost.h
+++ b/WordPressKit/RemoteReaderPost.h
@@ -20,13 +20,13 @@
 @property (nonatomic, strong) NSNumber *feedID;
 @property (nonatomic, strong) NSNumber *feedItemID;
 @property (nonatomic, strong) NSString *globalID;
+@property (nonatomic, strong) NSNumber *organizationID;
 @property (nonatomic) BOOL isBlogAtomic;
 @property (nonatomic) BOOL isBlogPrivate;
 @property (nonatomic) BOOL isFollowing;
 @property (nonatomic) BOOL isLiked;
 @property (nonatomic) BOOL isReblogged;
 @property (nonatomic) BOOL isWPCom;
-@property (nonatomic) BOOL isWPForTeams;
 @property (nonatomic, strong) NSNumber *likeCount;
 @property (nonatomic, strong) NSNumber *score;
 @property (nonatomic, strong) NSNumber *siteID;

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -54,7 +54,7 @@ NSString * const POSTRESTKeyTagDisplayName = @"display_name";
 NSString * const PostRESTKeyURL = @"URL";
 NSString * const PostRESTKeyWordCount = @"word_count";
 NSString * const PostRESTKeyRailcar = @"railcar";
-NSString * const PostRESTKeyWPForTeams = @"meta.data.site.options.is_wpforteams_site";
+NSString * const PostRESTKeyOrganizationID = @"meta.data.site.organization_id";
 
 // Tag dictionary keys
 NSString * const TagKeyPrimary = @"primaryTag";
@@ -124,7 +124,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     self.tags = [self tagsFromPostDictionary:dict];
     self.isSharingEnabled = [[dict numberForKey:PostRESTKeySharingEnabled] boolValue];
     self.isLikesEnabled = [[dict numberForKey:PostRESTKeyLikesEnabled] boolValue];
-    self.isWPForTeams = [[dict numberForKeyPath:PostRESTKeyWPForTeams] boolValue];
+    self.organizationID = [dict numberForKeyPath:PostRESTKeyOrganizationID] ?: @0;
     
     // Construct a title if necessary.
     if ([self.postTitle length] == 0 && [self.summary length] > 0) {

--- a/WordPressKit/RemoteReaderSiteInfo.h
+++ b/WordPressKit/RemoteReaderSiteInfo.h
@@ -10,9 +10,9 @@
 @property (nonatomic, copy) NSString *feedURL;
 @property (nonatomic) BOOL isFollowing;
 @property (nonatomic) BOOL isJetpack;
-@property (nonatomic) BOOL isWPForTeams;
 @property (nonatomic) BOOL isPrivate;
 @property (nonatomic) BOOL isVisible;
+@property (nonatomic, copy) NSNumber *organizationID;
 @property (nonatomic, copy) NSNumber *postCount;
 @property (nonatomic, copy) NSString *siteBlavatar;
 @property (nonatomic, copy) NSString *siteDescription;

--- a/WordPressKit/RemoteReaderSiteInfo.m
+++ b/WordPressKit/RemoteReaderSiteInfo.m
@@ -49,7 +49,7 @@ static NSString * const DeliveryMethodNotificationKey = @"notification";
     siteInfo.siteName = [response stringForKey:SiteDictionaryNameKey];
     siteInfo.siteURL = [response stringForKey:SiteDictionaryURLKey];
     siteInfo.subscriberCount = [response numberForKey:SiteDictionarySubscriptionsKey] ?: @0;
-    siteInfo.organizationID = [response numberForKey:SiteDictionaryOrganizationID];
+    siteInfo.organizationID = [response numberForKey:SiteDictionaryOrganizationID] ?: @0;
 
     if (![siteInfo.siteName length] && [siteInfo.siteURL length] > 0) {
         siteInfo.siteName = [[NSURL URLWithString:siteInfo.siteURL] host];

--- a/WordPressKit/RemoteReaderSiteInfo.m
+++ b/WordPressKit/RemoteReaderSiteInfo.m
@@ -8,7 +8,7 @@ static NSString * const SiteDictionaryFeedIDKey = @"feed_ID";
 static NSString * const SiteDictionaryFeedURLKey = @"feed_URL";
 static NSString * const SiteDictionaryFollowingKey = @"is_following";
 static NSString * const SiteDictionaryJetpackKey = @"is_jetpack";
-static NSString * const SiteDictionaryIsWPForTeamsKey = @"is_wpforteams_site";
+static NSString * const SiteDictionaryOrganizationID = @"organization_id";
 static NSString * const SiteDictionaryPrivateKey = @"is_private";
 static NSString * const SiteDictionaryVisibleKey = @"visible";
 static NSString * const SiteDictionaryPostCountKey = @"post_count";
@@ -19,7 +19,6 @@ static NSString * const SiteDictionaryNameKey = @"name";
 static NSString * const SiteDictionaryURLKey = @"URL";
 static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
 static NSString * const SiteDictionarySubscriptionKey = @"subscription";
-static NSString * const SiteDictionaryOptionsKey = @"options";
 
 // Subscription keys
 static NSString * const SubscriptionDeliveryMethodsKey = @"delivery_methods";
@@ -50,9 +49,7 @@ static NSString * const DeliveryMethodNotificationKey = @"notification";
     siteInfo.siteName = [response stringForKey:SiteDictionaryNameKey];
     siteInfo.siteURL = [response stringForKey:SiteDictionaryURLKey];
     siteInfo.subscriberCount = [response numberForKey:SiteDictionarySubscriptionsKey] ?: @0;
-
-    NSDictionary *options = [response valueForKey:SiteDictionaryOptionsKey];
-    siteInfo.isWPForTeams = [[options numberForKey:SiteDictionaryIsWPForTeamsKey] boolValue];
+    siteInfo.organizationID = [response numberForKey:SiteDictionaryOrganizationID];
 
     if (![siteInfo.siteName length] && [siteInfo.siteURL length] > 0) {
         siteInfo.siteName = [[NSURL URLWithString:siteInfo.siteURL] host];


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15343, https://github.com/wordpress-mobile/WordPress-iOS/issues/15264
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15461

This updates `RemoteReadePost` and `RemoteReaderSiteInfo` to parse the site's `organization_id` instead of `is_wpforteams_site`. This is used by WP to determine if a site is a P2.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
