### PR TITLE
Map `unseen_count` field to `RemoteReaderSiteInfo`

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.24.0-beta.2"
+  s.version       = "4.24.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/RemoteReaderSiteInfo.h
+++ b/WordPressKit/RemoteReaderSiteInfo.h
@@ -20,6 +20,7 @@
 @property (nonatomic, copy) NSString *siteName;
 @property (nonatomic, copy) NSString *siteURL;
 @property (nonatomic, copy) NSNumber *subscriberCount;
+@property (nonatomic, copy) NSString *unseenCount;
 @property (nonatomic, copy) NSString *postsEndpoint;
 @property (nonatomic, copy) NSString *endpointPath;
 

--- a/WordPressKit/RemoteReaderSiteInfo.h
+++ b/WordPressKit/RemoteReaderSiteInfo.h
@@ -20,7 +20,7 @@
 @property (nonatomic, copy) NSString *siteName;
 @property (nonatomic, copy) NSString *siteURL;
 @property (nonatomic, copy) NSNumber *subscriberCount;
-@property (nonatomic, copy) NSString *unseenCount;
+@property (nonatomic, copy) NSNumber *unseenCount;
 @property (nonatomic, copy) NSString *postsEndpoint;
 @property (nonatomic, copy) NSString *endpointPath;
 

--- a/WordPressKit/RemoteReaderSiteInfo.m
+++ b/WordPressKit/RemoteReaderSiteInfo.m
@@ -50,6 +50,7 @@ static NSString * const DeliveryMethodNotificationKey = @"notification";
     siteInfo.siteName = [response stringForKey:SiteDictionaryNameKey];
     siteInfo.siteURL = [response stringForKey:SiteDictionaryURLKey];
     siteInfo.subscriberCount = [response numberForKey:SiteDictionarySubscriptionsKey] ?: @0;
+    siteInfo.unseenCount = [response stringForKeyPath: SiteDictionaryUnseenCountKey];
     siteInfo.organizationID = [response numberForKey:SiteDictionaryOrganizationID] ?: @0;
 
     if (![siteInfo.siteName length] && [siteInfo.siteURL length] > 0) {

--- a/WordPressKit/RemoteReaderSiteInfo.m
+++ b/WordPressKit/RemoteReaderSiteInfo.m
@@ -43,6 +43,7 @@ static NSString * const DeliveryMethodNotificationKey = @"notification";
     siteInfo.isJetpack = [[response numberForKey:SiteDictionaryJetpackKey] boolValue];
     siteInfo.isPrivate = [[response numberForKey:SiteDictionaryPrivateKey] boolValue];
     siteInfo.isVisible = [[response numberForKey:SiteDictionaryVisibleKey] boolValue];
+    siteInfo.organizationID = [response numberForKey:SiteDictionaryOrganizationID] ?: @0;
     siteInfo.postCount = [response numberForKey:SiteDictionaryPostCountKey];
     siteInfo.siteBlavatar = [response stringForKeyPath:SiteDictionaryIconPathKey];
     siteInfo.siteDescription = [response stringForKey:SiteDictionaryDescriptionKey];
@@ -51,7 +52,6 @@ static NSString * const DeliveryMethodNotificationKey = @"notification";
     siteInfo.siteURL = [response stringForKey:SiteDictionaryURLKey];
     siteInfo.subscriberCount = [response numberForKey:SiteDictionarySubscriptionsKey] ?: @0;
     siteInfo.unseenCount = [response stringForKeyPath: SiteDictionaryUnseenCountKey];
-    siteInfo.organizationID = [response numberForKey:SiteDictionaryOrganizationID] ?: @0;
 
     if (![siteInfo.siteName length] && [siteInfo.siteURL length] > 0) {
         siteInfo.siteName = [[NSURL URLWithString:siteInfo.siteURL] host];

--- a/WordPressKit/RemoteReaderSiteInfo.m
+++ b/WordPressKit/RemoteReaderSiteInfo.m
@@ -19,6 +19,7 @@ static NSString * const SiteDictionaryNameKey = @"name";
 static NSString * const SiteDictionaryURLKey = @"URL";
 static NSString * const SiteDictionarySubscriptionsKey = @"subscribers_count";
 static NSString * const SiteDictionarySubscriptionKey = @"subscription";
+static NSString * const SiteDictionaryUnseenCountKey = @"unseen_count";
 
 // Subscription keys
 static NSString * const SubscriptionDeliveryMethodsKey = @"delivery_methods";

--- a/WordPressKit/RemoteReaderSiteInfo.m
+++ b/WordPressKit/RemoteReaderSiteInfo.m
@@ -51,7 +51,7 @@ static NSString * const DeliveryMethodNotificationKey = @"notification";
     siteInfo.siteName = [response stringForKey:SiteDictionaryNameKey];
     siteInfo.siteURL = [response stringForKey:SiteDictionaryURLKey];
     siteInfo.subscriberCount = [response numberForKey:SiteDictionarySubscriptionsKey] ?: @0;
-    siteInfo.unseenCount = [response stringForKeyPath: SiteDictionaryUnseenCountKey];
+    siteInfo.unseenCount = [response numberForKey: SiteDictionaryUnseenCountKey] ?: @0;
 
     if (![siteInfo.siteName length] && [siteInfo.siteURL length] > 0) {
         siteInfo.siteName = [[NSURL URLWithString:siteInfo.siteURL] host];


### PR DESCRIPTION
Testing PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15527

This PR maps the `unseen_count` field and value to the `unseenCount` property in `RemoteReaderSiteInfo`. The value of this new field will be displayed as the unread post count in the Reader in the near future.

- [ ] Please check here if your pull request includes additional test coverage.
