### PR TITLE
Jetpack Backup: mark a download as dismissed

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.26.0-beta.9"
+  s.version       = "4.26.0-beta.10"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/JetpackBackupServiceRemote.swift
+++ b/WordPressKit/JetpackBackupServiceRemote.swift
@@ -74,6 +74,28 @@ open class JetpackBackupServiceRemote: ServiceRemoteWordPressComREST {
         getDownloadStatus(siteID, success: success, failure: failure)
     }
 
+    /// Mark a backup as dismissed
+    /// - Parameters:
+    ///     - siteID: The target site's ID.
+    ///     - downloadID: The download ID of the snapshot being downloaded.
+    ///     - success: Closure to be executed on success.
+    ///     - failure: Closure to be executed on error.
+    ///
+    open func markAsDismissed(_ siteID: Int,
+                              downloadID: Int,
+                              success: @escaping () -> Void,
+                              failure: @escaping (Error) -> Void) {
+        let path = backupPath(for: siteID, with: "\(downloadID)")
+
+        let parameters = ["dismissed": true] as [String : AnyObject]
+
+        wordPressComRestApi.POST(path, parameters: parameters, success: { response, _ in
+            success()
+        }, failure: { error, _ in
+            failure(error)
+        })
+    }
+
     // MARK: - Private
 
     private func getDownloadStatus<T: Decodable>(_ siteID: Int,


### PR DESCRIPTION
WPiOS Related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15799

Adds an endpoint to mark a download as dismissed.
