### PR TITLE
Implementation for comment likes endpoint

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -470,6 +470,8 @@
 		AB49D09325D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB49D09225D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift */; };
 		AB49D09725D1AC0A0084905B /* post-likes-success.json in Resources */ = {isa = PBXBuildFile; fileRef = AB49D09625D1AC0A0084905B /* post-likes-success.json */; };
 		AB49D0B325D1B4D80084905B /* post-likes-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = AB49D0B225D1B4D80084905B /* post-likes-failure.json */; };
+		ABD95B7F25DD6C4B00735BEE /* CommentServiceRemoteRESTLikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD95B7E25DD6C4B00735BEE /* CommentServiceRemoteRESTLikesTests.swift */; };
+		ABD95B8525DD6DA200735BEE /* comment-likes-success.json in Resources */ = {isa = PBXBuildFile; fileRef = ABD95B8425DD6DA200735BEE /* comment-likes-success.json */; };
 		B5969E1C20A49AC4005E9DF1 /* NSString+MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = B5969E1920A49AC4005E9DF1 /* NSString+MD5.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B5969E1D20A49AC4005E9DF1 /* NSString+MD5.m in Sources */ = {isa = PBXBuildFile; fileRef = B5969E1A20A49AC4005E9DF1 /* NSString+MD5.m */; };
 		B5A4822820AC6BA9009D95F6 /* WPKitLoggingPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = B5A4822620AC6BA8009D95F6 /* WPKitLoggingPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1049,6 +1051,8 @@
 		AB49D09225D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceRemoteRESTLikesTests.swift; sourceTree = "<group>"; };
 		AB49D09625D1AC0A0084905B /* post-likes-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "post-likes-success.json"; sourceTree = "<group>"; };
 		AB49D0B225D1B4D80084905B /* post-likes-failure.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "post-likes-failure.json"; sourceTree = "<group>"; };
+		ABD95B7E25DD6C4B00735BEE /* CommentServiceRemoteRESTLikesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentServiceRemoteRESTLikesTests.swift; sourceTree = "<group>"; };
+		ABD95B8425DD6DA200735BEE /* comment-likes-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "comment-likes-success.json"; sourceTree = "<group>"; };
 		B56D96B0202C9B7500485233 /* WordPressUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WordPressUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B5969E1920A49AC4005E9DF1 /* NSString+MD5.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+MD5.h"; sourceTree = "<group>"; };
 		B5969E1A20A49AC4005E9DF1 /* NSString+MD5.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+MD5.m"; sourceTree = "<group>"; };
@@ -1472,6 +1476,7 @@
 				826016FE1F9FD59400533B6C /* Activity */,
 				FAD1345425909DF500A8FEB1 /* Backup */,
 				74B5F0DF1EF82AAB00B411E7 /* Blog */,
+				ABD95B7D25DD6C2400735BEE /* Comment */,
 				74585B911F0D520700E7E667 /* Domains */,
 				7EC60EBC22DC4F5A00FB0336 /* Editor */,
 				8BE67ED124AD05B5004DB4C9 /* Extensions */,
@@ -2010,6 +2015,7 @@
 				3297E1EC2564694C00287D21 /* jetpack-scan-idle-success-threats.json */,
 				3297E28A25647E0300287D21 /* jetpack-scan-enqueue-failure.json */,
 				3297E28B25647E0300287D21 /* jetpack-scan-enqueue-success.json */,
+				ABD95B8425DD6DA200735BEE /* comment-likes-success.json */,
 			);
 			path = "Mock Data";
 			sourceTree = "<group>";
@@ -2068,6 +2074,14 @@
 				9AB6D646218705E90008F274 /* RemoteDiff.swift */,
 			);
 			name = Revisions;
