### PR TITLE
Add organization_id to RemoteReaderTopic.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.23.0"
+  s.version       = "4.24.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -11,6 +11,7 @@ static NSString * const TopicMenuSectionRecommendedKey = @"recommended";
 static NSString * const TopicRemovedTagKey = @"removed_tag";
 static NSString * const TopicAddedTagKey = @"added_tag";
 static NSString * const TopicDictionaryIDKey = @"ID";
+static NSString * const TopicDictionaryOrganizationIDKey = @"organization_id";
 static NSString * const TopicDictionaryOwnerKey = @"owner";
 static NSString * const TopicDictionarySlugKey = @"slug";
 static NSString * const TopicDictionaryTagKey = @"tag";
@@ -335,6 +336,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
     topic.slug = [topicDict stringForKey:TopicDictionarySlugKey];
     topic.title = [topicDict stringForKey:TopicDictionaryDisplayNameKey] ?: [topicDict stringForKey:TopicDictionaryTitleKey];
     topic.type = [topicDict stringForKey:TopicDictionaryTypeKey];
+    topic.organizationID = [topicDict numberForKeyPath:TopicDictionaryOrganizationIDKey] ?: @0;
 
     return topic;
 }

--- a/WordPressKit/RemoteReaderTopic.h
+++ b/WordPressKit/RemoteReaderTopic.h
@@ -12,5 +12,6 @@
 @property (nonatomic, strong) NSNumber *topicID;
 @property (nonatomic, strong) NSString *type;
 @property (nonatomic, strong) NSString *owner;
+@property (nonatomic, strong) NSNumber *organizationID;
 
 @end


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15343, https://github.com/wordpress-mobile/WordPress-iOS/pull/15484#discussion_r542790416
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15494

This updates `RemoteReaderTopic` to parse the site's `organization_id`.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
