### PR TITLE
Add memberwise public init for JetpackRestoreTypes

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.24.0"
+  s.version       = "4.25.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/JetpackRestoreTypes.swift
+++ b/WordPressKit/JetpackRestoreTypes.swift
@@ -1,12 +1,26 @@
 import Foundation
 
-public struct JetpackRestoreTypes: Decodable {
-    public let themes: Bool
-    public let plugins: Bool
-    public let uploads: Bool
-    public let sqls: Bool
-    public let roots: Bool
-    public let contents: Bool
+public struct JetpackRestoreTypes {
+    public var themes: Bool
+    public var plugins: Bool
+    public var uploads: Bool
+    public var sqls: Bool
+    public var roots: Bool
+    public var contents: Bool
+    
+    public init(themes: Bool = true,
+                plugins: Bool = true ,
+                uploads: Bool = true,
+                sqls: Bool = true,
+                roots: Bool = true,
+                contents: Bool = true) {
+        self.themes = themes
+        self.plugins = plugins
+        self.uploads = uploads
+        self.sqls = sqls
+        self.roots = roots
+        self.contents = contents
+    }
     
     func toDictionary() -> [String: AnyObject] {
         return [


### PR DESCRIPTION
### Description

- Fixes `initializer is inaccessible due to 'internal' protection level` error when initializing `JetpackRestoreTypes` from another module (i.e. WP-iOS)
- Adds default bool values

### Notes

The default init you get for free using a struct is `internal`, so we need to explicitly define a `public` init  👀 

From [Swift Lang Docs](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html#//apple_ref/doc/uid/TP40014097-CH41-ID3): 

> If you want a public structure type to be initializable with a memberwise initializer when used in another module, you must provide a public memberwise initializer yourself as part of the type’s definition.

### Testing Details

🟢 Tests should be good!

- [ ] Please check here if your pull request includes additional test coverage.
