### PR TITLE
RemoteReaderPost: add isSeenSupported property

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.26.0-beta.5"
+  s.version       = "4.26.0-beta.6"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/RemoteReaderPost.h
+++ b/WordPressKit/RemoteReaderPost.h
@@ -28,6 +28,7 @@
 @property (nonatomic) BOOL isReblogged;
 @property (nonatomic) BOOL isWPCom;
 @property (nonatomic) BOOL isSeen;
+@property (nonatomic) BOOL isSeenSupported;
 @property (nonatomic, strong) NSNumber *likeCount;
 @property (nonatomic, strong) NSNumber *score;
 @property (nonatomic, strong) NSNumber *siteID;

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -111,7 +111,6 @@ static const NSUInteger ReaderPostTitleLength = 30;
     self.isFollowing = [[dict numberForKey:PostRESTKeyIsFollowing] boolValue];
     self.isLiked = [[dict numberForKey:PostRESTKeyILike] boolValue];
     self.isReblogged = [[dict numberForKey:PostRESTKeyIsReblogged] boolValue];
-    self.isSeen = [[dict numberForKey:PostRESTKeyIsSeen] boolValue];
     self.isWPCom = [self isWPComFromPostDictionary:dict];
     self.likeCount = [dict numberForKey:PostRESTKeyLikeCount];
     self.permalink = [self stringOrEmptyString:[dict stringForKey:PostRESTKeyURL]];
@@ -127,7 +126,15 @@ static const NSUInteger ReaderPostTitleLength = 30;
     self.isSharingEnabled = [[dict numberForKey:PostRESTKeySharingEnabled] boolValue];
     self.isLikesEnabled = [[dict numberForKey:PostRESTKeyLikesEnabled] boolValue];
     self.organizationID = [dict numberForKeyPath:PostRESTKeyOrganizationID] ?: @0;
-    
+
+    if ([dict numberForKey:PostRESTKeyIsSeen]) {
+        self.isSeen = [[dict numberForKey:PostRESTKeyIsSeen] boolValue];
+        self.isSeenSupported = YES;
+    } else {
+        self.isSeen = YES;
+        self.isSeenSupported = NO;
+    }
+
     // Construct a title if necessary.
     if ([self.postTitle length] == 0 && [self.summary length] > 0) {
         self.postTitle = [self titleFromSummary:self.summary];


### PR DESCRIPTION
### Description

Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/15355

This adds a `isSeenSupported` property to `RemoteReaderPost`. It is set based on the presence of `is_seen` in the response dictionary.
- If `is_seen` is present, `isSeenSupported` = `YES`.
- If `is_seen` is not present, `isSeenSupported` = `NO`.

### Testing Details

Can be tested with WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15745

- [ ] Please check here if your pull request includes additional test coverage.
