### PR TITLE
Implementation for post likes endpoint

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -467,6 +467,9 @@
 		9F4E52002088E38200424676 /* ObjectValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4E51FF2088E38200424676 /* ObjectValidation.swift */; };
 		9FCDD09720A5EF75004F0BF7 /* ReaderTopicServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FCDD09620A5EF75004F0BF7 /* ReaderTopicServiceError.swift */; };
 		A0EEB8CB04BEA5F9083EBACE /* Pods_WordPressKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EFF80A6E6EE37118CB1DA158 /* Pods_WordPressKit.framework */; };
+		AB49D09325D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB49D09225D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift */; };
+		AB49D09725D1AC0A0084905B /* post-likes-success.json in Resources */ = {isa = PBXBuildFile; fileRef = AB49D09625D1AC0A0084905B /* post-likes-success.json */; };
+		AB49D0B325D1B4D80084905B /* post-likes-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = AB49D0B225D1B4D80084905B /* post-likes-failure.json */; };
 		B5969E1C20A49AC4005E9DF1 /* NSString+MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = B5969E1920A49AC4005E9DF1 /* NSString+MD5.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5969E1D20A49AC4005E9DF1 /* NSString+MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = B5969E1A20A49AC4005E9DF1 /* NSString+MD5.m */; };
 		B5A4822820AC6BA9009D95F6 /* WPKitLoggingPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = B5A4822620AC6BA8009D95F6 /* WPKitLoggingPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1043,6 +1046,9 @@
 		9F3E0BAD20873835009CB5BA /* ReaderTopicServiceRemoteTest+Subscriptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemoteTest+Subscriptions.swift"; sourceTree = "<group>"; };
 		9F4E51FF2088E38200424676 /* ObjectValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObjectValidation.swift; sourceTree = "<group>"; };
 		9FCDD09620A5EF75004F0BF7 /* ReaderTopicServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTopicServiceError.swift; sourceTree = "<group>"; };
+		AB49D09225D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceRemoteRESTLikesTests.swift; sourceTree = "<group>"; };
+		AB49D09625D1AC0A0084905B /* post-likes-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "post-likes-success.json"; sourceTree = "<group>"; };
+		AB49D0B225D1B4D80084905B /* post-likes-failure.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "post-likes-failure.json"; sourceTree = "<group>"; };
 		B56D96B0202C9B7500485233 /* WordPressUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WordPressUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5969E1920A49AC4005E9DF1 /* NSString+MD5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+MD5.h"; sourceTree = "<group>"; };
 		B5969E1A20A49AC4005E9DF1 /* NSString+MD5.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MD5.m"; sourceTree = "<group>"; };
@@ -1279,6 +1285,7 @@
 			children = (
 				32AF21E2236DEB3C001C6502 /* PostServiceRemoteRESTAutosaveTests.swift */,
 				9AB6D649218727D60008F274 /* PostServiceRemoteRESTRevisionsTest.swift */,
+				AB49D09225D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift */,
 				740B23D01F17F6BB00067A2A /* PostServiceRemoteRESTTests.m */,
 				740B23D11F17F6BB00067A2A /* PostServiceRemoteXMLRPCTests.swift */,
 			);
@@ -1880,6 +1887,8 @@
 				9AB6D648218722BB0008F274 /* post-revisions-success.json */,
 				9AB6D64D218731380008F274 /* post-revisions-mapping-success.json */,
 				9AB6D64C218730130008F274 /* post-revisions-failure.json */,
+				AB49D09625D1AC0A0084905B /* post-likes-success.json */,
+				AB49D0B225D1B4D80084905B /* post-likes-failure.json */,
 				FFE247C120C9D749002DF3A2 /* reader-site-search-blog-id-fallback.json */,
 				17BF9A6E20C7E18200BF57D2 /* reader-site-search-failure.json */,
 				FFE247C020C9D748002DF3A2 /* reader-site-search-no-blog-or-feed-id.json */,
