### PR TITLE
Comments: determine which 'status' parameter to use based on provided status.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.28.0-beta.2"
+  s.version       = "4.28.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemote.h
+++ b/WordPressKit/CommentServiceRemote.h
@@ -1,8 +1,18 @@
 #import <Foundation/Foundation.h>
 #import <WordPressKit/RemoteComment.h>
 
-@protocol CommentServiceRemote <NSObject>
 
+// Used to determine which 'status' parameter to use when fetching Comments.
+typedef enum {
+    CommentStatusFilterAll = 0,
+    CommentStatusFilterUnapproved,
+    CommentStatusFilterApproved,
+    CommentStatusFilterTrash,
+    CommentStatusFilterSpam,
+} CommentStatusFilter;
+
+
+@protocol CommentServiceRemote <NSObject>
 
 /**
  Loads all of the comments associated with a blog

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -36,11 +36,12 @@
     if (options) {
         [parameters addEntriesFromDictionary:options];
     }
+    
+    NSNumber *statusFilter = [parameters numberForKey:@"status"];
+    [parameters removeObjectForKey:@"status"];
+    parameters[@"status"] = [self parameterForCommentStatus:statusFilter];
 
-    // If the comment status is not specified, default to all.
-    if (![parameters objectForKey:@"status"]) {
-        parameters[@"status"] = @"all";
-    }
+    NSLog(@"🔴 REST > params: %@", parameters);
     
     [self.wordPressComRestApi GET:requestUrl
                        parameters:parameters
@@ -56,7 +57,26 @@
 
 }
 
-
+- (NSString *)parameterForCommentStatus:(NSNumber *)status
+{
+    switch (status.intValue) {
+        case CommentStatusFilterUnapproved:
+            return @"unapproved";
+            break;
+        case CommentStatusFilterApproved:
+            return @"approved";
+            break;
+        case CommentStatusFilterTrash:
+            return @"trash";
+            break;
+        case CommentStatusFilterSpam:
+            return @"spam";
+            break;
+        default:
+            return @"all";
+            break;
+    }
+}
 
 - (void)createComment:(RemoteComment *)comment
               success:(void (^)(RemoteComment *comment))success

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -26,10 +26,11 @@
         [extraParameters addEntriesFromDictionary:options];
     }
     
-    // If the comment status is not specified, default to all.
-    if (![extraParameters objectForKey:@"status"]) {
-        extraParameters[@"status"] = @"all";
-    }
+    NSNumber *statusFilter = [extraParameters numberForKey:@"status"];
+    [extraParameters removeObjectForKey:@"status"];
+    extraParameters[@"status"] = [self parameterForCommentStatus:statusFilter];
+
+    NSLog(@"🔴 XMLRPC > params: %@", extraParameters);
     
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
     
@@ -45,6 +46,27 @@
                          failure(error);
                      }
                  }];
+}
+
+- (NSString *)parameterForCommentStatus:(NSNumber *)status
+{
+    switch (status.intValue) {
+        case CommentStatusFilterUnapproved:
+            return @"hold";
+            break;
+        case CommentStatusFilterApproved:
+            return @"approve";
+            break;
+        case CommentStatusFilterTrash:
+            return @"trash";
+            break;
+        case CommentStatusFilterSpam:
+            return @"spam";
+            break;
+        default:
+            return @"all";
+            break;
+    }
 }
 
 - (void)getCommentWithID:(NSNumber *)commentID


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15955
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15972

This adds a `CommentStatusFilter` enum for the host app to specify the status used when fetching Comments. Since REST and XMLRPC statuses differ, they are determined separately for each in `parameterForCommentStatus`.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
