### PR TITLE
Increases endpoint version for login with email.  Improves Jetpack-connect support.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.24.0-beta.3"
+  s.version       = "4.24.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemote.h
+++ b/WordPressKit/AccountServiceRemote.h
@@ -98,6 +98,7 @@ typedef NS_ERROR_ENUM(AccountServiceRemoteErrorDomain, AccountServiceRemoteError
 - (void)requestWPComAuthLinkForEmail:(NSString *)email
                             clientID:(NSString *)clientID
                         clientSecret:(NSString *)clientSecret
+                        jetpackLogin:(BOOL)jetpackLogin
                          wpcomScheme:(NSString *)scheme
                              success:(void (^)(void))success
                              failure:(void (^)(NSError *error))failure;

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -224,19 +224,21 @@ static NSString * const UserDictionaryEmailVerifiedKey = @"email_verified";
 - (void)requestWPComAuthLinkForEmail:(NSString *)email
                             clientID:(NSString *)clientID
                         clientSecret:(NSString *)clientSecret
+                        jetpackLogin:(BOOL)jetpackLogin
                          wpcomScheme:(NSString *)scheme
                              success:(void (^)(void))success
                              failure:(void (^)(NSError *error))failure
 {
-    
     NSString *path = [self pathForEndpoint:@"auth/send-login-email"
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_3];
+    
+    NSDictionary *extraParams = jetpackLogin ? @{@"source": @"jetpack"} : nil;
     
     [self requestWPComMagicLinkForEmail:email
                                    path:path
                                clientID:clientID
                            clientSecret:clientSecret
-                            extraParams: nil
+                            extraParams:extraParams
                             wpcomScheme:scheme
                                 success:success
                                 failure:failure];

--- a/WordPressKitTests/AccountServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/AccountServiceRemoteRESTTests.swift
@@ -533,7 +533,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Request WPCom Auth Link success")
 
         stubRemoteResponse(linkEndpoint, filename: requestLinkSuccessMockFilename, contentType: .ApplicationJSON)
-        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", wpcomScheme: "wordpress", success: {
+        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", jetpackLogin: false, wpcomScheme: "wordpress", success: {
             expect.fulfill()
         }, failure: { error in
             XCTFail("This callback shouldn't get called")
@@ -547,7 +547,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Request WPCom Auth Link with bad email address fails")
 
         stubRemoteResponse(linkEndpoint, filename: requestLinkNoSuchUserFailureMockFilename, contentType: .ApplicationJSON, status: 404)
-        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", wpcomScheme: "wordpress", success: {
+        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", jetpackLogin: false, wpcomScheme: "wordpress", success: {
             expect.fulfill()
             XCTFail("This callback shouldn't get called")
         }, failure: { error in
@@ -568,7 +568,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Request WPCom Auth Link with bad client ID fails")
 
         stubRemoteResponse(linkEndpoint, filename: requestLinkInvalidClientFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", wpcomScheme: "wordpress", success: {
+        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", jetpackLogin: false, wpcomScheme: "wordpress", success: {
             expect.fulfill()
             XCTFail("This callback shouldn't get called")
         }, failure: { error in
@@ -589,7 +589,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Request WPCom Auth Link with bad secret fails")
 
         stubRemoteResponse(linkEndpoint, filename: requestLinkInvalidSecretFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", wpcomScheme: "wordpress", success: {
+        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", jetpackLogin: false, wpcomScheme: "wordpress", success: {
             expect.fulfill()
             XCTFail("This callback shouldn't get called")
         }, failure: { error in
@@ -611,7 +611,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Request WPCom Auth Link with server error failure")
 
         stubRemoteResponse(linkEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", wpcomScheme: "wordpress", success: {
+        remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", jetpackLogin: false, wpcomScheme: "wordpress", success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in


### PR DESCRIPTION
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15532
WPAuth PR: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/550

### Description

Increases the endpoint version for the magic-link-login endpoint.

Adds better support for Jetpack login.

Please refer to the WPiOS PR for details about the changes proposed here.

### Testing Details

Please refer to the WPiOS PR for testing instructions.
