### PR TITLE
Remove testing log messages

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.28.0-beta.5"
+  s.version       = "4.28.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.28.0-beta.4"
+  s.version       = "4.28.0-beta.5"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -41,8 +41,6 @@
     [parameters removeObjectForKey:@"status"];
     parameters[@"status"] = [self parameterForCommentStatus:statusFilter];
 
-    NSLog(@"🔴 REST > params: %@", parameters);
-    
     [self.wordPressComRestApi GET:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -30,8 +30,6 @@
     [extraParameters removeObjectForKey:@"status"];
     extraParameters[@"status"] = [self parameterForCommentStatus:statusFilter];
 
-    NSLog(@"🔴 XMLRPC > params: %@", extraParameters);
-    
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
     
     [self.api callMethod:@"wp.getComments"


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15955
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/15998

This removes log messages I accidentally left in.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
