### PR TITLE
Include parameters in multipart POST request

### DIFF
--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -160,8 +160,8 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     
     BodyPart *contentPart =[[BodyPart alloc] initWithName:@"content" data:[post.content dataUsingEncoding:NSUTF8StringEncoding]];
-    BodyPart *titlePart = [[BodyPart alloc] initWithName:@"title" data:[post.content dataUsingEncoding:NSUTF8StringEncoding]];
-    BodyPart *statusPart = [[BodyPart alloc] initWithName:@"status" data:[post.content dataUsingEncoding:NSUTF8StringEncoding]];
+    BodyPart *titlePart = [[BodyPart alloc] initWithName:@"title" data:[post.title dataUsingEncoding:NSUTF8StringEncoding]];
+    BodyPart *statusPart = [[BodyPart alloc] initWithName:@"status" data:[post.status dataUsingEncoding:NSUTF8StringEncoding]];
     BodyPart *mediaPart = [[BodyPart alloc] initWithName:@"media[]" url:media.localURL fileName:filename mimeType:type];
     
     [self.wordPressComRestApi multipartPOST:requestUrl

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -158,14 +158,15 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
 
-    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{}];
-    parameters[@"content"] = post.content;
-    parameters[@"title"] = post.title;
-    parameters[@"status"] = post.status;
-    FilePart *filePart = [[FilePart alloc] initWithParameterName:@"media[]" url:media.localURL filename:filename mimeType:type];
+    
+    BodyPart *contentPart =[[BodyPart alloc] initWithName:@"content" data:[post.content dataUsingEncoding:NSUTF8StringEncoding]];
+    BodyPart *titlePart = [[BodyPart alloc] initWithName:@"title" data:[post.content dataUsingEncoding:NSUTF8StringEncoding]];
+    BodyPart *statusPart = [[BodyPart alloc] initWithName:@"status" data:[post.content dataUsingEncoding:NSUTF8StringEncoding]];
+    BodyPart *mediaPart = [[BodyPart alloc] initWithName:@"media[]" url:media.localURL fileName:filename mimeType:type];
+    
     [self.wordPressComRestApi multipartPOST:requestUrl
-                                 parameters:parameters
-                                  fileParts:@[filePart]
+                                 parameters:nil
+                                  bodyParts:@[contentPart, titlePart, statusPart, mediaPart]
                             requestEnqueued:^(NSNumber *taskID) {
                                 if (requestEnqueued) {
                                     requestEnqueued(taskID);

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -290,11 +290,11 @@ open class WordPressComRestApi: NSObject {
     }
 
     /**
-     Executes a multipart POST using the current serializer, the parameters defined and the fileParts defined in the request
+     Executes a multipart POST to the specified endpoint defined on URLString, including the parameters and the fileParts defined in the request.
      This request will be streamed from disk, so it's ideally to be used for large media post uploads.
 
      - parameter URLString:  the endpoint to connect
-     - parameter parameters: the parameters to use on the request
+     - parameter parameters: the parameters to use on the request (only String and Int parameters will be included)
      - parameter fileParts:  the file parameters that are added to the multipart request
      - parameter requestEnqueued: callback to be called when the fileparts are serialized and request is added to the background session. Defaults to nil
      - parameter success:    callback to be called on successful request
@@ -327,6 +327,15 @@ open class WordPressComRestApi: NSObject {
             for filePart in fileParts {
                 multipartFormData.append(filePart.url, withName: filePart.parameterName, fileName: filePart.filename, mimeType: filePart.mimeType)
             }
+            
+            if let parameters = parameters {
+                for (key, value) in parameters {
+                    if value is String || value is Int {
+                        multipartFormData.append("\(value)".data(using: .utf8)!, withName: key)
+                    }
+                }
+            }
+            
         }, to: URLString, encodingCompletion: { (encodingResult) in
             switch encodingResult {
             case .success(let upload, _, _):

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -290,12 +290,12 @@ open class WordPressComRestApi: NSObject {
     }
 
     /**
-     Executes a multipart POST to the specified endpoint defined on URLString, including the parameters and the fileParts defined in the request.
+     Executes a multipart POST to the specified endpoint defined on URLString, including the parameters and bodyParts defined in the request.
      This request will be streamed from disk, so it's ideally to be used for large media post uploads.
 
      - parameter URLString:  the endpoint to connect
-     - parameter parameters: the parameters to use on the request (only String and Int parameters will be included)
-     - parameter fileParts:  the file parameters that are added to the multipart request
+     - parameter parameters: the parameters to use on the request
+     - parameter bodyParts:  the body parameters that are added to the multipart request
      - parameter requestEnqueued: callback to be called when the fileparts are serialized and request is added to the background session. Defaults to nil
      - parameter success:    callback to be called on successful request
      - parameter failure:    callback to be called on failed request
@@ -306,7 +306,7 @@ open class WordPressComRestApi: NSObject {
      */
     @objc @discardableResult open func multipartPOST(_ URLString: String,
                               parameters: [String: AnyObject]?,
-                              fileParts: [FilePart],
+                              bodyParts: [BodyPart],
                               requestEnqueued: RequestEnqueuedBlock? = nil,
                               success: @escaping SuccessResponseBlock,
                               failure: @escaping FailureReponseBlock) -> Progress? {
@@ -324,16 +324,8 @@ open class WordPressComRestApi: NSObject {
         }
 
         uploadSessionManager.upload(multipartFormData: { (multipartFormData) in
-            for filePart in fileParts {
-                multipartFormData.append(filePart.url, withName: filePart.parameterName, fileName: filePart.filename, mimeType: filePart.mimeType)
-            }
-            
-            if let parameters = parameters {
-                for (key, value) in parameters {
-                    if value is String || value is Int {
-                        multipartFormData.append("\(value)".data(using: .utf8)!, withName: key)
-                    }
-                }
+            for part in bodyParts {
+                part.appendToFormData(multipartFormData)
             }
             
         }, to: URLString, encodingCompletion: { (encodingResult) in
@@ -432,20 +424,63 @@ open class WordPressComRestApi: NSObject {
     }
 }
 
-// MARK: - FilePart
+// MARK: - BodyPart
 
-/// FilePart represents the infomartion needed to encode a file on a multipart form request
-public final class FilePart: NSObject {
-    @objc let parameterName: String
-    @objc let url: URL
-    @objc let filename: String
-    @objc let mimeType: String
-
-    @objc public init(parameterName: String, url: URL, filename: String, mimeType: String) {
-        self.parameterName = parameterName
+/// BodyPart represents the information needed to encode a part on a multipart form request
+public final class BodyPart: NSObject {
+    @objc let name: String
+    @objc let data: Data?
+    @objc let url: URL?
+    @objc let fileName: String?
+    @objc let mimeType: String?
+    
+    @objc public init(name: String, data: Data) {
+        self.name = name
+        self.data = data
+        self.url = nil
+        self.fileName = nil
+        self.mimeType = nil
+    }
+    
+    @objc public init(name: String, url: URL) {
+        self.name = name
         self.url = url
-        self.filename = filename
+        self.data = nil
+        self.fileName = nil
+        self.mimeType = nil
+    }
+    
+    @objc public init(name: String, url: URL, fileName: String?, mimeType: String?) {
+        self.name = name
+        self.url = url
+        self.data = nil
+        self.fileName = fileName
         self.mimeType = mimeType
+    }
+    
+    @objc public init(name: String, data: Data, fileName: String?, mimeType: String?) {
+        self.name = name
+        self.data = data
+        self.url = nil
+        self.fileName = fileName
+        self.mimeType = mimeType
+    }
+    
+    public func appendToFormData(_ multipartFormData: MultipartFormData) {
+        if let url = self.url {
+            if let fileName = self.fileName, let mimeType = self.mimeType {
+                multipartFormData.append(url, withName: self.name, fileName: fileName, mimeType: mimeType)
+            } else {
+                multipartFormData.append(url, withName: self.name)
+            }
+        }
+        else if let data = self.data {
+            if let fileName = self.fileName, let mimeType = self.mimeType {
+            multipartFormData.append(data, withName: self.name, fileName: fileName, mimeType: mimeType)
+            } else {
+                multipartFormData.append(data, withName: self.name)
+            }
+        }
     }
 }
 

--- a/WordPressKitTests/MockWordPressComRestApi.swift
+++ b/WordPressKitTests/MockWordPressComRestApi.swift
@@ -31,7 +31,7 @@ class MockWordPressComRestApi: WordPressComRestApi {
 
     override func multipartPOST(_ URLString: String,
                                 parameters: [String : AnyObject]?,
-                                fileParts: [FilePart],
+                                bodyParts: [BodyPart],
                                 requestEnqueued: RequestEnqueuedBlock? = nil,
                                 success: @escaping SuccessResponseBlock,
                                 failure: @escaping FailureReponseBlock) -> Progress? {

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -187,7 +187,7 @@ class WordPressComRestApiTests: XCTestCase {
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, bodyParts: [], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
         }, failure: { (error, httpResponse) in
@@ -206,8 +206,8 @@ class WordPressComRestApiTests: XCTestCase {
 
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        let filePart = FilePart(parameterName: "file", url: URL(fileURLWithPath: "/a.txt") as URL, filename: "a.txt", mimeType: "image/jpeg")
-        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        let filePart = BodyPart(name: "file", url: URL(fileURLWithPath: "/a.txt") as URL, fileName: "a.txt", mimeType: "image/jpeg")
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, bodyParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
@@ -230,8 +230,8 @@ class WordPressComRestApiTests: XCTestCase {
         let mediaURL = URL(fileURLWithPath: mediaPath)
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        let filePart = FilePart(parameterName: "media[]", url: mediaURL as URL, filename: "test-image.jpg", mimeType: "image/jpeg")
-        let progress1 = api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        let mediaPart = BodyPart(name: "media[]", url: mediaURL as URL, fileName: "test-image.jpg", mimeType: "image/jpeg")
+        let progress1 = api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, bodyParts: [mediaPart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
                 XCTFail("This call should fail")
             }, failure: { (error, httpResponse) in
                 print(error)
@@ -240,7 +240,7 @@ class WordPressComRestApiTests: XCTestCase {
             }
         )
         progress1?.cancel()
-        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, bodyParts: [mediaPart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
             expect.fulfill()
 
             }, failure: { (error, httpResponse) in


### PR DESCRIPTION
### Description

Fixes https://github.com/wordpress-mobile/WordPressKit-iOS/issues/333

Unfortunately Alamofire doesn't provide a way to serialise the parameters object to be included in the `multipartFormData` object, as a workaround I'm only adding the `String` and `Int` values that are converted to `Data`.

### Testing Details

The easiest way to test this is by adding items from the free photo library as they include as the caption value its photo credit in the upload parameters.

1. Go to the media screen.
2. Tap on `+` button.
3. Tap on `Free Photo Library`.
4. Search any term.
5. Tap one or multiple items.
6. Tap on `Add` button.
7. Wait for the items to be uploaded.
8. Tap on one of the uploaded items.
9. Check that the caption value is defined.

- [x] Please check here if your pull request includes additional test coverage.