@@ -2312,6 +2321,7 @@
 				FFE247BD20C9C88B002DF3A2 /* empty.json in Resources */,
 				BA8EA71324A056C300D5CC9F /* plugin-service-remote-featured-malformed.json in Resources */,
 				436D5643211B7F9B00CEAA33 /* validate-domain-contact-information-response-fail.json in Resources */,
+				AB49D09725D1AC0A0084905B /* post-likes-success.json in Resources */,
 				74FC6F401F191C1D00112505 /* notifications-mark-as-read.json in Resources */,
 				74D67F3A1F15C3740010C5ED /* site-viewers-delete-failure.json in Resources */,
 				BA3F138E24A09C87006367A3 /* plugin-install-generic-error.json in Resources */,
@@ -2378,6 +2388,7 @@
 				7403A2FD1EF06FEB00DED7DC /* me-settings-change-primary-site-success.json in Resources */,
 				74C473B71EF3229B009918F2 /* site-delete-unexpected-json-failure.json in Resources */,
 				3297E2852564746800287D21 /* jetpack-scan-unavailable.json in Resources */,
+				AB49D0B325D1B4D80084905B /* post-likes-failure.json in Resources */,
 				9A2D0B30225E1245009E585F /* jetpack-service-check-site-success-no-jetpack.json in Resources */,
 				FA79F1882591730D00D235A9 /* backup-prepare-backup-success.json in Resources */,
 				9A88174E223C01E400A3AB20 /* jetpack-service-error-unknown.json in Resources */,
@@ -2850,6 +2861,7 @@
 				9A2D0B2B225E0E22009E585F /* JetpackServiceRemoteTests.swift in Sources */,
 				74FA25F71F1FDA200044BC54 /* MediaServiceRemoteRESTTests.swift in Sources */,
 				D8DB404021EF222000B8238E /* SiteCreationSegmentsTests.swift in Sources */,
+				AB49D09325D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift in Sources */,
 				7433BC051EFC4556002D9E92 /* PlanServiceRemoteTests.swift in Sources */,
 				740B23D61F17F7C100067A2A /* XMLRPCTestable.swift in Sources */,
 				FFE247A720C891D1002DF3A2 /* WordPressComOAuthTests.swift in Sources */,

--- a/WordPressKit/PostServiceRemote.h
+++ b/WordPressKit/PostServiceRemote.h
@@ -106,9 +106,9 @@
  *  @param      success     The block that will be executed on success. Can be nil.
  *  @param      failure     The block that will be executed on failure. Can be nil.
  */