+			sourceTree = "<group>";
+		};
+		ABD95B7D25DD6C2400735BEE /* Comment */ = {
+			isa = PBXGroup;
+			children = (
+				ABD95B7E25DD6C4B00735BEE /* CommentServiceRemoteRESTLikesTests.swift */,
+			);
+			name = Comment;
 			sourceTree = "<group>";
 		};
 		B5A4821F20AC6B5C009D95F6 /* Private */ = {
@@ -2327,6 +2341,7 @@
 				BA3F138E24A09C87006367A3 /* plugin-install-generic-error.json in Resources */,
 				3236F79C24AE413A0088E8F3 /* reader-interests-success.json in Resources */,
 				93BD275C1EE73442002BB00B /* is-available-username-success.json in Resources */,
+				ABD95B8525DD6DA200735BEE /* comment-likes-success.json in Resources */,
 				8BFD71FE25CACCBF0094534E /* backup-get-backup-status-complete-without-download-id-success.json in Resources */,
 				74D67F331F15C3740010C5ED /* site-users-delete-auth-failure.json in Resources */,
 				3297E1EE2564694C00287D21 /* jetpack-scan-idle-success-threats.json in Resources */,
@@ -2847,6 +2862,7 @@
 				32AF21E3236DEB3C001C6502 /* PostServiceRemoteRESTAutosaveTests.swift in Sources */,
 				3236F79A24AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift in Sources */,
 				74B5F0DE1EF82A9600B411E7 /* BlogServiceRemoteRESTTests.m in Sources */,
+				ABD95B7F25DD6C4B00735BEE /* CommentServiceRemoteRESTLikesTests.swift in Sources */,
 				8B749E8225AF7DDA00023F03 /* JetpackCapabilitiesServiceRemoteTests.swift in Sources */,
 				74E2294B1F1E73340085F7F2 /* SharingServiceRemoteTests.m in Sources */,
 				73B3DAD621FBB20D00B2CF18 /* WordPressComRestApiTests+Locale.swift in Sources */,

--- a/WordPressKit/CommentServiceRemoteREST.h
+++ b/WordPressKit/CommentServiceRemoteREST.h
@@ -2,6 +2,8 @@
 #import <WordPressKit/CommentServiceRemote.h>
 #import <WordPressKit/SiteServiceRemoteWordPressComREST.h>
 
+@class RemoteUser;
+
 @interface CommentServiceRemoteREST : SiteServiceRemoteWordPressComREST <CommentServiceRemote>
 
 /**
@@ -75,5 +77,17 @@
 - (void)unlikeCommentWithID:(NSNumber *)commentID
                     success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure;
+
+/**
+ Requests a list of users that liked the comment with the specified ID. Due to
+ API limitation, up to 90 users will be returned from the endpoint.
+ 
+ @param commentID The ID for the comment. Cannot be nil.
+ @param success The block that will be executed on success. Can be nil.
+ @param failure The block that will be executed on failure. Can be nil.
+ */
+- (void)getLikesForCommentID:(NSNumber *)commentID
+                     success:(void (^)(NSArray<RemoteUser *> *))success
+                     failure:(void (^)(NSError *))failure;
 
 @end

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -1,6 +1,7 @@
 #import "CommentServiceRemoteREST.h"
 #import "WPKit-Swift.h"
 #import "RemoteComment.h"
+#import "RemoteUser.h"
 
 @import NSObject_SafeExpectations;
 @import WordPressShared;
@@ -365,6 +366,30 @@
                            }];
 }
 
+- (void)getLikesForCommentID:(NSNumber *)commentID
+                     success:(void (^)(NSArray<RemoteUser *> *))success
+                     failure:(void (^)(NSError *))failure
+{
+    NSParameterAssert(commentID);
+
+    NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes", self.siteID, commentID];
+    NSString *requestUrl = [self pathForEndpoint:path
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+
+    [self.wordPressComRestApi GET:requestUrl
+                       parameters:nil
+                          success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+        if (success) {
+            NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
+            success([self remoteUsersFromJSONArray:jsonUsers]);
+        }
+    } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+        if (failure) {
+            failure(error);
+        }
+    }];
+}
+
 #pragma mark - Private methods
 
 - (NSArray *)remoteCommentsFromJSONArray:(NSArray *)jsonComments
@@ -418,6 +443,41 @@
         remoteStatus = @"approved";
     }
     return remoteStatus;
