### PR TITLE
Adds optional parameter for quantity to Domain Suggestion service

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.23.0-beta.7"
+  s.version       = "4.23.0-beta.8"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/WordPress-iOS/issues/15378
**Related PR:** 
    - `WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/15482

### Description
This adds an optional parameter to the `getDomainSuggestions` service to also accept a `quantity`. By default, the API endpoint returns `5` results which can also result in inconsistent behavior where a request asking for `5` results might return nothing but a request for `20` will return results. 

### Testing Details
This can be tested alongside the `WordPress-iOS` PR 

<details>
<summary>Testing steps from WordPress-iOS PR</summary>

### Search results have a match
1. Navigate to the Create WordPress.com site
    - My Sites > ➕ > Create WordPress.com site 
1. Choose a design or skip (this should be tested with each path to trigger both endpoints) 
1. Search for a Domain
1. **Expect** 
    - To have a maximum of 20 results displayed (Could be less depending on domain availability and your search term)
    - You should be able to scroll so the last row beyond the keyboard
    - The results should be sorted with exact matches first, then alphabetically after that. (Subdomains are sorted alphabetically)

### Search results don't have a match
1. Navigate to the Create WordPress.com site
    - My Sites > ➕ > Create WordPress.com site 
1. Choose a design or skip 
1. Search for a Domain
1. **Expect** 
    - To see a cell with `{your search term}.wordpress.com` and `This domain is unavailable`

## Screenshots:

Exact Match | No Match
--- | ---
<kbd><a href="https://user-images.githubusercontent.com/3384451/101957800-21215100-3bd0-11eb-90c3-8febb14bd77c.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/101957800-21215100-3bd0-11eb-90c3-8febb14bd77c.png"/></a></kbd> | <kbd><a href="https://user-images.githubusercontent.com/3384451/101957932-634a9280-3bd0-11eb-8180-0935e04680d7.png"><img width="300" src="https://user-images.githubusercontent.com/3384451/101957932-634a9280-3bd0-11eb-8180-0935e04680d7.png"/></a></kbd>


</details>


- [ ] Please check here if your pull request includes additional test coverage.