-- (void)getLikesForID:(nonnull NSNumber *)postID
-              success:(nullable void (^)(NSArray<RemoteUser *> * _Nonnull users))success
-              failure:(nullable void (^)(NSError * _Nullable))failure;
+- (void)getLikesForID:(NSNumber *)postID
+              success:(void (^)(NSArray<RemoteUser *> *))success
+              failure:(void (^)(NSError *))failure;
 
 /**
  *  @brief      Returns a dictionary set with option parameters of the PostServiceRemoteOptions protocol.

--- a/WordPressKit/PostServiceRemote.h
+++ b/WordPressKit/PostServiceRemote.h
@@ -2,7 +2,6 @@
 #import <WordPressKit/PostServiceRemoteOptions.h>
 
 @class RemotePost;
-@class RemoteUser;
 
 @protocol PostServiceRemote <NSObject>
 
@@ -95,20 +94,6 @@
 - (void)restorePost:(RemotePost *)post
             success:(void (^)(RemotePost *))success
             failure:(void (^)(NSError *error))failure;
-
-/**
- *  @brief      Requests a list of users that liked the post with the specified ID.
- *
- *  @discussion Due to the API limitation, up to 90 users will be returned from the
- *              endpoint.
- *
- *  @param      postID      The ID for the post. Cannot be nil.
- *  @param      success     The block that will be executed on success. Can be nil.
- *  @param      failure     The block that will be executed on failure. Can be nil.
- */
-- (void)getLikesForID:(NSNumber *)postID
-              success:(void (^)(NSArray<RemoteUser *> *))success
-              failure:(void (^)(NSError *))failure;
 
 /**
  *  @brief      Returns a dictionary set with option parameters of the PostServiceRemoteOptions protocol.

--- a/WordPressKit/PostServiceRemote.h
+++ b/WordPressKit/PostServiceRemote.h
@@ -2,6 +2,7 @@
 #import <WordPressKit/PostServiceRemoteOptions.h>
 
 @class RemotePost;
+@class RemoteUser;
 
 @protocol PostServiceRemote <NSObject>
 
@@ -94,6 +95,20 @@
 - (void)restorePost:(RemotePost *)post
             success:(void (^)(RemotePost *))success
             failure:(void (^)(NSError *error))failure;
+
+/**
+ *  @brief      Requests a list of users that liked the post with the specified ID.
+ *
+ *  @discussion Due to the API limitation, up to 90 users will be returned from the
+ *              endpoint.
+ *
+ *  @param      postID      The ID for the post. Cannot be nil.
+ *  @param      success     The block that will be executed on success. Can be nil.
+ *  @param      failure     The block that will be executed on failure. Can be nil.
+ */
+- (void)getLikesForID:(nonnull NSNumber *)postID
+              success:(nullable void (^)(NSArray<RemoteUser *> * _Nonnull users))success
+              failure:(nullable void (^)(NSError * _Nullable))failure;
 
 /**
  *  @brief      Returns a dictionary set with option parameters of the PostServiceRemoteOptions protocol.

--- a/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/PostServiceRemoteREST.h
@@ -3,6 +3,8 @@
 #import <WordPressKit/SiteServiceRemoteWordPressComREST.h>
 #import <WordPressKit/RemoteMedia.h>
 
+@class RemoteUser;
+
 @interface PostServiceRemoteREST : SiteServiceRemoteWordPressComREST <PostServiceRemote>
 
 /**
@@ -52,5 +54,19 @@
 - (void)getAutoSaveForPost:(RemotePost *)post
                    success:(void (^)(RemotePost *))success
                    failure:(void (^)(NSError *error))failure;
+
+/**
+ *  @brief      Requests a list of users that liked the post with the specified ID.
+ *
+ *  @discussion Due to the API limitation, up to 90 users will be returned from the
+ *              endpoint.
+ *
+ *  @param      postID      The ID for the post. Cannot be nil.
+ *  @param      success     The block that will be executed on success. Can be nil.
+ *  @param      failure     The block that will be executed on failure. Can be nil.
+ */
+- (void)getLikesForID:(NSNumber *)postID
+              success:(void (^)(NSArray<RemoteUser *> *))success
+              failure:(void (^)(NSError *))failure;
 
 @end

--- a/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/PostServiceRemoteREST.h
@@ -65,8 +65,8 @@
  *  @param      success     The block that will be executed on success. Can be nil.
  *  @param      failure     The block that will be executed on failure. Can be nil.
  */
-- (void)getLikesForID:(NSNumber *)postID
-              success:(void (^)(NSArray<RemoteUser *> *))success
-              failure:(void (^)(NSError *))failure;
+- (void)getLikesForPostID:(NSNumber *)postID
+                  success:(void (^)(NSArray<RemoteUser *> *))success
+                  failure:(void (^)(NSError *))failure;
 
 @end

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -589,10 +589,12 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     return [jsonTags allKeys];
 }
 
-/// Returns an array of users based on provided json representation
-/// of users.
-///
-/// @param jsonUsers Array containing json representation of users
+/**
+ *  @brief  Returns an array of RemoteUser based on provided JSON
+ *          representation of users.
+ *
+ *  @param  jsonUsers   An array containing JSON representations of users.
+ */
 - (NSArray<RemoteUser *> *)remoteUsersFromJSONArray:(NSArray *)jsonUsers
 {
     return [jsonUsers wp_map:^id(NSDictionary *jsonUser) {
@@ -600,21 +602,23 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     }];
 }
 
