### PR TITLE
Bump pod version.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.24.0-beta.1"
+  s.version       = "4.24.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
For some reason https://github.com/wordpress-mobile/WordPressKit-iOS/pull/316/files didn't show `4.24.0-beta.1` had already been used in `develop`. This just bumps the pod version to `4.24.0-beta.2` so I can create a new release for that PR.

- [ ] Please check here if your pull request includes additional test coverage.