+}
+
+/**
+ Returns an array of RemoteUser based on provided JSON representation of users.
+ 
+ @param jsonUsers An array containing JSON representations of users.
+ */
+- (NSArray<RemoteUser *> *)remoteUsersFromJSONArray:(NSArray *)jsonUsers
+{
+    return [jsonUsers wp_map:^id(NSDictionary *jsonUser) {
+        return [self remoteUserFromJSONDictionary:jsonUser];
+    }];
+}
+
+/**
+ Creates a RemoteUser instance based on provided JSON object. Expected dictionary
+ contents (and its mapping to the RemoteUser object):
+    - ID -> userID
+    - login -> username
+    - name -> displayName
+    - site_ID -> primaryBlogID
+    - avatar_URL -> avatarURL
+
+ @param jsonUser The dictionary that represents a RemoteUser.
+ */
+- (RemoteUser *)remoteUserFromJSONDictionary:(NSDictionary *)jsonUser
+{
+    RemoteUser *user = [RemoteUser new];
+    user.userID = jsonUser[@"ID"];
+    user.username = jsonUser[@"login"];
+    user.displayName = jsonUser[@"name"];
+    user.primaryBlogID = jsonUser[@"site_ID"];
+    user.avatarURL = jsonUser[@"avatar_URL"];
+
+    return user;
 }
 
 @end

--- a/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
@@ -1,0 +1,66 @@
+import Foundation
+import XCTest
+
+@testable import WordPressKit
+
+
+final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
+    private let fetchCommentLikesSuccessFilename = "comment-likes-success.json"
+    private let fetchCommentLikesFailureFilename = "post-likes-failure.json"
+    private let siteId = 0
+    private let commentId = 1
+    private var remote: CommentServiceRemoteREST!
+    private var commentLikesEndpoint: String {
+        return "sites/\(siteId)/comments/\(commentId)/likes"
+    }
+    
+    override func setUp() {
+        super.setUp()
+        remote = CommentServiceRemoteREST(wordPressComRestApi: getRestApi(), siteID: NSNumber(value: siteId))
+    }
+    
+    override func tearDown() {
+        remote = nil
+        super.tearDown()
+    }
+    
+    // MARK: Tests
+    
+    func testThatFetchCommentLikesWorks() {
+        let expect = expectation(description: "Fetching comment likes should succeed")
+        
+        stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesSuccessFilename, contentType: .ApplicationJSON)
+        remote.getLikesForCommentID(NSNumber(value: commentId), success: { users in
+            guard let user = users?.first else {
+                XCTFail("Failed to retrieve mock comment likes")
+                return
+            }
+            
+            XCTAssertEqual(user.userID, NSNumber(value: 54321))
+            XCTAssertEqual(user.username, "johnwick")
+            XCTAssertEqual(user.displayName, "John Wick")
+            XCTAssertEqual(user.primaryBlogID, NSNumber(value: 124625450))
+            XCTAssertEqual(user.avatarURL, "avatar URL")
+            expect.fulfill()
+            
+        }, failure: { _ in
+            XCTFail("This callback shouldn't get called")
+        })
+        
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+    
+    func testFailureBlockCalledWhenFetchingFails() {
+        let expect = expectation(description: "Failure block should be called when fetching post likes fails")
+        
+        stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
+        remote.getLikesForCommentID(NSNumber(value: commentId), success: { _ in
+        XCTFail("This callback shouldn't get called")
+        }, failure: { error in
+            XCTAssertNotNil(error)
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+}

--- a/WordPressKitTests/Mock Data/comment-likes-success.json
+++ b/WordPressKitTests/Mock Data/comment-likes-success.json
@@ -1,0 +1,22 @@
+{
+    "found": 1,
+    "i_like": false,
+    "likes": [
+        {
+            "ID": 54321,
+            "login": "johnwick",
+            "email": false,
+            "name": "John Wick",
+            "first_name": "John",
+            "last_name": "Wick",
+            "nice_name": "johnwick",
+            "URL": "",
+            "avatar_URL": "avatar URL",
+            "profile_URL": "profile URL",
+            "ip_address": false,
+            "site_ID": 124625450,
+            "site_visible": true,
+            "default_avatar": false
+        }
+    ]
+}


### PR DESCRIPTION
### Description

Related to #347, this PR adds an endpoint for fetching comment likes based on [this API documentation](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/comments/%24comment_ID/likes/). Similar to post likes, implementation for comment likes is added in `CommentServiceRemoteREST` with the response mapped to `RemoteUser`.

### References
- Related issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/15662
- Design: [Likes Enhancements i2](https://wp.me/pbArwn-1CQ)

### Testing Details

Added tests to ensure that the objects returned from the API are correctly parsed into `RemoteUser`s, and a negative test that ensures the failure block gets called.

- [x] Please check here if your pull request includes additional test coverage.