-/// Creates a RemoteUser instance based on provided json object.
-/// Expected dictionary contents (and its mappings to RemoteUser):
-/// - ID -> userID
-/// - email -> email
-/// - login -> username
-/// - name -> displayName
-/// - site_ID -> primaryBlogID
-/// - avatar_URL -> avatarURL
-///
-/// @param jsonUser The dictionary representing RemoteUser
+/**
+ *  @brief      Creates a RemoteUser instance based on provided JSON object.
+ *
+ *  @discussion Expected dictionary contents (and its mapping to the
+ *              RemoteUser object):
+ *              - ID -> userID
+ *              - login -> username
+ *              - name -> displayName
+ *              - site_ID -> primaryBlogID
+ *              - avatar_URL -> avatarURL
+ *
+ *  @param  jsonUser    The dictionary that represents a RemoteUser.
+ */
 - (RemoteUser *)remoteUserFromJSONDictionary:(NSDictionary *)jsonUser
 {
     RemoteUser *user = [RemoteUser new];
     user.userID = jsonUser[@"ID"];
-    user.email = jsonUser[@"email"];
     user.username = jsonUser[@"login"];
     user.displayName = jsonUser[@"name"];
     user.primaryBlogID = jsonUser[@"site_ID"];

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -320,8 +320,8 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     [self.wordPressComRestApi GET:requestUrl
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
-        NSArray *jsonUsers = responseObject[@"likes"];
-        if (success && jsonUsers) {
+        if (success) {
+            NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
             success([self remoteUsersFromJSONArray:jsonUsers]);
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -307,9 +307,9 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
            }];
 }
 
-- (void)getLikesForID:(NSNumber *)postID
-              success:(void (^)(NSArray<RemoteUser *> * _Nonnull))success
-              failure:(void (^)(NSError * _Nullable))failure
+- (void)getLikesForPostID:(NSNumber *)postID
+                  success:(void (^)(NSArray<RemoteUser *> * _Nonnull))success
+                  failure:(void (^)(NSError * _Nullable))failure
 {
     NSParameterAssert(postID);
     

--- a/WordPressKitTests/Mock Data/post-likes-failure.json
+++ b/WordPressKitTests/Mock Data/post-likes-failure.json
@@ -1,0 +1,4 @@
+{
+  "error": "unauthorized",
+  "message": "User cannot access this private blog."
+}

--- a/WordPressKitTests/Mock Data/post-likes-success.json
+++ b/WordPressKitTests/Mock Data/post-likes-success.json
@@ -11,6 +11,7 @@
             "name": "John Doe",
             "first_name": "John",
             "last_name": "Doe",
+            "nice_name": "johndoe",
             "URL": "",
             "avatar_URL": "avatar URL",
             "profile_URL": "profile URL",

--- a/WordPressKitTests/Mock Data/post-likes-success.json
+++ b/WordPressKitTests/Mock Data/post-likes-success.json
@@ -1,0 +1,23 @@
+{
+    "found": 1,
+    "i_like": true,
+    "site_ID": 0,
+    "post_ID": 1,
+    "likes": [
+        {
+            "ID": 12345,
+            "login": "johndoe",
+            "email": false,
+            "name": "John Doe",
+            "first_name": "John",
+            "last_name": "Doe",
+            "URL": "",
+            "avatar_URL": "avatar URL",
+            "profile_URL": "profile URL",
+            "ip_address": false,
+            "site_ID": 54321,
+            "site_visible": true,
+            "default_avatar": false
+        }
+    ]
+}

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import XCTest
+
+@testable import WordPressKit
+
+
+final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
+    private let fetchPostLikesSuccessFilename = "post-likes-success.json"
+    private let fetchPostLikesFailureFilename = "post-likes-failure.json"
+    private let siteId = 0
+    private let postId = 1
+    private var remote: PostServiceRemoteREST!
+    private var postLikesEndpoint: String {
+        return "sites/\(siteId)/posts/\(postId)/likes"
+    }
+    
+    override func setUp() {
+        super.setUp()
+        remote = PostServiceRemoteREST(wordPressComRestApi: getRestApi(), siteID: NSNumber(value: siteId))
+    }
+    
+    override func tearDown() {
+        remote = nil
+        super.tearDown()
+    }
+    
+    // MARK: Tests
+    
+    func testThatFetchPostLikesWorks() {
+        let expect = expectation(description: "Fetch likes should succeed")
+        
+        stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
+        remote.getLikesForID(NSNumber(value: postId), success: { users in
+            guard let user = users.first else {
+                XCTFail("Failed to retrieve mock post likes")
+                return
+            }
+            
+            XCTAssertEqual(user.userID, NSNumber(value: 12345))
+            XCTAssertEqual(user.username, "johndoe")
+            XCTAssertEqual(user.displayName, "John Doe")
+            XCTAssertEqual(user.primaryBlogID, NSNumber(value: 54321))
+            XCTAssertEqual(user.avatarURL, "avatar URL")
+            expect.fulfill()
+            
+        }, failure: { _ in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+    
+    func testFailureBlockCalledWhenFetchingFails() {
+        let expect = expectation(description: "Failure block should be called when fetching post likes fails")
+        
+        stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
+        remote.getLikesForID(NSNumber(value: postId)) { _ in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        } failure: { error in
+            XCTAssertNotNil(error)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+}

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -30,7 +30,7 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetch likes should succeed")
         
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForID(NSNumber(value: postId), success: { users in
+        remote.getLikesForPostID(NSNumber(value: postId), success: { users in
             guard let user = users?.first else {
                 XCTFail("Failed to retrieve mock post likes")
                 return
@@ -54,8 +54,8 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Failure block should be called when fetching post likes fails")
         
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getLikesForID(NSNumber(value: postId), success: { _ in
-            XCTFail("This callback shouldn't get called")
+        remote.getLikesForPostID(NSNumber(value: postId), success: { _ in
+        XCTFail("This callback shouldn't get called")
         }, failure: { error in
             XCTAssertNotNil(error)
             expect.fulfill()

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -54,12 +54,12 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Failure block should be called when fetching post likes fails")
         
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getLikesForID(NSNumber(value: postId)) { _ in
+        remote.getLikesForID(NSNumber(value: postId), success: { _ in
             XCTFail("This callback shouldn't get called")
-        } failure: { error in
+        }, failure: { error in
             XCTAssertNotNil(error)
             expect.fulfill()
-        }
+        })
 
         waitForExpectations(timeout: timeout, handler: nil)
     }

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -31,7 +31,7 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
         remote.getLikesForID(NSNumber(value: postId), success: { users in
-            guard let user = users.first else {
+            guard let user = users?.first else {
                 XCTFail("Failed to retrieve mock post likes")
                 return
             }

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -45,7 +45,6 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             
         }, failure: { _ in
             XCTFail("This callback shouldn't get called")
-            expect.fulfill()
         })
         
         waitForExpectations(timeout: timeout, handler: nil)
@@ -57,7 +56,6 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
         remote.getLikesForID(NSNumber(value: postId)) { _ in
             XCTFail("This callback shouldn't get called")
-            expect.fulfill()
         } failure: { error in
             XCTAssertNotNil(error)
             expect.fulfill()


### PR DESCRIPTION
### Description

This PR adds an endpoint for fetching post likes based on [this API documentation](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/likes/). Since the likes are contextual to the Post object, the implementation is added in `PostServiceRemoteREST`. The response is then mapped to the existing `RemoteUser` object.

References:
- Related issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/15662
- Design: [Likes Enhancements i2](https://wp.me/pbArwn-1CQ)

### Testing Details

Added test that ensures the object returned from the API are correctly parsed into `RemoteUser`s, and a negative test that ensures the failure block is called.

- [x] Please check here if your pull request includes additional test coverage.
