### PR TITLE
Fix unit test timezone issue in local machine

### DIFF
--- a/WordPressKitTests/StatsRemoteV2Tests.swift
+++ b/WordPressKitTests/StatsRemoteV2Tests.swift
@@ -44,6 +44,12 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
     override func setUp() {
         super.setUp()
+        
+        // standardize timezone to GMT+0
+        if let timezone = TimeZone(abbreviation: "GMT") {
+            NSTimeZone.default = timezone
+        }
+        
         remote = StatsServiceRemoteV2(wordPressComRestApi: getRestApi(), siteID: siteID, siteTimezone: .autoupdatingCurrent)
     }
 


### PR DESCRIPTION
### Description

In StatsPostingStreakInsight, posting dates are mapped by calling the
`startOfDay` method on Calendar. This method is timezone sensitive as it
refers to the local machine's timezone.

For example, in one of the test data: 2018-03-29 16:00:53 +0000. Calling
the startOfDay method outputs 2018-03-28 17:00:00 +0000 on my local
machine, which causes some differences in calculation and results in
test failure.

The test passes on CI just fine, this fixes errors on test runs where
the machines are not GMT+0.

### Testing Details

Ensure that all tests pass, both locally and on the CI.

- [ ] Please check here if your pull request includes additional test coverage.
