### PR TITLE
Add mobile and tablet screenshots to remote site design

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.26.0-beta.3"
+  s.version       = "4.26.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/RemoteSiteDesign.swift
+++ b/WordPressKit/RemoteSiteDesign.swift
@@ -5,6 +5,8 @@ public struct RemoteSiteDesign: Codable {
     public let title: String
     public let demoURL: String
     public let screenshot: String?
+    public let mobileScreenshot: String?
+    public let tabletScreenshot: String?
     public let themeSlug: String?
     public let segmentID: Int64?
 
@@ -13,6 +15,8 @@ public struct RemoteSiteDesign: Codable {
         case title
         case demoURL = "demo_url"
         case screenshot
+        case mobileScreenshot = "mobile_screenshot"
+        case tabletScreenshot = "tablet_screenshot"
         case themeSlug = "theme"
         case segmentID = "segment_id"
     }
@@ -23,6 +27,8 @@ public struct RemoteSiteDesign: Codable {
         title = try map.decode(String.self, forKey: .title)
         demoURL = try map.decode(String.self, forKey: .demoURL)
         screenshot = try? map.decode(String.self, forKey: .screenshot)
+        mobileScreenshot = try? map.decode(String.self, forKey: .mobileScreenshot)
+        tabletScreenshot = try? map.decode(String.self, forKey: .tabletScreenshot)
         themeSlug = try? map.decode(String.self, forKey: .themeSlug)
         segmentID = try? map.decode(Int64.self, forKey: .segmentID)
     }


### PR DESCRIPTION
#### Related PR:

`WordPress-iOS`: https://github.com/wordpress-mobile/WordPress-iOS/pull/15688

### Description

This adds mobile and tablet screenshots to the remote site design as part of this issue: https://github.com/wordpress-mobile/gutenberg-mobile/issues/2977.


### Testing Details

Testing steps are in the related PR.

- [ ] Please check here if your pull request includes additional test coverage.
