### PR TITLE
Comments: allow fetching by status

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.27.0-beta.1"
+  s.version       = "4.27.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -28,13 +28,18 @@
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
-                                 @"status": @"all",
                                  @"context": @"edit",
                                  @"force": @"wpcom", // Force fetching data from shadow site on Jetpack sites
                                  @"number": @(maximumComments)
                                  }];
+
     if (options) {
         [parameters addEntriesFromDictionary:options];
+    }
+
+    // If the comment status is not specified, default to all.
+    if (![parameters objectForKey:@"status"]) {
+        parameters[@"status"] = @"all";
     }
     
     [self.wordPressComRestApi GET:requestUrl

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -399,10 +399,6 @@
     comment.type = jsonDictionary[@"type"];
     comment.isLiked = [[jsonDictionary numberForKey:@"i_like"] boolValue];
     comment.likeCount = [jsonDictionary numberForKey:@"like_count"];
-    
-    // TODO: for testing only. Remove before merge.
-    NSLog(@"🔴 comment content: %@", comment.content);
-    NSLog(@"🔴 comment status: %@", comment.status);
 
     return comment;
 }

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -399,6 +399,10 @@
     comment.type = jsonDictionary[@"type"];
     comment.isLiked = [[jsonDictionary numberForKey:@"i_like"] boolValue];
     comment.likeCount = [jsonDictionary numberForKey:@"like_count"];
+    
+    // TODO: for testing only. Remove before merge.
+    NSLog(@"🔴 comment content: %@", comment.content);
+    NSLog(@"🔴 comment status: %@", comment.status);
 
     return comment;
 }

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -194,11 +194,7 @@
     comment.postTitle = xmlrpcDictionary[@"post_title"];
     comment.status = xmlrpcDictionary[@"status"];
     comment.type = xmlrpcDictionary[@"type"];
-    
-    // TODO: for testing only. Remove before merge.
-    NSLog(@"🔴 comment content: %@", comment.content);
-    NSLog(@"🔴 comment status: %@", comment.status);
-    
+
     return comment;
 }
 

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -194,6 +194,11 @@
     comment.postTitle = xmlrpcDictionary[@"post_title"];
     comment.status = xmlrpcDictionary[@"status"];
     comment.type = xmlrpcDictionary[@"type"];
+    
+    // TODO: for testing only. Remove before merge.
+    NSLog(@"🔴 comment content: %@", comment.content);
+    NSLog(@"🔴 comment status: %@", comment.status);
+    
     return comment;
 }
 

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -20,13 +20,19 @@
                             success:(void (^)(NSArray *posts))success
                             failure:(void (^)(NSError *error))failure
 {
-    NSMutableDictionary *extraParameters = [@{
-                                                @"number": @(maximumComments)
-                                            } mutableCopy];
+    NSMutableDictionary *extraParameters = [@{ @"number": @(maximumComments) } mutableCopy];
+
     if (options) {
         [extraParameters addEntriesFromDictionary:options];
     }
+    
+    // If the comment status is not specified, default to all.
+    if (![extraParameters objectForKey:@"status"]) {
+        extraParameters[@"status"] = @"all";
+    }
+    
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
+    
     [self.api callMethod:@"wp.getComments"
               parameters:parameters
                  success:^(id responseObject, NSHTTPURLResponse *httpResponse) {


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15893
WPiOS PR:  https://github.com/wordpress-mobile/WordPress-iOS/pull/15899

If `status` does not exist in the `parameters` dictionary before the API call is made, it is added and set to `all`. This allows the `status` to be provided in the `options` dictionary, specifying the Comment `status` to be fetched.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
