### PR TITLE
Reader seen toggle: Separate methods to toggle by feedItemID or postID.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.26.0-beta.2"
+  s.version       = "4.26.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

Ref #https://github.com/wordpress-mobile/WordPress-iOS/issues/15355

This adds methods to toggle a post's seen status by feedItemID (for non-WP sites) or postID (for WP sites).

### Testing Details

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15718

- [ ] Please check here if your pull request includes additional test coverage.
