### PR TITLE
Initial pass of `swiftlint autocorrect`

### DIFF
--- a/WordPressKit/AccountServiceRemoteREST+SocialService.swift
+++ b/WordPressKit/AccountServiceRemoteREST+SocialService.swift
@@ -5,7 +5,6 @@ public enum SocialServiceName: String {
     case apple
 }
 
-
 extension AccountServiceRemoteREST {
 
     /// Connect to the specified social service via its OpenID Connect (JWT) token.
@@ -20,7 +19,7 @@ extension AccountServiceRemoteREST {
     ///     - failure The block that will be executed on failure.
     public func connectToSocialService(_ service: SocialServiceName,
                                        serviceIDToken token: String,
-                                       connectParameters: [String:AnyObject]? = nil,
+                                       connectParameters: [String: AnyObject]? = nil,
                                        oAuthClientID: String,
                                        oAuthClientSecret: String,
                                        success:@escaping (() -> Void),
@@ -31,16 +30,16 @@ extension AccountServiceRemoteREST {
             "client_id": oAuthClientID,
             "client_secret": oAuthClientSecret,
             "service": service.rawValue,
-            "id_token": token,
+            "id_token": token
         ] as [String: AnyObject]
 
         if let connectParameters = connectParameters {
             params.merge(connectParameters, uniquingKeysWith: { (current, _) in current })
         }
-        
-        wordPressComRestApi.POST(path, parameters: params, success: { (responseObject, httpResponse) in
+
+        wordPressComRestApi.POST(path, parameters: params, success: { (_, _) in
             success()
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
@@ -51,13 +50,13 @@ extension AccountServiceRemoteREST {
     ///     - email Email from Apple account.
     ///     - fullName User's full name from Apple account.
     /// - Returns: Dictionary with endpoint parameters, to be used when connecting to social service.
-    static public func appleSignInParameters(email: String, fullName: String) -> [String:AnyObject] {
+    static public func appleSignInParameters(email: String, fullName: String) -> [String: AnyObject] {
         return [
             "user_email": email as AnyObject,
             "user_name": fullName as AnyObject
         ]
     }
-    
+
     /// Disconnect fromm the specified social service.
     ///
     /// - Parameters:
@@ -71,12 +70,12 @@ extension AccountServiceRemoteREST {
         let params = [
             "client_id": oAuthClientID,
             "client_secret": oAuthClientSecret,
-            "service": service.rawValue,
+            "service": service.rawValue
         ] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: params, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: params, success: { (_, _) in
             success()
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }

--- a/WordPressKit/AccountSettingsRemote.swift
+++ b/WordPressKit/AccountSettingsRemote.swift
@@ -34,9 +34,9 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
         wordPressComRestApi.GET(path,
-                parameters: parameters as [String : AnyObject]?,
+                parameters: parameters as [String: AnyObject]?,
                 success: {
-                    responseObject, httpResponse in
+                    responseObject, _ in
 
                     do {
                         let settings = try self.settingsFromResponse(responseObject)
@@ -45,7 +45,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
                         failure(error)
                     }
             },
-                failure: { error, httpResponse in
+                failure: { error, _ in
                     failure(error)
         })
     }
@@ -56,13 +56,13 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let parameters = [fieldNameForChange(change): change.stringValue]
 
         wordPressComRestApi.POST(path,
-            parameters: parameters as [String : AnyObject]?,
+            parameters: parameters as [String: AnyObject]?,
             success: {
-                responseObject, httpResponse in
+                _, _ in
 
                 success()
             },
-            failure: { error, httpResponse in
+            failure: { error, _ in
                 failure(error)
         })
     }
@@ -81,11 +81,11 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
         wordPressComRestApi.POST(path,
-                                 parameters: parameters as [String : AnyObject]?,
-                                 success: { responseObject, httpResponse in
+                                 parameters: parameters as [String: AnyObject]?,
+                                 success: { _, _ in
                                     success()
                                  },
-                                 failure: { error, httpResponse in
+                                 failure: { _, _ in
                                     failure()
                                  })
     }
@@ -99,16 +99,16 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
     public func validateUsername(to username: String, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "me/username/validate/\(username)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
-        
+
         wordPressComRestApi.GET(path,
                                 parameters: nil,
-                                success: { responseObject, httpResponse in
+                                success: { _, _ in
                                     // The success block needs to be changed if
                                     // any allowed_actions is required
                                     // by the changeUsername API
                                     success()
         },
-                                 failure: { error, httpResponse in
+                                 failure: { error, _ in
                                     failure(error)
         })
     }
@@ -117,7 +117,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let endpoint = "wpcom/v2/users/username/suggestions"
         let parameters = ["name": base]
 
-        wordPressComRestApi.GET(endpoint, parameters: parameters as [String: AnyObject]?, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(endpoint, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                 let suggestions = response["suggestions"] as? [String] else {
                 finished([])
@@ -125,7 +125,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
             }
 
             finished(suggestions)
-        }) { (error, httpResponse) in
+        }) { (_, _) in
             finished([])
         }
     }
@@ -134,18 +134,18 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let endpoint = "me/settings"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = ["password": password]
-        
+
         wordPressComRestApi.POST(path,
-                                 parameters: parameters as [String : AnyObject]?,
+                                 parameters: parameters as [String: AnyObject]?,
                                  success: {
-                                    responseObject, httpResponse in
+                                    _, _ in
                                     success()
         },
-                                 failure: { error, httpResponse in
+                                 failure: { error, _ in
                                     failure(error)
         })
     }
-    
+
     private func settingsFromResponse(_ responseObject: AnyObject) throws -> AccountSettings {
         guard let
             response = responseObject as? [String: AnyObject],

--- a/WordPressKit/Activity.swift
+++ b/WordPressKit/Activity.swift
@@ -35,7 +35,7 @@ open class Activity {
         guard let publishedDate = Date.dateWithISO8601WithMillisecondsString(publishedString) else {
             throw Error.incorrectPusblishedDateFormat
         }
-        
+
         activityID = id
         summary = summaryText
         text = contentText
@@ -191,7 +191,7 @@ public class RewindStatus {
     public let restore: RestoreStatus?
 
     internal init(state: State) {
-        //FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
+        // FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
         // stops returning 412's for those sites.
         self.state = state
         self.lastUpdated = Date()

--- a/WordPressKit/ActivityServiceRemote.swift
+++ b/WordPressKit/ActivityServiceRemote.swift
@@ -153,7 +153,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
                                         failure(ResponseError.decodingFailure)
                                     }
                                 }, failure: { error, _ in
-                                    //FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
+                                    // FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
                                     // stops returning 412's for those sites.
                                     if let error = error as? WordPressComRestApiError, error == WordPressComRestApiError.preconditionFailure {
                                         let status = RewindStatus(state: .unavailable)
@@ -190,24 +190,24 @@ private extension ActivityServiceRemote {
 
         return (activities, totalItems)
     }
-    
+
     func mapActivityGroupsResponse(_ response: AnyObject) throws -> ([ActivityGroup]) {
         guard let json = response as? [String: AnyObject],
               let totalItems = json["totalItems"] as? Int, totalItems > 0 else {
             return []
         }
-        
+
         guard let rawGroups = json["groups"] as? [String: AnyObject] else {
                 throw ActivityServiceRemote.ResponseError.decodingFailure
         }
-        
+
         let groups: [ActivityGroup] = try rawGroups.map { (key, value) -> ActivityGroup in
             guard let group = value as? [String: AnyObject] else {
                 throw ActivityServiceRemote.ResponseError.decodingFailure
             }
             return try ActivityGroup(key, dictionary: group)
         }
-        
+
         return groups
     }
 

--- a/WordPressKit/ActivityServiceRemote_ApiVersion1_0.swift
+++ b/WordPressKit/ActivityServiceRemote_ApiVersion1_0.swift
@@ -1,10 +1,9 @@
-
 @objc public class ActivityServiceRemote_ApiVersion1_0: ServiceRemoteWordPressComREST {
 
     public enum ResponseError: Error {
         case decodingFailure
     }
-    
+
     /// Makes a request to Restore a site to a previous state.
     ///
     /// - Parameters:

--- a/WordPressKit/AnnouncementServiceRemote.swift
+++ b/WordPressKit/AnnouncementServiceRemote.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// Retrieves feature announcements from the related endpoint
 public class AnnouncementServiceRemote: ServiceRemoteWordPressComREST {
 
@@ -32,7 +31,6 @@ public class AnnouncementServiceRemote: ServiceRemoteWordPressComREST {
     }
 }
 
-
 // MARK: - Helpers
 private extension AnnouncementServiceRemote {
 
@@ -53,7 +51,6 @@ private extension AnnouncementServiceRemote {
         return container.announcements
     }
 }
-
 
 // MARK: - Constants
 private extension AnnouncementServiceRemote {
@@ -77,7 +74,6 @@ private extension AnnouncementServiceRemote {
         }
     }
 }
-
 
 // MARK: - Decoded data
 public struct AnnouncementsContainer: Decodable {

--- a/WordPressKit/AtomicAuthenticationServiceRemote.swift
+++ b/WordPressKit/AtomicAuthenticationServiceRemote.swift
@@ -1,25 +1,25 @@
 import Foundation
 
 public class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
-    
+
     public enum ResponseError: Error {
         case responseIsNotADictionary(response: AnyObject)
         case decodingFailure(response: [String: AnyObject])
         case couldNotInstantiateCookie(name: String, value: String, domain: String, path: String, expires: Date)
     }
-    
+
     public func getAuthCookie(
         siteID: Int,
         success: @escaping (_ cookie: HTTPCookie) -> Void,
         failure: @escaping (Error) -> Void) {
-        
+
         let endpoint = "sites/\(siteID)/atomic-auth-proxy/read-access-cookies"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
         wordPressComRestApi.GET(path,
                 parameters: nil,
                 success: {
-                    responseObject, httpResponse in
+                    responseObject, _ in
 
                     do {
                         let settings = try self.cookie(from: responseObject)
@@ -28,24 +28,24 @@ public class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
                         failure(error)
                     }
             },
-                failure: { error, httpResponse in
+                failure: { error, _ in
                     failure(error)
         })
     }
 
     // MARK: - Result Parsing
-    
+
     private func date(from expiration: Int) -> Date {
         return Date(timeIntervalSince1970: TimeInterval(expiration))
     }
-    
+
     private func cookie(from responseObject: AnyObject) throws -> HTTPCookie {
         guard let response = responseObject as? [String: AnyObject] else {
             let error = ResponseError.responseIsNotADictionary(response: responseObject)
             DDLogError("❗️Error: \(error)")
             throw error
         }
-        
+
         guard let cookies = response["cookies"] as? [[String: Any]] else {
             let error = ResponseError.decodingFailure(response: response)
             DDLogError("❗️Error: \(error)")
@@ -64,7 +64,7 @@ public class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
                 DDLogError("❗️Error: \(error)")
                 throw error
         }
-        
+
         let expirationDate = date(from: expires)
 
         guard let cookie = HTTPCookie(properties: [
@@ -72,13 +72,13 @@ public class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
             .value: value,
             .domain: domain,
             .path: path,
-            .expires: expirationDate,
+            .expires: expirationDate
         ]) else {
             let error = ResponseError.couldNotInstantiateCookie(name: name, value: value, domain: domain, path: path, expires: expirationDate)
             DDLogError("❗️Error: \(error)")
             throw error
         }
-        
+
         return cookie
     }
 }

--- a/WordPressKit/Authenticator.swift
+++ b/WordPressKit/Authenticator.swift
@@ -44,7 +44,7 @@ public class CookieNonceAuthenticator: Authenticator {
     private let loginURL: URL
     private let adminURL: URL
     private let version: String
-    private var nonce: Secret<String>? = nil
+    private var nonce: Secret<String>?
     // If we can't get this to work once, don't retry for the same site
     // It is likely that there is something preventing us from extracting a nonce
     private var canRetry = true
@@ -203,12 +203,12 @@ private extension CookieNonceAuthenticator {
 
         func scrapNonceFromNewPost(html: String) -> String? {
             guard let regex = try? NSRegularExpression(pattern: "apiFetch.createNonceMiddleware\\(\\s*['\"](?<nonce>\\w+)['\"]\\s*\\)", options: []),
-                let match = regex.firstMatch(in: html, options: [], range: NSMakeRange(0, html.count)) else {
+                let match = regex.firstMatch(in: html, options: [], range: NSRange(location: 0, length: html.count)) else {
                     return nil
             }
             let nsrange = match.range(withName: "nonce")
             let nonce = Range(nsrange, in: html)
-                .map( { html[$0] })
+                .map({ html[$0] })
                 .map( String.init )
 
             return nonce

--- a/WordPressKit/AutomatedTransferService.swift
+++ b/WordPressKit/AutomatedTransferService.swift
@@ -26,7 +26,7 @@ public class AutomatedTransferService: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/automated-transfers/eligibility"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject] else {
                 failure(.unknown)
                 return
@@ -53,7 +53,7 @@ public class AutomatedTransferService: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let payload = ["plugin": pluginSlug] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: payload, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: payload, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -80,7 +80,7 @@ public class AutomatedTransferService: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/automated-transfers/status"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return

--- a/WordPressKit/BlogJetpackSettingsServiceRemote.swift
+++ b/WordPressKit/BlogJetpackSettingsServiceRemote.swift
@@ -11,13 +11,13 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
     /// Fetches the Jetpack settings for the specified site
     ///
     public func getJetpackSettingsForSite(_ siteID: Int, success: @escaping (RemoteBlogJetpackSettings) -> Void, failure: @escaping (Error) -> Void) {
-        
+
         let endpoint = "jetpack-blogs/\(siteID)/rest-api"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = ["path": "/jetpack/v4/settings"]
 
         wordPressComRestApi.GET(path,
-                                parameters: parameters as [String : AnyObject]?,
+                                parameters: parameters as [String: AnyObject]?,
                                 success: {
                                     response, _ in
                                     guard let results = response["data"] as? [String: AnyObject],
@@ -93,12 +93,12 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = ["path": "/jetpack/v4/settings",
                           "body": jSONBody,
-                          "json": true] as [String : AnyObject]
+                          "json": true] as [String: AnyObject]
 
         wordPressComRestApi.POST(path,
                                  parameters: parameters,
                                  success: {
-                                     _,_  in
+                                     _, _  in
                                      success()
                                  }, failure: {
                                      error, _ in
@@ -117,7 +117,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(path,
                                  parameters: parameters,
                                  success: {
-                                    _,_  in
+                                    _, _  in
                                     success()
                                  }, failure: {
                                     error, _ in
@@ -133,9 +133,9 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let parameters = [ModuleOptionKeys.active: active]
 
         wordPressComRestApi.POST(path,
-                                 parameters: parameters as [String : AnyObject],
+                                 parameters: parameters as [String: AnyObject],
                                  success: {
-                                     _,_  in
+                                     _, _  in
                                      success()
                                  }, failure: {
                                      error, _ in
@@ -152,7 +152,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(path,
                                  parameters: nil,
                                  success: {
-                                     _,_  in
+                                     _, _  in
                                      success()
                                  }, failure: {
                                      error, _ in
@@ -168,7 +168,7 @@ private extension BlogJetpackSettingsServiceRemote {
 
         guard let monitorEnabled = dictionary[Keys.monitorEnabled] as? Bool,
             let blockMaliciousLoginAttempts = dictionary[Keys.blockMaliciousLoginAttempts] as? Bool,
-            let whitelistedIPs = dictionary[Keys.whiteListedIPAddresses]?[Keys.whiteListedIPsLocal] as? Array<String>,
+            let whitelistedIPs = dictionary[Keys.whiteListedIPAddresses]?[Keys.whiteListedIPsLocal] as? [String],
             let ssoEnabled = dictionary[Keys.ssoEnabled] as? Bool,
             let ssoMatchAccountsByEmail = dictionary[Keys.ssoMatchAccountsByEmail] as? Bool,
             let ssoRequireTwoStepAuthentication = dictionary[Keys.ssoRequireTwoStepAuthentication] as? Bool else {
@@ -189,7 +189,7 @@ private extension BlogJetpackSettingsServiceRemote {
             let monitorPushNotifications = dictionary[Keys.monitorPushNotifications] as? Bool else {
                 throw ResponseError.decodingFailure
         }
-        
+
         return RemoteBlogJetpackMonitorSettings(monitorEmailNotifications: monitorEmailNotifications,
                                                 monitorPushNotifications: monitorPushNotifications)
     }
@@ -220,7 +220,7 @@ private extension BlogJetpackSettingsServiceRemote {
             Keys.whiteListedIPAddresses: shouldSendWhitelist ? joinedIPs : nil,
             Keys.ssoEnabled: settings.ssoEnabled,
             Keys.ssoMatchAccountsByEmail: settings.ssoMatchAccountsByEmail,
-            Keys.ssoRequireTwoStepAuthentication: settings.ssoRequireTwoStepAuthentication,
+            Keys.ssoRequireTwoStepAuthentication: settings.ssoRequireTwoStepAuthentication
         ]
         return settingsDictionary.compactMapValues { $0 }
     }

--- a/WordPressKit/CocoaLumberjack.swift
+++ b/WordPressKit/CocoaLumberjack.swift
@@ -31,7 +31,7 @@ extension DDLogFlag {
         self = DDLogFlag(rawValue: logLevel.rawValue)
     }
 
-    ///returns the log level, or the lowest equivalant.
+    /// returns the log level, or the lowest equivalant.
     public func toLogLevel() -> DDLogLevel {
         if let ourValid = DDLogLevel(rawValue: rawValue) {
             return ourValid

--- a/WordPressKit/Decodable+Dictionary.swift
+++ b/WordPressKit/Decodable+Dictionary.swift
@@ -16,12 +16,12 @@ struct JSONCodingKeys: CodingKey {
 /// Add support to decode to a Dictionary
 /// From: https://stackoverflow.com/q/44603248
 extension KeyedDecodingContainer {
-    func decode(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> Dictionary<String, Any> {
+    func decode(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> [String: Any] {
         let container = try self.nestedContainer(keyedBy: JSONCodingKeys.self, forKey: key)
         return try container.decode(type)
     }
 
-    func decodeIfPresent(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> Dictionary<String, Any>? {
+    func decodeIfPresent(_ type: Dictionary<String, Any>.Type, forKey key: K) throws -> [String: Any]? {
         guard contains(key) else {
             return nil
         }
@@ -31,12 +31,12 @@ extension KeyedDecodingContainer {
         return try decode(type, forKey: key)
     }
 
-    func decode(_ type: Array<Any>.Type, forKey key: K) throws -> Array<Any> {
+    func decode(_ type: Array<Any>.Type, forKey key: K) throws -> [Any] {
         var container = try self.nestedUnkeyedContainer(forKey: key)
         return try container.decode(type)
     }
 
-    func decodeIfPresent(_ type: Array<Any>.Type, forKey key: K) throws -> Array<Any>? {
+    func decodeIfPresent(_ type: Array<Any>.Type, forKey key: K) throws -> [Any]? {
         guard contains(key) else {
             return nil
         }
@@ -46,8 +46,8 @@ extension KeyedDecodingContainer {
         return try decode(type, forKey: key)
     }
 
-    func decode(_ type: Dictionary<String, Any>.Type) throws -> Dictionary<String, Any> {
-        var dictionary = Dictionary<String, Any>()
+    func decode(_ type: Dictionary<String, Any>.Type) throws -> [String: Any] {
+        var dictionary = [String: Any]()
 
         for key in allKeys {
             if let boolValue = try? decode(Bool.self, forKey: key) {
@@ -70,7 +70,7 @@ extension KeyedDecodingContainer {
 
 extension UnkeyedDecodingContainer {
 
-    mutating func decode(_ type: Array<Any>.Type) throws -> Array<Any> {
+    mutating func decode(_ type: Array<Any>.Type) throws -> [Any] {
         var array: [Any] = []
         while isAtEnd == false {
             // See if the current value in the JSON array is `null` first and prevent infite recursion with nested arrays.
@@ -91,7 +91,7 @@ extension UnkeyedDecodingContainer {
         return array
     }
 
-    mutating func decode(_ type: Dictionary<String, Any>.Type) throws -> Dictionary<String, Any> {
+    mutating func decode(_ type: Dictionary<String, Any>.Type) throws -> [String: Any] {
 
         let nestedContainer = try self.nestedContainer(keyedBy: JSONCodingKeys.self)
         return try nestedContainer.decode(type)

--- a/WordPressKit/DomainContactInformation.swift
+++ b/WordPressKit/DomainContactInformation.swift
@@ -13,10 +13,10 @@ public struct ValidateDomainContactInformationResponse: Codable {
         public var lastName: [String]?
         public var state: [String]?
     }
-    
+
     public var success: Bool = false
     public var messages: Messages?
-    
+
     public init() {
     }
 }
@@ -33,7 +33,7 @@ public struct DomainContactInformation: Codable {
     public var fax: String?
     public var state: String?
     public var organization: String?
-    
+
     public init() {
     }
 }

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -9,7 +9,7 @@ public struct DomainSuggestion: Codable {
     public var domainNameStrippingSubdomain: String {
         return domainName.components(separatedBy: ".").first ?? domainName
     }
-    
+
     public init(json: [String: AnyObject]) throws {
         guard let domain = json["domain_name"] as? String else {
              throw DomainsServiceRemote.ResponseError.decodingFailed
@@ -27,7 +27,7 @@ public struct DomainSuggestionRequest: Encodable {
     public let query: String
     public let segmentID: Int64
     public let quantity: Int?
-    
+
     public init(query: String, segmentID: Int64, quantity: Int?) {
         self.query = query
         self.segmentID = segmentID
@@ -46,7 +46,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         case onlyWordPressDotCom
         case wordPressDotComAndDotBlogSubdomains
         case whitelistedTopLevelDomains([String])
-        
+
         fileprivate func parameters() -> [String: AnyObject] {
             switch self {
             case .noWordpressDotCom:
@@ -66,7 +66,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
             }
         }
     }
-    
+
     public func getDomainsForSite(_ siteID: Int, success: @escaping ([RemoteDomain]) -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "sites/\(siteID)/domains"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
@@ -93,7 +93,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         let parameters: [String: AnyObject] = ["domain": domain as AnyObject]
 
         wordPressComRestApi.POST(path, parameters: parameters,
-                                success: { response, _ in
+                                success: { _, _ in
 
             success()
         }, failure: { error, _ in
@@ -107,7 +107,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
                                 failure: @escaping (Error) -> Void) {
         let endPoint = "domains/supported-states/\(countryCode)"
         let servicePath = path(forEndpoint: endPoint, withVersion: ._1_1)
-        
+
         wordPressComRestApi.GET(
             servicePath,
             parameters: nil,
@@ -128,12 +128,12 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
             failure(error)
         })
     }
-    
+
     public func getDomainContactInformation(success: @escaping (DomainContactInformation) -> Void,
                                             failure: @escaping (Error) -> Void) {
         let endPoint = "me/domain-contact-information"
         let servicePath = path(forEndpoint: endPoint, withVersion: ._1_1)
-        
+
         wordPressComRestApi.GET(
             servicePath,
             parameters: nil,
@@ -150,20 +150,20 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
             failure(error)
         }
     }
-    
+
     public func validateDomainContactInformation(contactInformation: [String: String],
                                                  domainNames: [String],
                                                  success: @escaping (ValidateDomainContactInformationResponse) -> Void,
                                                  failure: @escaping (Error) -> Void) {
         let endPoint = "me/domain-contact-information/validate"
         let servicePath = path(forEndpoint: endPoint, withVersion: ._1_1)
-        
+
         let parameters: [String: AnyObject] = ["contact_information": contactInformation as AnyObject,
                                                "domain_names": domainNames as AnyObject]
         wordPressComRestApi.POST(
             servicePath,
             parameters: parameters,
-            success: { response,_ in
+            success: { response, _ in
                 do {
                     let data = try JSONSerialization.data(withJSONObject: response, options: .prettyPrinted)
                     let decodedResult = try JSONDecoder.apiDecoder.decode(ValidateDomainContactInformationResponse.self, from: data)
@@ -172,7 +172,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
                     DDLogError("Error parsing ValidateDomainContactInformationResponse  (\(error)): \(response)")
                     failure(error)
                 }
-        }) { (error, response) in
+        }) { (error, _) in
             failure(error)
         }
     }
@@ -220,7 +220,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         if let quantity = quantity {
             parameters["quantity"] = quantity as AnyObject
         }
-        
+
         wordPressComRestApi.GET(servicePath,
                                 parameters: parameters,
                                 success: {
@@ -243,7 +243,7 @@ private func map(suggestions response: AnyObject) throws -> [DomainSuggestion] {
     guard let jsonSuggestions = response as? [[String: AnyObject]] else {
         throw DomainsServiceRemote.ResponseError.decodingFailed
     }
-    
+
     var suggestions: [DomainSuggestion] = []
     for jsonSuggestion in jsonSuggestions {
         do {

--- a/WordPressKit/EditorServiceRemote.swift
+++ b/WordPressKit/EditorServiceRemote.swift
@@ -6,14 +6,14 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/gutenberg?platform=mobile&editor=\(editor.rawValue)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, _) in
             do {
                 let settings = try EditorSettings(with: responseObject)
                 success(settings)
             } catch {
                 failure(error)
             }
-        }) { (error, httpError) in
+        }) { (error, _) in
             failure(error)
         }
     }
@@ -25,10 +25,10 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         let parameters = [
             "platform": "mobile",
             "editor": editor.rawValue,
-            "set_only_if_empty": setOnlyIfEmpty,
+            "set_only_if_empty": setOnlyIfEmpty
         ] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: parameters, success: { (responseObject, _) in
             guard let response = responseObject as? [String: String] else {
                 if let boolResponse = responseObject as? Bool, boolResponse == false {
                     return failure(EditorSettings.Error.badRequest)
@@ -42,7 +42,7 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
                 }
             })
             success(mappedResponse)
-        }) { (error, httpError) in
+        }) { (error, _) in
             failure(error)
         }
     }
@@ -51,14 +51,14 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/gutenberg"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, _) in
             do {
                 let settings = try EditorSettings(with: responseObject)
                 success(settings)
             } catch {
                 failure(error)
             }
-        }) { (error, httpError) in
+        }) { (error, _) in
             failure(error)
         }
     }

--- a/WordPressKit/EditorSettings.swift
+++ b/WordPressKit/EditorSettings.swift
@@ -22,7 +22,6 @@ public struct EditorSettings {
         case notSet = ""
     }
 
-
     /// Editor choosen by the user to be used on Web
     ///
     /// - classic: The classic editor

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -24,7 +24,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.GET(path,
                                 parameters: parameters,
                                 success: { response, _ in
-                                    
+
                                     if let featureFlagList = response as? NSDictionary {
 
                                         let reconstitutedList = featureFlagList.compactMap { row -> FeatureFlag? in

--- a/WordPressKit/GravatarServiceRemote.swift
+++ b/WordPressKit/GravatarServiceRemote.swift
@@ -5,7 +5,7 @@ import WordPressShared
 ///
 open class GravatarServiceRemote {
     let baseGravatarURL = "https://www.gravatar.com/"
-    
+
     public init() {}
 
     /// This method fetches the Gravatar profile for the specified email address.
@@ -39,15 +39,15 @@ open class GravatarServiceRemote {
         }
 
         let session = URLSession.shared
-        let task = session.dataTask(with: targetURL) { (data: Data?, response: URLResponse?, error: Error?) in
+        let task = session.dataTask(with: targetURL) { (data: Data?, _: URLResponse?, error: Error?) in
             guard error == nil, let data = data else {
                 failure(error)
                 return
             }
             do {
                 let jsonData = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
-                
-                guard let jsonDictionary = jsonData as? [String: Array<Any>],
+
+                guard let jsonDictionary = jsonData as? [String: [Any]],
                     let entry = jsonDictionary["entry"],
                     let profileData = entry.first as? NSDictionary else {
                         DispatchQueue.main.async {
@@ -57,7 +57,7 @@ open class GravatarServiceRemote {
                         }
                         return
                 }
-                
+
                 let profile = RemoteGravatarProfile(dictionary: profileData)
                 DispatchQueue.main.async {
                     success(profile)
@@ -65,7 +65,7 @@ open class GravatarServiceRemote {
                 return
 
             } catch {
-                failure (error)
+                failure(error)
                 return
             }
         }
@@ -73,14 +73,13 @@ open class GravatarServiceRemote {
         task.resume()
     }
 
-
     /// This method hits the Gravatar Endpoint, and uploads a new image, to be used as profile.
     ///
     /// - Parameters:
     ///     - image: The new Gravatar Image, to be uploaded
     ///     - completion: An optional closure to be executed on completion.
     ///
-    open func uploadImage(_ image: UIImage, accountEmail: String, accountToken: String, completion: ((_ error: NSError?) -> ())?) {
+    open func uploadImage(_ image: UIImage, accountEmail: String, accountToken: String, completion: ((_ error: NSError?) -> Void)?) {
         guard let targetURL = URL(string: UploadParameters.endpointURL) else {
             assertionFailure()
             return
@@ -101,13 +100,12 @@ open class GravatarServiceRemote {
 
         // Task
         let session = URLSession.shared
-        let task = session.uploadTask(with: request as URLRequest, from: requestBody, completionHandler: { (data, response, error) in
+        let task = session.uploadTask(with: request as URLRequest, from: requestBody, completionHandler: { (_, _, error) in
             completion?(error as NSError?)
         })
 
         task.resume()
     }
-
 
     // MARK: - Private Helpers
 
@@ -116,7 +114,6 @@ open class GravatarServiceRemote {
     private func boundaryForRequest() -> String {
         return "Boundary-" + UUID().uuidString
     }
-
 
     /// Returns the Body for a Gravatar Upload OP.
     ///
@@ -148,7 +145,6 @@ open class GravatarServiceRemote {
 
         return body as Data
     }
-
 
     // MARK: - Private Structs
     private struct UploadParameters {

--- a/WordPressKit/HTTPAuthenticationAlertController.swift
+++ b/WordPressKit/HTTPAuthenticationAlertController.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// URLAuthenticationChallenge Handler: It's up to the Host App to actually use this, whenever `WordPressOrgXMLRPCApi.onChallenge` is hit!
 ///
 open class HTTPAuthenticationAlertController {
@@ -42,14 +41,14 @@ open class HTTPAuthenticationAlertController {
 
         let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button label"),
                                          style: .default,
-                                         handler: { (action) in
+                                         handler: { (_) in
                                             executeHandlerForChallenge(challenge, disposition: .cancelAuthenticationChallenge, credential: nil)
         })
         controller.addAction(cancelAction)
 
         let trustAction = UIAlertAction(title: NSLocalizedString("Trust", comment: "Connect when the SSL certificate is invalid"),
                                         style: .default,
-                                        handler: { (action) in
+                                        handler: { (_) in
                                             let credential = URLCredential(trust: challenge.protectionSpace.serverTrust!)
                                             URLCredentialStorage.shared.setDefaultCredential(credential, for: challenge.protectionSpace)
                                             executeHandlerForChallenge(challenge, disposition: .useCredential, credential: credential)
@@ -76,14 +75,14 @@ open class HTTPAuthenticationAlertController {
 
         let cancelAction = UIAlertAction(title: NSLocalizedString("Cancel", comment: "Cancel button label"),
                                          style: .default,
-                                         handler: { (action) in
+                                         handler: { (_) in
                                             executeHandlerForChallenge(challenge, disposition: .cancelAuthenticationChallenge, credential: nil)
         })
         controller.addAction(cancelAction)
 
         let loginAction = UIAlertAction(title: NSLocalizedString("Log In", comment: "Log In button label."),
                                         style: .default,
-                                        handler: { (action) in
+                                        handler: { (_) in
                                             guard let username = controller.textFields?.first?.text,
                                                 let password = controller.textFields?.last?.text else {
                                                     executeHandlerForChallenge(challenge, disposition: .cancelAuthenticationChallenge, credential: nil)

--- a/WordPressKit/HomepageSettingsServiceRemote.swift
+++ b/WordPressKit/HomepageSettingsServiceRemote.swift
@@ -27,7 +27,7 @@ public class HomepageSettingsServiceRemote: ServiceRemoteWordPressComREST {
         }
 
         wordPressComRestApi.POST(path, parameters: parameters,
-                                success: { response, _ in
+                                success: { _, _ in
             success()
         }, failure: { error, _ in
             failure(error)

--- a/WordPressKit/Insights/StatsAllAnnualInsight.swift
+++ b/WordPressKit/Insights/StatsAllAnnualInsight.swift
@@ -1,6 +1,6 @@
 public struct StatsAllAnnualInsight {
     public let allAnnualInsights: [StatsAnnualInsight]
-    
+
     public init(allAnnualInsights: [StatsAnnualInsight]) {
         self.allAnnualInsights = allAnnualInsights
     }
@@ -17,7 +17,7 @@ public struct StatsAnnualInsight {
     public let averageCommentsCount: Double
     public let totalImagesCount: Int
     public let averageImagesCount: Double
-    
+
     public init(year: Int,
                 totalPostsCount: Int,
                 totalWordsCount: Int,
@@ -45,18 +45,18 @@ extension StatsAllAnnualInsight: StatsInsightData {
     public static var pathComponent: String {
         return "stats/insights"
     }
-    
-    public init?(jsonDictionary: [String : AnyObject]) {
+
+    public init?(jsonDictionary: [String: AnyObject]) {
         guard let yearlyInsights = jsonDictionary["years"] as? [[String: AnyObject]] else {
             return nil
         }
-        
+
         let allAnnualInsights: [StatsAnnualInsight] = yearlyInsights.compactMap {
             guard let yearString = $0["year"] as? String,
                 let year = Int(yearString) else {
                     return nil
             }
-            
+
             return StatsAnnualInsight(year: year,
                                       totalPostsCount: $0["total_posts"] as? Int ?? 0,
                                       totalWordsCount: $0["total_words"] as? Int ?? 0,
@@ -68,7 +68,7 @@ extension StatsAllAnnualInsight: StatsInsightData {
                                       totalImagesCount: $0["total_images"] as? Int ?? 0,
                                       averageImagesCount: $0["avg_images"] as? Double ?? 0)
         }
-        
+
         self.allAnnualInsights = allAnnualInsights
     }
 }

--- a/WordPressKit/Insights/StatsAllTimesInsight.swift
+++ b/WordPressKit/Insights/StatsAllTimesInsight.swift
@@ -18,10 +18,9 @@ public struct StatsAllTimesInsight {
     }
 }
 
-
 extension StatsAllTimesInsight: StatsInsightData {
 
-    //MARK: - StatsInsightData Conformance
+    // MARK: - StatsInsightData Conformance
     public init?(jsonDictionary: [String: AnyObject]) {
         guard
             let statsDict = jsonDictionary["stats"] as? [String: AnyObject],
@@ -38,7 +37,7 @@ extension StatsAllTimesInsight: StatsInsightData {
         self.bestViewsDay = bestViewsDay
     }
 
-    //MARK: -
+    // MARK: -
     private static var dateFormatter: DateFormatter {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"

--- a/WordPressKit/Insights/StatsAnnualAndMostPopularTimeInsight.swift
+++ b/WordPressKit/Insights/StatsAnnualAndMostPopularTimeInsight.swift
@@ -65,7 +65,7 @@ extension StatsAnnualAndMostPopularTimeInsight: StatsInsightData {
         return "stats/insights"
     }
 
-    public init?(jsonDictionary: [String : AnyObject]) {
+    public init?(jsonDictionary: [String: AnyObject]) {
         guard
             let highestHour = jsonDictionary["highest_hour"] as? Int,
             let highestHourPercentageValue = jsonDictionary["highest_hour_percent"] as? Double,

--- a/WordPressKit/Insights/StatsCommentsInsight.swift
+++ b/WordPressKit/Insights/StatsCommentsInsight.swift
@@ -11,7 +11,7 @@ public struct StatsCommentsInsight {
 
 extension StatsCommentsInsight: StatsInsightData {
 
-    //MARK: - StatsInsightData Conformance
+    // MARK: - StatsInsightData Conformance
     public static var pathComponent: String {
         return "stats/comments"
     }
@@ -78,7 +78,6 @@ private extension StatsTopCommentsAuthor {
         self.init(name: name, avatar: avatar, commentCount: commentCount)
     }
 
-
     init?(name: String, avatar: String, commentCount: Int) {
         let url: URL?
 
@@ -113,8 +112,3 @@ private extension StatsTopCommentsPost {
                   postURL: URL(string: postURL))
     }
 }
-
-
-
-
-

--- a/WordPressKit/Insights/StatsDotComFollowersInsight.swift
+++ b/WordPressKit/Insights/StatsDotComFollowersInsight.swift
@@ -11,7 +11,7 @@ public struct StatsDotComFollowersInsight {
 
 extension StatsDotComFollowersInsight: StatsInsightData {
 
-    //MARK: - StatsInsightData Conformance
+    // MARK: - StatsInsightData Conformance
     public static func queryProperties(with maxCount: Int) -> [String: String] {
         return ["type": "wpcom",
                 "max": String(maxCount)]
@@ -35,7 +35,7 @@ extension StatsDotComFollowersInsight: StatsInsightData {
         self.topDotComFollowers = followers
     }
 
-    //MARK: -
+    // MARK: -
     fileprivate static let dateFormatter = ISO8601DateFormatter()
 }
 
@@ -66,7 +66,6 @@ extension StatsFollower {
 
         self.init(name: name, avatar: avatar, date: dateString)
     }
-
 
     init?(name: String, avatar: String, date: String) {
         guard let date = StatsDotComFollowersInsight.dateFormatter.date(from: date) else {

--- a/WordPressKit/Insights/StatsEmailFollowersInsight.swift
+++ b/WordPressKit/Insights/StatsEmailFollowersInsight.swift
@@ -11,7 +11,7 @@ public struct StatsEmailFollowersInsight {
 
 extension StatsEmailFollowersInsight: StatsInsightData {
 
-    //MARK: - StatsInsightData Conformance
+    // MARK: - StatsInsightData Conformance
     public static func queryProperties(with maxCount: Int) -> [String: String] {
         return ["type": "email",
                 "max": String(maxCount)]

--- a/WordPressKit/Insights/StatsLastPostInsight.swift
+++ b/WordPressKit/Insights/StatsLastPostInsight.swift
@@ -26,7 +26,7 @@ public struct StatsLastPostInsight {
 
 extension StatsLastPostInsight: StatsInsightData {
 
-    //MARK: - StatsInsightData Conformance
+    // MARK: - StatsInsightData Conformance
     public static func queryProperties(with maxCount: Int) -> [String: String] {
         return ["order_by": "date",
                 "number": "1",
@@ -42,7 +42,7 @@ extension StatsLastPostInsight: StatsInsightData {
         fatalError("This shouldn't be ever called, instead init?(jsonDictionary:_ views:_) be called instead.")
     }
 
-    //MARK: -
+    // MARK: -
 
     private static let dateFormatter = ISO8601DateFormatter()
 

--- a/WordPressKit/Insights/StatsPostingStreakInsight.swift
+++ b/WordPressKit/Insights/StatsPostingStreakInsight.swift
@@ -39,7 +39,7 @@ public struct PostingStreakEvent {
 
 extension StatsPostingStreakInsight: StatsInsightData {
 
-    //MARK: - StatsInsightData Conformance
+    // MARK: - StatsInsightData Conformance
     public static var pathComponent: String {
         return "stats/streak"
     }

--- a/WordPressKit/Insights/StatsPublicizeInsight.swift
+++ b/WordPressKit/Insights/StatsPublicizeInsight.swift
@@ -8,7 +8,7 @@ public struct StatsPublicizeInsight {
 
 extension StatsPublicizeInsight: StatsInsightData {
 
-    //MARK: - StatsInsightData Conformance
+    // MARK: - StatsInsightData Conformance
     public static var pathComponent: String {
         return "stats/publicize"
     }
@@ -86,4 +86,3 @@ private extension StatsPublicizeService {
         self.iconURL = icon
     }
 }
-

--- a/WordPressKit/Insights/StatsTagsAndCategoriesInsight.swift
+++ b/WordPressKit/Insights/StatsTagsAndCategoriesInsight.swift
@@ -11,7 +11,7 @@ extension StatsTagsAndCategoriesInsight: StatsInsightData {
         return "stats/tags"
     }
 
-    public init?(jsonDictionary: [String : AnyObject]) {
+    public init?(jsonDictionary: [String: AnyObject]) {
         guard
             let outerTags = jsonDictionary["tags"] as? [[String: AnyObject]]
             // The shape of the API response here leaves... something to be desired.
@@ -73,7 +73,7 @@ extension StatsTagAndCategory {
 
         let mappedChildren = innerTags.compactMap { StatsTagAndCategory(singleTag: $0) }
         let label = mappedChildren.map { $0.name }.joined(separator: ", ")
-        
+
         self.init(name: label, kind: .folder, url: nil, viewsCount: views, children: mappedChildren)
     }
 

--- a/WordPressKit/Insights/StatsTodayInsight.swift
+++ b/WordPressKit/Insights/StatsTodayInsight.swift
@@ -17,7 +17,7 @@ public struct StatsTodayInsight {
 
 extension StatsTodayInsight: StatsInsightData {
 
-    //MARK: - StatsInsightData Conformance
+    // MARK: - StatsInsightData Conformance
     public static var pathComponent: String {
         return "stats/summary"
     }

--- a/WordPressKit/JSONDecoderExtension.swift
+++ b/WordPressKit/JSONDecoderExtension.swift
@@ -11,20 +11,20 @@ extension JSONDecoder {
 }
 
 extension JSONDecoder.DateDecodingStrategy {
-    
+
     enum DateFormat: String, CaseIterable {
         case noTime = "yyyy-mm-dd"
         case dateWithTime = "yyyy-MM-dd HH:mm:ss"
         case iso8601 = "yyyy-MM-dd'T'HH:mm:ssZ"
         case iso8601WithMilliseconds = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
-        
+
         var formatter: DateFormatter {
             let dateFormatter = DateFormatter()
             dateFormatter.dateFormat = rawValue
             return dateFormatter
         }
     }
-    
+
     static var supportMultipleDateFormats: JSONDecoder.DateDecodingStrategy {
         return JSONDecoder.DateDecodingStrategy.custom({ (decoder) -> Date in
             let container = try decoder.singleValueContainer()
@@ -45,7 +45,7 @@ extension JSONDecoder.DateDecodingStrategy {
                     debugDescription: "Cannot decode date string \(dateStr)"
                 )
             }
-            
+
             return calculatedDate
         })
     }

--- a/WordPressKit/Jetpack Scan/JetpackScanThreat.swift
+++ b/WordPressKit/Jetpack Scan/JetpackScanThreat.swift
@@ -110,7 +110,7 @@ public struct JetpackScanThreat: Decodable {
         // context attr was present or not
         if let contextDict = try? container.decodeIfPresent([String: Any].self, forKey: .context) {
             context = JetpackThreatContext(with: contextDict)
-        } else if ((try container.decodeIfPresent(String.self, forKey: .context)) != nil) {
+        } else if (try container.decodeIfPresent(String.self, forKey: .context)) != nil {
             context = JetpackThreatContext.emptyObject()
         } else {
             context = nil
@@ -189,7 +189,7 @@ public struct JetpackThreatContext {
         self.lines = lines
     }
 
-    public init?(with dict: [String: Any]){
+    public init?(with dict: [String: Any]) {
         guard let marksDict = dict["marks"] as? [String: Any] else {
             return nil
         }
@@ -222,7 +222,6 @@ public struct JetpackThreatContext {
         // Since the dictionary keys are unsorted, resort by line number
         self.lines =  lines.sorted { $0.lineNumber < $1.lineNumber }
     }
-
 
     /// Parses the marks dictionary and converts them to an array of NSRange's
     private static func highlights(with dict: [String: Any], for key: String) -> [NSRange]? {

--- a/WordPressKit/Jetpack Scan/JetpackThreatFixStatus.swift
+++ b/WordPressKit/Jetpack Scan/JetpackThreatFixStatus.swift
@@ -64,9 +64,9 @@ public struct JetpackThreatFixStatus {
     public let threatId: Int
     public let status: ThreatFixStatus
 
-    public var threat: JetpackScanThreat? = nil
+    public var threat: JetpackScanThreat?
 
-    public init(with threatId: Int, status: String){
+    public init(with threatId: Int, status: String) {
         self.threatId = threatId
         self.status = ThreatFixStatus(rawValue: status)
     }

--- a/WordPressKit/JetpackBackup.swift
+++ b/WordPressKit/JetpackBackup.swift
@@ -1,21 +1,21 @@
 import Foundation
 
 public struct JetpackBackup: Decodable {
-    
+
     // Common
     public let backupPoint: Date
     public let downloadID: Int
     public let rewindID: String
     public let startedAt: Date
-    
+
     // Prepare backup
     public let progress: Int?
-    
+
     // Get backup status
     public let downloadCount: Int?
     public let url: String?
     public let validUntil: Date?
-    
+
     private enum CodingKeys: String, CodingKey {
         case backupPoint
         case downloadID = "downloadId"

--- a/WordPressKit/JetpackBackupServiceRemote.swift
+++ b/WordPressKit/JetpackBackupServiceRemote.swift
@@ -3,7 +3,7 @@ import WordPressShared
 import CocoaLumberjack
 
 open class JetpackBackupServiceRemote: ServiceRemoteWordPressComREST {
-    
+
     /// Prepare a downloadable backup snapshot for a site.
     ///
     /// - Parameters:
@@ -87,9 +87,9 @@ open class JetpackBackupServiceRemote: ServiceRemoteWordPressComREST {
                               failure: @escaping (Error) -> Void) {
         let path = backupPath(for: siteID, with: "\(downloadID)")
 
-        let parameters = ["dismissed": true] as [String : AnyObject]
+        let parameters = ["dismissed": true] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { response, _ in
+        wordPressComRestApi.POST(path, parameters: parameters, success: { _, _ in
             success()
         }, failure: { error, _ in
             failure(error)

--- a/WordPressKit/JetpackCapabilitiesServiceRemote.swift
+++ b/WordPressKit/JetpackCapabilitiesServiceRemote.swift
@@ -27,7 +27,7 @@ open class JetpackCapabilitiesServiceRemote: ServiceRemoteWordPressComREST {
                                             }
 
                                             dispatchGroup.leave()
-                                         }, failure: { error, _ in
+                                         }, failure: { _, _ in
                                             dispatchGroup.leave()
                                          })
             }

--- a/WordPressKit/JetpackRestoreTypes.swift
+++ b/WordPressKit/JetpackRestoreTypes.swift
@@ -7,7 +7,7 @@ public struct JetpackRestoreTypes {
     public var sqls: Bool
     public var roots: Bool
     public var contents: Bool
-    
+
     public init(themes: Bool = true,
                 plugins: Bool = true ,
                 uploads: Bool = true,
@@ -21,7 +21,7 @@ public struct JetpackRestoreTypes {
         self.roots = roots
         self.contents = contents
     }
-    
+
     func toDictionary() -> [String: AnyObject] {
         return [
             "themes": themes as AnyObject,

--- a/WordPressKit/JetpackScanServiceRemote.swift
+++ b/WordPressKit/JetpackScanServiceRemote.swift
@@ -52,7 +52,6 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 
-
     // MARK: - Threats
     public enum ThreatError: Swift.Error {
         case invalidResponse
@@ -84,7 +83,6 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 
-
     /// Begins the fix process for a single threat
     public func fixThreat(_ threat: JetpackScanThreat, siteID: Int, success: @escaping(JetpackThreatFixStatus) -> Void, failure: @escaping(Error) -> Void) {
         fixThreats([threat], siteID: siteID, success: { response in
@@ -98,13 +96,13 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
             failure(error)
         })
     }
-    
+
     /// Begins the ignore process for a single threat
     public func ignoreThreat(_ threat: JetpackScanThreat, siteID: Int, success: @escaping () -> Void, failure: @escaping(Error) -> Void) {
         let path = self.path(forEndpoint: "sites/\(siteID)/alerts/\(threat.id)", withVersion: ._2_0)
         let parameters = ["ignore": true] as [String: AnyObject]
-        
-        wordPressComRestApi.POST(path, parameters: parameters, success: { (response, _) in
+
+        wordPressComRestApi.POST(path, parameters: parameters, success: { (_, _) in
             success()
         }, failure: { (error, _) in
             failure(error)

--- a/WordPressKit/JetpackServiceRemote.swift
+++ b/WordPressKit/JetpackServiceRemote.swift
@@ -49,14 +49,14 @@ public class JetpackServiceRemote: ServiceRemoteWordPressComREST {
         let parameters = ["url": url.absoluteString as AnyObject]
         wordPressComRestApi.GET(path,
                                 parameters: parameters,
-                                success: { [weak self] (response: AnyObject, httpResponse: HTTPURLResponse?) in
+                                success: { [weak self] (response: AnyObject, _: HTTPURLResponse?) in
                                     do {
                                         let hasJetpack = try self?.hasJetpackMapping(object: response)
                                         success(hasJetpack ?? false)
                                     } catch {
                                         failure(error)
                                     }
-        }) { (error: NSError, httpResponse: HTTPURLResponse?) in
+        }) { (error: NSError, _: HTTPURLResponse?) in
             failure(error)
         }
     }
@@ -75,15 +75,15 @@ public class JetpackServiceRemote: ServiceRemoteWordPressComREST {
                           "password": password]
 
         wordPressComRestApi.POST(requestUrl,
-                                 parameters: parameters as [String : AnyObject],
-                                 success: { (response: AnyObject, httpResponse: HTTPURLResponse?) in
+                                 parameters: parameters as [String: AnyObject],
+                                 success: { (response: AnyObject, _: HTTPURLResponse?) in
                                     if let response = response as? [String: Bool],
                                         let success = response[Constants.status] {
                                         completion(success, nil)
                                     } else {
                                         completion(false, JetpackInstallError(type: .installResponseError))
                                     }
-        }) { (error: NSError, httpResponse: HTTPURLResponse?) in
+        }) { (error: NSError, _: HTTPURLResponse?) in
             let key = error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
             let jetpackError = JetpackInstallError(title: error.localizedDescription,
                                                    code: error.code,

--- a/WordPressKit/KeyringConnection.swift
+++ b/WordPressKit/KeyringConnection.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// KeyringConnection represents a keyring connected to a particular external service.
 /// We only rarely need keyring data and we don't really need to persist it. For these
 /// reasons KeyringConnection is treated like a model, even though it is not an NSManagedObject,
@@ -9,7 +8,7 @@ import Foundation
 open class KeyringConnection: NSObject {
     @objc open var additionalExternalUsers = [KeyringConnectionExternalUser]()
     @objc open var dateIssued = Date()
-    @objc open var dateExpires: Date? = nil
+    @objc open var dateExpires: Date?
     @objc open var externalID = "" // Some services uses strings for their IDs
     @objc open var externalName = ""
     @objc open var externalDisplay = ""

--- a/WordPressKit/KeyringConnectionExternalUser.swift
+++ b/WordPressKit/KeyringConnectionExternalUser.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// KeyringConnectionExternalUser represents an additional user account on the
 /// external service that could be used other than the default account.
 ///

--- a/WordPressKit/NotificationSettingsServiceRemote.swift
+++ b/WordPressKit/NotificationSettingsServiceRemote.swift
@@ -14,7 +14,6 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
         super.init(wordPressComRestApi: wordPressComRestApi)
     }
 
-
     /// Retrieves all of the Notification Settings
     ///
     /// - Parameters:
@@ -28,15 +27,14 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
 
         wordPressComRestApi.GET(requestUrl,
             parameters: nil,
-            success: { (response: AnyObject, httpResponse: HTTPURLResponse?) -> Void in
+            success: { (response: AnyObject, _: HTTPURLResponse?) -> Void in
                 let settings = RemoteNotificationSettings.fromDictionary(response as? NSDictionary)
                 success?(settings)
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) -> Void in
+            failure: { (error: NSError, _: HTTPURLResponse?) -> Void in
                 failure?(error)
             })
     }
-
 
     /// Updates the specified Notification Settings
     ///
@@ -45,7 +43,7 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional closure to be called on success.
     ///     - failure: Optional closure to be called on failure.
     ///
-    @objc open func updateSettings(_ settings: [String: AnyObject], success: (() -> ())?, failure: ((NSError?) -> Void)?) {
+    @objc open func updateSettings(_ settings: [String: AnyObject], success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let path = String(format: "me/notifications/settings/")
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 
@@ -53,14 +51,13 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
 
         wordPressComRestApi.POST(requestUrl,
             parameters: parameters,
-            success: { (response: AnyObject, httpResponse: HTTPURLResponse?) -> Void in
+            success: { (_: AnyObject, _: HTTPURLResponse?) -> Void in
                 success?()
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) -> Void in
+            failure: { (error: NSError, _: HTTPURLResponse?) -> Void in
                 failure?(error)
             })
     }
-
 
     /// Registers a given Apple Push Token in the WordPress.com Backend.
     ///
@@ -70,7 +67,7 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional closure to be called on success.
     ///     - failure: Optional closure to be called on failure.
     ///
-    @objc open func registerDeviceForPushNotifications(_ token: String, pushNotificationAppId: String, success: ((_ deviceId: String) -> ())?, failure: ((NSError) -> Void)?) {
+    @objc open func registerDeviceForPushNotifications(_ token: String, pushNotificationAppId: String, success: ((_ deviceId: String) -> Void)?, failure: ((NSError) -> Void)?) {
         let endpoint = "devices/new"
         let requestUrl = path(forEndpoint: endpoint, withVersion: ._1_1)
 
@@ -87,8 +84,8 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
         ]
 
         wordPressComRestApi.POST(requestUrl,
-            parameters: parameters as [String : AnyObject]?,
-            success: { (response: AnyObject, httpResponse: HTTPURLResponse?) -> Void in
+            parameters: parameters as [String: AnyObject]?,
+            success: { (response: AnyObject, _: HTTPURLResponse?) -> Void in
                 if let responseDict = response as? NSDictionary,
                     let rawDeviceId = responseDict.object(forKey: "ID") {
                     // Failsafe: Make sure deviceId is always a string
@@ -101,11 +98,10 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
                     failure?(outerError)
                 }
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) -> Void in
+            failure: { (error: NSError, _: HTTPURLResponse?) -> Void in
                 failure?(error)
             })
     }
-
 
     /// Unregisters a given DeviceID for Push Notifications
     ///
@@ -114,21 +110,19 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
     ///     - success: Optional closure to be called on success.
     ///     - failure: Optional closure to be called on failure.
     ///
-    @objc open func unregisterDeviceForPushNotifications(_ deviceId: String, success: (() -> ())?, failure: ((NSError) -> Void)?) {
+    @objc open func unregisterDeviceForPushNotifications(_ deviceId: String, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
         let endpoint = String(format: "devices/%@/delete", deviceId)
         let requestUrl = path(forEndpoint: endpoint, withVersion: ._1_1)
 
         wordPressComRestApi.POST(requestUrl,
             parameters: nil,
-            success: { (response: AnyObject!, httpResponse: HTTPURLResponse?) -> Void in
+            success: { (_: AnyObject!, _: HTTPURLResponse?) -> Void in
                 success?()
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) -> Void in
+            failure: { (error: NSError, _: HTTPURLResponse?) -> Void in
                 failure?(error)
             })
     }
-
-
 
     /// Describes all of the possible errors that might be generated by this class.
     ///

--- a/WordPressKit/NotificationSyncServiceRemote.swift
+++ b/WordPressKit/NotificationSyncServiceRemote.swift
@@ -7,14 +7,11 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     //
     private let defaultPageSize = 100
 
-
     // MARK: - Errors
     //
     public enum SyncError: Error {
         case failed
     }
-
-
 
     /// Retrieves latest Notifications (OR collection of Notifications, whenever noteIds is present)
     ///
@@ -32,7 +29,6 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
         }
     }
 
-
     /// Retrieves the Notification Hashes for the specified pageSize (OR collection of NoteID's, when present)
     ///
     /// - Parameters:
@@ -49,7 +45,6 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
             completion(error, notes)
         }
     }
-
 
     /// Updates a Notification's Read Status as specified.
     ///
@@ -69,7 +64,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
             "counts": ["\(notificationID)": value]
         ]
 
-        wordPressComRestApi.POST(requestUrl, parameters: parameters as [String : AnyObject]?, success: { (response, _)  in
+        wordPressComRestApi.POST(requestUrl, parameters: parameters as [String: AnyObject]?, success: { (response, _)  in
             let error = self.errorFromResponse(response)
             completion(error)
 
@@ -77,7 +72,6 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
             completion(error)
         })
     }
-
 
     /// Updates the Last Seen Notification's Timestamp.
     ///
@@ -93,7 +87,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
             "time": timestamp
         ]
 
-        wordPressComRestApi.POST(requestUrl, parameters: parameters as [String : AnyObject]?, success: { (response, _)  in
+        wordPressComRestApi.POST(requestUrl, parameters: parameters as [String: AnyObject]?, success: { (response, _)  in
             let error = self.errorFromResponse(response)
             completion(error)
 
@@ -102,8 +96,6 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 }
-
-
 
 // MARK: - Private Methods
 //
@@ -124,7 +116,6 @@ private extension NotificationSyncServiceRemote {
 
         return SyncError.failed
     }
-
 
     /// Retrieves the Notification for the specified pageSize (OR collection of NoteID's, when present).
     /// Note that only the specified fields will be retrieved.

--- a/WordPressKit/ObjectValidation.swift
+++ b/WordPressKit/ObjectValidation.swift
@@ -1,23 +1,21 @@
 import Foundation
 
-
 @objc public extension NSObject {
-    
+
     /// Validate if a class is a valid NSObject and if it's not nil
     ///
     /// - Returns: Bool value
-    @objc func wp_isValidObject() -> Bool {
+    func wp_isValidObject() -> Bool {
         return !(self is NSNull)
     }
 }
 
-
 @objc public extension NSString {
-    
+
     ///  Validate if a class is a valid NSString and if it's not nil
     ///
     /// - Returns: Bool value
-    @objc func wp_isValidString() -> Bool {
+    func wp_isValidString() -> Bool {
         return wp_isValidObject() && self != ""
     }
 }

--- a/WordPressKit/PeopleServiceRemote.swift
+++ b/WordPressKit/PeopleServiceRemote.swift
@@ -14,7 +14,6 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         case unknownError
     }
 
-
     /// Retrieves the collection of users associated to a given Site.
     ///
     /// - Parameters:
@@ -38,10 +37,10 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "offset": offset as AnyObject,
             "order_by": "display_name" as AnyObject,
             "order": "ASC" as AnyObject,
-            "fields": "ID, nice_name, first_name, last_name, name, avatar_URL, roles, is_super_admin, linked_user_ID" as AnyObject,
+            "fields": "ID, nice_name, first_name, last_name, name, avatar_URL, roles, is_super_admin, linked_user_ID" as AnyObject
         ]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                 let users = response["users"] as? [[String: AnyObject]],
                 let people = try? self.peopleFromResponse(users, siteID: siteID, type: User.self) else {
@@ -52,7 +51,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             let hasMore = self.peopleFoundFromResponse(response) > (offset + people.count)
             success(people, hasMore)
 
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
@@ -72,7 +71,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
                       offset: Int = 0,
                       count: Int,
                       success: @escaping ((_ followers: [Follower], _ hasMore: Bool) -> Void),
-                      failure: @escaping (Error) -> ()) {
+                      failure: @escaping (Error) -> Void) {
         let endpoint = "sites/\(siteID)/follows"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let pageNumber = (offset / count + 1)
@@ -82,7 +81,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "fields": "ID, nice_name, first_name, last_name, name, avatar_URL" as AnyObject
         ]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                 let followers = response["users"] as? [[String: AnyObject]],
                 let people = try? self.peopleFromResponse(followers, siteID: siteID, type: Follower.self) else {
@@ -93,7 +92,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             let hasMore = self.peopleFoundFromResponse(response) > (offset + people.count)
             success(people, hasMore)
 
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
@@ -113,7 +112,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
                     offset: Int = 0,
                     count: Int,
                     success: @escaping ((_ followers: [Viewer], _ hasMore: Bool) -> Void),
-                    failure: @escaping (Error) -> ()) {
+                    failure: @escaping (Error) -> Void) {
         let endpoint = "sites/\(siteID)/viewers"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let pageNumber = (offset / count + 1)
@@ -122,7 +121,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "page": pageNumber as AnyObject
         ]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { responseObject, httpResponse in
+        wordPressComRestApi.GET(path, parameters: parameters, success: { responseObject, _ in
             guard let response = responseObject as? [String: AnyObject],
                 let viewers = response["viewers"] as? [[String: AnyObject]],
                 let people = try? self.peopleFromResponse(viewers, siteID: siteID, type: Viewer.self) else {
@@ -133,7 +132,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             let hasMore = self.peopleFoundFromResponse(response) > (offset + people.count)
             success(people, hasMore)
 
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
@@ -152,15 +151,15 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
     public func updateUserRole(_ siteID: Int,
                         userID: Int,
                         newRole: String,
-                        success: ((RemotePerson) -> ())? = nil,
-                        failure: ((Error) -> ())? = nil) {
+                        success: ((RemotePerson) -> Void)? = nil,
+                        failure: ((Error) -> Void)? = nil) {
         let endpoint = "sites/\(siteID)/users/\(userID)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = ["roles": [newRole]]
 
         wordPressComRestApi.POST(path,
-                parameters: parameters as [String : AnyObject]?,
-                success: { (responseObject, httpResponse) in
+                parameters: parameters as [String: AnyObject]?,
+                success: { (responseObject, _) in
                     guard let response = responseObject as? [String: AnyObject],
                                 let person = try? self.personFromResponse(response, siteID: siteID, type: User.self) else {
                         failure?(ResponseError.decodingFailure)
@@ -169,11 +168,10 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
 
                     success?(person)
                 },
-                failure: { (error, httpResponse) in
+                failure: { (error, _) in
                     failure?(error)
                 })
     }
-
 
     /// Deletes or removes a User from a site.
     ///
@@ -198,13 +196,12 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             parameters["reassign"] = reassignID as AnyObject?
         }
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: nil, success: { (_, _) in
             success?()
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure?(error)
         })
     }
-
 
     /// Deletes or removes a Follower from a site.
     ///
@@ -221,13 +218,12 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/followers/\(userID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: nil, success: { (_, _) in
             success?()
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure?(error)
         })
     }
-
 
     /// Deletes or removes a User from a site.
     ///
@@ -244,13 +240,12 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/viewers/\(userID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: nil, success: { (_, _) in
             success?()
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure?(error)
         })
     }
-
 
     /// Retrieves all of the Available Roles, for a given SiteID.
     ///
@@ -263,11 +258,11 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
     ///
     public func getUserRoles(_ siteID: Int,
                       success: @escaping (([RemoteRole]) -> Void),
-                      failure: ((Error) -> ())? = nil) {
+                      failure: ((Error) -> Void)? = nil) {
         let endpoint = "sites/\(siteID)/roles"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                     let roles = try? self.rolesFromResponse(response) else {
                 failure?(ResponseError.decodingFailure)
@@ -275,11 +270,10 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             }
 
             success(roles)
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure?(error)
         })
     }
-
 
     /// Validates Invitation Recipients.
     ///
@@ -303,7 +297,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "role": role
         ]
 
-        wordPressComRestApi.POST(path, parameters: parameters as [String : AnyObject]?, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
             guard let responseDict = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -316,11 +310,10 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
 
             success()
 
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
-
 
     /// Sends an Invitation to the specified recipient.
     ///
@@ -347,7 +340,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "message": message
         ]
 
-        wordPressComRestApi.POST(path, parameters: parameters as [String : AnyObject]?, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
             guard let responseDict = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -360,7 +353,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
 
             success()
 
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
@@ -383,7 +376,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "number": 100
         ] as [String: AnyObject]
 
-        wordPressComRestApi.GET(path, parameters: params, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(path, parameters: params, success: { (responseObject, _) in
             guard let responseDict = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -397,7 +390,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             }
             success(results)
 
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
@@ -415,7 +408,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/invites/links/generate"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, _) in
             guard let responseArray = responseObject as? [[String: AnyObject]] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -427,7 +420,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             }
             success(results)
 
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
 
@@ -446,17 +439,16 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/invites/links/disable"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, _) in
             let deletedKeys = responseObject as? [String] ?? [String]()
             success(deletedKeys)
 
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
 
 }
-
 
 /// Encapsulates PeopleServiceRemote Private Methods
 ///
@@ -515,16 +507,16 @@ private extension PeopleServiceRemote {
 
         let role = roles?.first ?? ""
 
-        return T(ID            : ID,
-                 username      : username,
-                 firstName     : firstName,
-                 lastName      : lastName,
-                 displayName   : displayName,
-                 role          : role,
-                 siteID        : siteID,
-                 linkedUserID  : linkedUserID,
-                 avatarURL     : avatarURL,
-                 isSuperAdmin  : isSuperAdmin)
+        return T(ID: ID,
+                 username: username,
+                 firstName: firstName,
+                 lastName: lastName,
+                 displayName: displayName,
+                 role: role,
+                 siteID: siteID,
+                 linkedUserID: linkedUserID,
+                 avatarURL: avatarURL,
+                 isSuperAdmin: isSuperAdmin)
     }
 
     /// Returns the count of persons that can be retrieved from the backend.
@@ -534,7 +526,6 @@ private extension PeopleServiceRemote {
     func peopleFoundFromResponse(_ response: [String: AnyObject]) -> Int {
         return response["found"] as? Int ?? 0
     }
-
 
     /// Parses a collection of Roles, and returns instances of the RemotePerson.Role Enum.
     ///

--- a/WordPressKit/PlanServiceRemote.swift
+++ b/WordPressKit/PlanServiceRemote.swift
@@ -16,7 +16,7 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         case noActivePlan
     }
 
-    // MARK - Endpoints
+    // MARK: - Endpoints
 
     /// Get the list of WordPress.com plans, their descriptions, and their features.
     ///
@@ -45,7 +45,6 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 
-
     /// Fetch the plan ID and name for each of the user's sites.
     /// Accepts locale as a parameter in order to override automatic localization
     /// and return non-localized results when needed.
@@ -53,7 +52,7 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
     public func getPlanDescriptionsForAllSitesForLocale(_ locale: String, success: @escaping ([Int: RemotePlanSimpleDescription]) -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "me/sites"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
-        let parameters:[String: String] = [
+        let parameters: [String: String] = [
             "fields": "ID, plan",
             "locale": locale
         ]
@@ -77,8 +76,7 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 
-
-    // MARK - Non-public methods
+    // MARK: - Non-public methods
 
     func parsePlanDescriptionsForSites(_ response: EndpointResponse) -> [Int: RemotePlanSimpleDescription] {
         var result = [Int: RemotePlanSimpleDescription]()
@@ -99,7 +97,6 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         return result
     }
 
-
     func parsePlanDescriptionForSite(_ site: EndpointResponse) -> (siteID: Int, plan: RemotePlanSimpleDescription)? {
         guard
             let siteID = site["ID"] as? Int,
@@ -118,7 +115,6 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         return (siteID, RemotePlanSimpleDescription(planID: planID, name: name))
     }
 
-
     func parseWpcomPlans(_ response: EndpointResponse) -> [RemoteWpcomPlan] {
         guard let json = response["plans"] as? [EndpointResponse] else {
             return [RemoteWpcomPlan]()
@@ -127,12 +123,10 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         return json.compactMap { parseWpcomPlan($0) }
     }
 
-
     func parseWpcomPlanProducts(_ products: [EndpointResponse]) -> String {
         let parsedResult = products.compactMap { $0["plan_id"] as? String }
         return parsedResult.joined(separator: ",")
     }
-
 
     func parseWpcomPlanGroups(_ response: EndpointResponse) -> [RemotePlanGroup] {
         guard let json = response["groups"] as? [EndpointResponse] else {
@@ -141,14 +135,12 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         return json.compactMap { parsePlanGroup($0) }
     }
 
-
     func parseWpcomPlanFeatures(_ response: EndpointResponse) -> [RemotePlanFeature] {
         guard let json = response["features"] as? [EndpointResponse] else {
             return [RemotePlanFeature]()
         }
         return json.compactMap { parsePlanFeature($0) }
     }
-
 
     func parseWpcomPlan(_ item: EndpointResponse) -> RemoteWpcomPlan? {
         guard
@@ -181,7 +173,6 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
                                      nonLocalizedShortname: nonLocalizedShortname)
     }
 
-
     func parsePlanGroup(_ item: EndpointResponse) -> RemotePlanGroup? {
         guard
             let slug = item["slug"] as? String,
@@ -190,7 +181,6 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         }
         return RemotePlanGroup(slug: slug, name: name)
     }
-
 
     func parsePlanFeature(_ item: EndpointResponse) -> RemotePlanFeature? {
         guard

--- a/WordPressKit/PlanServiceRemote_ApiVersion1_3.swift
+++ b/WordPressKit/PlanServiceRemote_ApiVersion1_3.swift
@@ -32,7 +32,7 @@ import CocoaLumberjack
             }
         )
     }
-    
+
     private static func mapPlansResponse(_ response: AnyObject) throws
         -> (activePlan: RemotePlan_ApiVersion1_3, availablePlans: [RemotePlan_ApiVersion1_3]) {
 

--- a/WordPressKit/PluginDirectoryEntry.swift
+++ b/WordPressKit/PluginDirectoryEntry.swift
@@ -184,7 +184,6 @@ extension PluginDirectoryEntry: Codable {
     }
 }
 
-        
 // Since the WPOrg API returns `author` as a HTML string (or freeform text), we need to get ugly and parse out the important bits out of it ourselves.
 // Using the built-in NSAttributedString API for it is too slow — it's required to run on main thread and it calls out to WebKit APIs,
 // making the context switches excessively expensive when trying to display a list of plugins.
@@ -227,7 +226,7 @@ internal func extractAuthor(_ author: String) -> Author {
 internal func extractHTMLText(_ text: String?) -> NSAttributedString? {
     guard Thread.isMainThread,
         let data = text?.data(using: .utf16),
-        let attributedString = try? NSAttributedString(data: data, options: [.documentType : NSAttributedString.DocumentType.html], documentAttributes: nil) else {
+        let attributedString = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil) else {
             return nil
     }
 
@@ -281,7 +280,7 @@ private final class AuthorParser: NSObject, XMLParserDelegate {
     var author = ""
     var url: URL?
 
-    func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String] = [:]) {
+    func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String: String] = [:]) {
         guard elementName == "a",
             let href = attributeDict["href"] else {
                 return

--- a/WordPressKit/PluginDirectoryFeedPage.swift
+++ b/WordPressKit/PluginDirectoryFeedPage.swift
@@ -34,7 +34,7 @@ public struct PluginDirectoryFeedPage: Decodable, Equatable {
 
         let pageNumber = try info.decode(Int.self, forKey: .page)
 
-        pageMetadata = PluginDirectoryPageMetadata(page: pageNumber, pluginSlugs: plugins.map { $0.slug} )
+        pageMetadata = PluginDirectoryPageMetadata(page: pageNumber, pluginSlugs: plugins.map { $0.slug})
     }
 
     public static func ==(lhs: PluginDirectoryFeedPage, rhs: PluginDirectoryFeedPage) -> Bool {

--- a/WordPressKit/PluginDirectoryServiceRemote.swift
+++ b/WordPressKit/PluginDirectoryServiceRemote.swift
@@ -37,7 +37,7 @@ public enum PluginDirectoryFeedType: Hashable {
             return "search:\(term)"
         }
     }
-    
+
     public func hash(into hasher: inout Hasher) {
         hasher.combine(slug)
     }
@@ -115,19 +115,18 @@ public struct PluginDirectoryFeedEndpoint: Endpoint {
 
         let request = URLRequest(url: PluginDirectoryRemoteConstants.feedEndpoint)
         let encodedRequest = try URLEncoding.default.encode(request, with: parameters)
-        
+
         return encodedRequest
     }
-    
+
     public func parseResponse(data: Data) throws -> PluginDirectoryFeedPage {
         return try PluginDirectoryRemoteConstants.jsonDecoder.decode(PluginDirectoryFeedPage.self, from: data)
     }
-    
+
     public func validate(request: URLRequest?, response: HTTPURLResponse, data: Data?) throws {
         if response.statusCode != 200 { throw Error.genericError}
     }
 }
-
 
 public struct PluginDirectoryServiceRemote {
 

--- a/WordPressKit/PluginServiceRemote.swift
+++ b/WordPressKit/PluginServiceRemote.swift
@@ -11,7 +11,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
     public func getFeaturedPlugins(success: @escaping ([PluginDirectoryEntry]) -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "wpcom/v2/plugins/featured"
 
-        wordPressComRestApi.GET(endpoint, parameters: nil, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(endpoint, parameters: nil, success: { (responseObject, _) in
             guard let response = responseObject as? [[String: AnyObject]] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -22,7 +22,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
             } catch {
                 failure(ResponseError.decodingFailure)
             }
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             DDLogError("[PluginServiceRemoteError] Error fetching featured plugins: \(error)")
             failure(error)
         })
@@ -33,7 +33,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_2)
         let parameters = [String: AnyObject]()
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, httpResponse) in
+        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -45,7 +45,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
             } catch {
                 failure(self.errorFromResponse(response))
             }
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             DDLogError("[PluginServiceRemoteError] Error fetching site plugins: \(error)")
             failure(error)
         })
@@ -123,7 +123,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(
             path,
             parameters: nil,
-            success: { responseObject,_  in
+            success: { responseObject, _  in
                 guard let response = responseObject as? [String: AnyObject] else {
                     failure(ResponseError.decodingFailure)
                     return
@@ -151,7 +151,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(
             path,
             parameters: nil,
-            success: { _,_  in
+            success: { _, _  in
                 success()
             }, failure: { (error, _) in
                 DDLogError("[PluginServiceRemoteError] Error removing plugin: \(error)")
@@ -170,7 +170,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.POST(
             path,
             parameters: parameters,
-            success: { _,_  in
+            success: { _, _  in
                 success()
             },
             failure: { (error, _) in
@@ -209,7 +209,6 @@ internal extension PluginServiceRemote {
             let author = response["author"] as? String else {
                 throw ResponseError.decodingFailure
         }
-
 
         let version = (response["version"] as? String)?.nonEmptyString()
         let url = (response["plugin_url"] as? String).flatMap(URL.init(string:))

--- a/WordPressKit/PluginState.swift
+++ b/WordPressKit/PluginState.swift
@@ -15,7 +15,7 @@ public struct PluginState: Equatable, Codable {
             }
         }
 
-        private enum CodingKeys: String, CodingKey  {
+        private enum CodingKeys: String, CodingKey {
             case updated
             case available
             case updating
@@ -82,7 +82,7 @@ public struct PluginState: Equatable, Codable {
             && lhs.autoupdate == rhs.autoupdate
             && lhs.automanaged == rhs.automanaged
             && lhs.url == rhs.url
-    }    
+    }
 }
 
 public extension PluginState {

--- a/WordPressKit/PostServiceRemoteREST+Revisions.swift
+++ b/WordPressKit/PostServiceRemoteREST+Revisions.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 public extension PostServiceRemoteREST {
     func getPostRevisions(for siteId: Int,
                                  postId: Int,
@@ -30,14 +29,12 @@ public extension PostServiceRemoteREST {
     }
 }
 
-
 private extension PostServiceRemoteREST {
     private typealias JSONRevision = [String: Any]
 
     private struct RemoteDiffs: Codable {
         var diffs: [RemoteDiff]
     }
-
 
     private func map(from data: Data, _ completion: @escaping ([RemoteRevision]?, Error?) -> Void) {
         do {

--- a/WordPressKit/PushAuthenticationServiceRemote.swift
+++ b/WordPressKit/PushAuthenticationServiceRemote.swift
@@ -11,7 +11,7 @@ import Foundation
     ///     - success: Closure to be executed on success. Can be nil.
     ///     - failure: Closure to be executed on failure. Can be nil.
     ///
-    @objc open func authorizeLogin(_ token: String, success: (() -> ())?, failure: (() -> ())?) {
+    @objc open func authorizeLogin(_ token: String, success: (() -> Void)?, failure: (() -> Void)?) {
         let path = "me/two-step/push-authentication"
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 
@@ -21,10 +21,10 @@ import Foundation
         ]
 
         wordPressComRestApi.POST(requestUrl, parameters: parameters as [String: AnyObject],
-                                 success: { (response: AnyObject, httpResponse: HTTPURLResponse?) -> Void in
+                                 success: { (_: AnyObject, _: HTTPURLResponse?) -> Void in
                                     success?()
                                  },
-                                 failure: { (error: NSError, httpResponse: HTTPURLResponse?) -> Void in
+                                 failure: { (_: NSError, _: HTTPURLResponse?) -> Void in
                                     failure?()
                                  })
     }

--- a/WordPressKit/ReaderFeed.swift
+++ b/WordPressKit/ReaderFeed.swift
@@ -49,8 +49,8 @@ public struct ReaderFeed: Decodable {
         feedID = try? rootContainer.decode(String.self, forKey: .feedID)
         blogID = try? rootContainer.decode(String.self, forKey: .blogID)
 
-        var feedDescription: String? = nil
-        var blavatarURL: URL? = nil
+        var feedDescription: String?
+        var blavatarURL: URL?
 
         do {
             let metaContainer = try rootContainer.nestedContainer(keyedBy: MetaKeys.self, forKey: .meta)

--- a/WordPressKit/ReaderPostServiceRemote+Cards.swift
+++ b/WordPressKit/ReaderPostServiceRemote+Cards.swift
@@ -49,7 +49,7 @@ extension ReaderPostServiceRemote {
                                     }
         }, failure: { error, _ in
             DDLogError("Error fetching reader cards: \(error)")
-            
+
             failure(error)
         })
     }

--- a/WordPressKit/ReaderPostServiceRemote+V2.swift
+++ b/WordPressKit/ReaderPostServiceRemote+V2.swift
@@ -58,13 +58,13 @@ extension ReaderPostServiceRemote {
                                  success: @escaping (() -> Void),
                                  failure: @escaping ((Error) -> Void)) {
         let endpoint = seen ? SeenEndpoints.feedSeen : SeenEndpoints.feedUnseen
-        
+
         let params = [
             "feed_id": feedID,
             "feed_item_ids": [feedItemID],
             "source": "reader-ios"
         ] as [String: AnyObject]
-        
+
         updateSeenStatus(endpoint: endpoint, params: params, success: success, failure: failure)
     }
 
@@ -88,7 +88,7 @@ extension ReaderPostServiceRemote {
             "post_ids": [postID],
             "source": "reader-ios"
         ] as [String: AnyObject]
-        
+
         updateSeenStatus(endpoint: endpoint, params: params, success: success, failure: failure)
     }
 
@@ -96,10 +96,10 @@ extension ReaderPostServiceRemote {
                                   params: [String: AnyObject],
                                   success: @escaping (() -> Void),
                                   failure: @escaping ((Error) -> Void)) {
-        
+
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
-        
-        wordPressComRestApi.POST(path, parameters: params, success: { (responseObject, httpResponse) in
+
+        wordPressComRestApi.POST(path, parameters: params, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                   let status = response["status"] as? Bool,
                   status == true else {
@@ -107,11 +107,11 @@ extension ReaderPostServiceRemote {
                 return
             }
             success()
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }
-    
+
     private struct SeenEndpoints {
         // Creates a new `seen` entry (i.e. mark as seen)
         static let feedSeen = "seen-posts/seen/new"

--- a/WordPressKit/ReaderServiceDeliveryFrequency.swift
+++ b/WordPressKit/ReaderServiceDeliveryFrequency.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// Delivery frequency values for email notifications
 ///
 /// - daily: daily frequency

--- a/WordPressKit/ReaderTopicServiceError.swift
+++ b/WordPressKit/ReaderTopicServiceError.swift
@@ -1,21 +1,20 @@
 import Foundation
 
-
 public enum ReaderTopicServiceError: Error {
     case invalidId
     case topicNotfound(id: Int)
     case remoteResponse(message: String?, url: String)
-    
+
     public var description: String {
         switch self {
         case .invalidId:
             return "Invalid id: an id must be valid or not nil"
-            
+
         case .topicNotfound(let id):
             let localizedString = NSLocalizedString("Topic not found for id:",
                                                     comment: "Used when a Reader Topic is not found for a specific id")
             return localizedString + " \(id)"
-            
+
         case .remoteResponse(let message, let url):
             let localizedString = NSLocalizedString("An error occurred while processing your request: ",
                                                     comment: "Used when a remote response doesn't have a specific message for a specific request")

--- a/WordPressKit/ReaderTopicServiceRemote+Interests.swift
+++ b/WordPressKit/ReaderTopicServiceRemote+Interests.swift
@@ -36,7 +36,7 @@ extension ReaderTopicServiceRemote {
         let path = self.path(forEndpoint: "read/tags/mine/new", withVersion: ._1_2)
         let parameters = ["tags": withSlugs] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { response, _ in
+        wordPressComRestApi.POST(path, parameters: parameters, success: { _, _ in
             success()
         }) { error, _ in
             DDLogError("Error fetching reader interests: \(error)")

--- a/WordPressKit/ReaderTopicServiceRemote+Subscription.swift
+++ b/WordPressKit/ReaderTopicServiceRemote+Subscription.swift
@@ -1,11 +1,10 @@
 import Foundation
 
-
 extension ReaderTopicServiceRemote {
     private struct Delivery {
         static let frequency = "delivery_frequency"
     }
-    
+
     /// Subscribe action for site notifications
     ///
     /// - Parameters:
@@ -15,7 +14,7 @@ extension ReaderTopicServiceRemote {
     @nonobjc public func subscribeSiteNotifications(with siteId: Int, _ success: @escaping () -> Void, _ failure: @escaping (ReaderTopicServiceError?) -> Void) {
         POST(with: .notifications(siteId: siteId, action: .subscribe), success: success, failure: failure)
     }
-    
+
     /// Unsubscribe action for site notifications
     ///
     /// - Parameters:
@@ -25,7 +24,7 @@ extension ReaderTopicServiceRemote {
     @nonobjc public func unsubscribeSiteNotifications(with siteId: Int, _ success: @escaping () -> Void, _ failure: @escaping (ReaderTopicServiceError?) -> Void) {
         POST(with: .notifications(siteId: siteId, action: .unsubscribe), success: success, failure: failure)
     }
-    
+
     /// Subscribe action for site comments
     ///
     /// - Parameters:
@@ -35,7 +34,7 @@ extension ReaderTopicServiceRemote {
     @nonobjc public func subscribeSiteComments(with siteId: Int, _ success: @escaping () -> Void, _ failure: @escaping (ReaderTopicServiceError?) -> Void) {
         POST(with: .comments(siteId: siteId, action: .subscribe), success: success, failure: failure)
     }
-    
+
     /// Unubscribe action for site comments
     ///
     /// - Parameters:
@@ -55,7 +54,7 @@ extension ReaderTopicServiceRemote {
     @nonobjc public func subscribePostsEmail(with siteId: Int, _ success: @escaping () -> Void, _ failure: @escaping (ReaderTopicServiceError?) -> Void) {
         POST(with: .postsEmail(siteId: siteId, action: .subscribe), success: success, failure: failure)
     }
-    
+
     /// Unsubscribe action for post emails
     ///
     /// - Parameters:
@@ -65,7 +64,7 @@ extension ReaderTopicServiceRemote {
     @nonobjc public func unsubscribePostsEmail(with siteId: Int, _ success: @escaping () -> Void, _ failure: @escaping (ReaderTopicServiceError?) -> Void) {
         POST(with: .postsEmail(siteId: siteId, action: .unsubscribe), success: success, failure: failure)
     }
-    
+
     /// Update action for posts email
     ///
     /// - Parameters:
@@ -77,15 +76,14 @@ extension ReaderTopicServiceRemote {
         let parameters = [Delivery.frequency: NSString(string: frequency.rawValue)]
         POST(with: .postsEmail(siteId: siteId, action: .update), parameters: parameters, success: success, failure: failure)
     }
-    
-    
+
     // MARK: Private methods
-    
+
     private func POST(with request: ReaderTopicServiceSubscriptionsRequest, parameters: [String: AnyObject]? = nil, success: @escaping () -> Void, failure: @escaping (ReaderTopicServiceError?) -> Void) {
         let urlRequest = path(forEndpoint: request.path, withVersion: request.apiVersion)
-        
+
         DDLogInfo("URL: \(urlRequest)")
-        
+
         wordPressComRestApi.POST(urlRequest, parameters: parameters, success: { (_, response) in
             DDLogInfo("Success \(response?.url?.absoluteString ?? "unknown url")")
             success()

--- a/WordPressKit/RemoteBlogJetpackModulesSettings.swift
+++ b/WordPressKit/RemoteBlogJetpackModulesSettings.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// This struct encapsulates the *remote* Jetpack modules settings available for a Blog entity
 ///
 public struct RemoteBlogJetpackModulesSettings {

--- a/WordPressKit/RemoteBlogJetpackSettings.swift
+++ b/WordPressKit/RemoteBlogJetpackSettings.swift
@@ -7,7 +7,7 @@ public struct RemoteBlogJetpackSettings {
     /// Indicates whether the Jetpack site's monitor is on or off
     ///
     public let monitorEnabled: Bool
-    
+
     /// Indicates whether Jetpack will block malicious login attemps
     ///
     public let blockMaliciousLoginAttempts: Bool

--- a/WordPressKit/RemoteBlogSettings.swift
+++ b/WordPressKit/RemoteBlogSettings.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// This class encapsulates all of the *remote* settings available for a Blog entity
 ///
 public class RemoteBlogSettings: NSObject {
@@ -59,7 +58,6 @@ public class RemoteBlogSettings: NSObject {
     /// Numbers of posts per page
     ///
     @objc public var postsPerPage: NSNumber?
-
 
     // MARK: - Discussion
 
@@ -134,8 +132,6 @@ public class RemoteBlogSettings: NSObject {
     ///
     @objc public var pingbackOutboundEnabled: NSNumber?
 
-
-
     // MARK: - Related Posts
 
     /// When set to true, Related Posts will be allowed.
@@ -190,8 +186,6 @@ public class RemoteBlogSettings: NSObject {
     ///
     @objc public var sharingDisabledReblogs: NSNumber?
 
-
-
     // MARK: - Helpers
 
     /// Computed property, meant to help conversion from Remote / String-Based values, into their Integer counterparts
@@ -204,8 +198,6 @@ public class RemoteBlogSettings: NSObject {
             return commentsSortOrder == RemoteBlogSettings.AscendingStringValue
         }
     }
-
-
 
     // MARK: - Private
 

--- a/WordPressKit/RemoteDiff.swift
+++ b/WordPressKit/RemoteDiff.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// RemoteDiff model
 public struct RemoteDiff: Codable {
     /// Revision id from the content has been changed
@@ -19,8 +18,7 @@ public struct RemoteDiff: Codable {
         case values = "diff"
     }
 
-
-    // MARK - Decode protocol
+    // MARK: - Decode protocol
 
     public init(from decoder: Decoder) throws {
         let data = try decoder.container(keyedBy: CodingKeys.self)
@@ -30,7 +28,6 @@ public struct RemoteDiff: Codable {
         values = try data.decode(RemoteDiffValues.self, forKey: .values)
     }
 }
-
 
 /// RemoteDiffValues model
 public struct RemoteDiffValues: Codable {
@@ -51,7 +48,6 @@ public struct RemoteDiffValues: Codable {
     }
 }
 
-
 /// RemoteDiffTotals model
 public struct RemoteDiffTotals: Codable {
     /// Total of additional operations
@@ -66,8 +62,7 @@ public struct RemoteDiffTotals: Codable {
         case totalDeletions = "del"
     }
 
-
-    // MARK - Decode protocol
+    // MARK: - Decode protocol
 
     public init(from decoder: Decoder) throws {
         let data = try decoder.container(keyedBy: CodingKeys.self)
@@ -76,7 +71,6 @@ public struct RemoteDiffTotals: Codable {
         totalDeletions = (try? data.decode(Int.self, forKey: .totalDeletions)) ?? 0
     }
 }
-
 
 /// RemoteDiffOperation enumeration
 ///
@@ -90,7 +84,6 @@ public enum RemoteDiffOperation: String, Codable {
     case del
     case unknown
 }
-
 
 /// DiffValue
 public struct RemoteDiffValue: Codable {
@@ -106,8 +99,7 @@ public struct RemoteDiffValue: Codable {
         case value
     }
 
-
-    // MARK - Decode protocol
+    // MARK: - Decode protocol
 
     public init(from decoder: Decoder) throws {
         let data = try decoder.container(keyedBy: CodingKeys.self)

--- a/WordPressKit/RemoteDomain.swift
+++ b/WordPressKit/RemoteDomain.swift
@@ -5,7 +5,7 @@ import Foundation
     case mapped
     case siteRedirect
     case wpCom
-    
+
     public var description: String {
         switch self {
         case .registered:

--- a/WordPressKit/RemoteHomepageType.swift
+++ b/WordPressKit/RemoteHomepageType.swift
@@ -10,4 +10,3 @@ public enum RemoteHomepageType {
         return self == .page
     }
 }
-

--- a/WordPressKit/RemoteNotification.swift
+++ b/WordPressKit/RemoteNotification.swift
@@ -56,7 +56,6 @@ public struct RemoteNotification {
     ///
     public let meta: [String: AnyObject]?
 
-
     /// Designed Initializer
     ///
     public init?(document: [String: AnyObject]) {

--- a/WordPressKit/RemoteNotificationSettings.swift
+++ b/WordPressKit/RemoteNotificationSettings.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// The goal of this class is to parse Notification Settings data from the backend, and structure it in a
 /// meaningful way. Notification Settings come in three different flavors:
 ///
@@ -20,8 +19,6 @@ open class RemoteNotificationSettings {
     ///
     public let streams: [Stream]
 
-
-
     /// Represents a communication channel that may post notifications to the user.
     ///
     public enum Channel: Equatable {
@@ -30,13 +27,11 @@ open class RemoteNotificationSettings {
         case wordPressCom
     }
 
-
     /// Contains the Notification Settings for a specific communications stream.
     ///
     open class Stream {
         open var kind: Kind
-        open var preferences: [String : Bool]?
-
+        open var preferences: [String: Bool]?
 
         /// Enumerates all of the possible Stream Kinds
         ///
@@ -47,7 +42,6 @@ open class RemoteNotificationSettings {
 
             static let allValues = [ Timeline, Email, Device ]
         }
-
 
         /// Private Designated Initializer
         ///
@@ -60,14 +54,13 @@ open class RemoteNotificationSettings {
             self.preferences    = filterNonBooleanEntries(preferences)
         }
 
-
         /// Helper method that will filter out non boolean entries, and return a native Swift collection.
         ///
         /// - Parameter dictionary: NextStep Dictionary containing raw values
         ///
         /// - Returns: A native Swift dictionary, containing only the Boolean entries
         ///
-        private func filterNonBooleanEntries(_ dictionary: NSDictionary?) -> [String : Bool] {
+        private func filterNonBooleanEntries(_ dictionary: NSDictionary?) -> [String: Bool] {
             var filtered = [String: Bool]()
             if dictionary == nil {
                 return filtered
@@ -86,7 +79,6 @@ open class RemoteNotificationSettings {
 
             return filtered
         }
-
 
         /// Parser method that will convert a raw dictionary of stream settings into Swift Native objects.
         ///
@@ -107,7 +99,6 @@ open class RemoteNotificationSettings {
         }
     }
 
-
     /// Private Designated Initializer
     ///
     /// - Parameters:
@@ -119,7 +110,6 @@ open class RemoteNotificationSettings {
         self.streams = Stream.fromDictionary(settings)
     }
 
-
     /// Private Designated Initializer
     ///
     /// - Parameter wpcomSettings: Dictionary containing the collection of WordPress.com Settings
@@ -130,7 +120,6 @@ open class RemoteNotificationSettings {
         self.streams = [ Stream(kind: .Email, preferences: wpcomSettings) ]
     }
 
-
     /// Private Convenience Initializer
     ///
     /// - Parameter blogSettings: Dictionary containing the collection of settings for a single blog
@@ -140,7 +129,6 @@ open class RemoteNotificationSettings {
         self.init(channel: Channel.blog(blogId: blogId), settings: blogSettings)
     }
 
-
     /// Private Convenience Initializer
     ///
     /// - Parameter otherSettings: Dictionary containing the collection of "Other Settings"
@@ -148,8 +136,6 @@ open class RemoteNotificationSettings {
     private convenience init(otherSettings: NSDictionary?) {
         self.init(channel: Channel.other, settings: otherSettings)
     }
-
-
 
     /// Static Helper that will parse all of the Remote Settings, into a collection of Swift Native
     /// RemoteNotificationSettings objects.
@@ -177,8 +163,6 @@ open class RemoteNotificationSettings {
         return parsed
     }
 }
-
-
 
 /// Swift requires this method to be implemented globally. Sorry about that!
 ///

--- a/WordPressKit/RemotePerson.swift
+++ b/WordPressKit/RemotePerson.swift
@@ -75,7 +75,7 @@ public struct User: RemotePerson {
     public let avatarURL: URL?
     public let isSuperAdmin: Bool
     public static let kind = PersonKind.user
-    
+
     public init(ID: Int,
          username: String,
          firstName: String?,
@@ -113,7 +113,7 @@ public struct Follower: RemotePerson {
     public let avatarURL: URL?
     public let isSuperAdmin: Bool
     public static let kind = PersonKind.follower
-    
+
     public init(ID: Int,
                 username: String,
                 firstName: String?,
@@ -151,7 +151,7 @@ public struct Viewer: RemotePerson {
     public let avatarURL: URL?
     public let isSuperAdmin: Bool
     public static let kind = PersonKind.viewer
-    
+
     public init(ID: Int,
                 username: String,
                 firstName: String?,

--- a/WordPressKit/RemotePlan_ApiVersion1_3.swift
+++ b/WordPressKit/RemotePlan_ApiVersion1_3.swift
@@ -25,19 +25,19 @@ import Foundation
     @objc public var productSlug: String?
     @objc public var subscribedDate: Date?
     @objc public var userFacingExpiry: Date?
-    
+
     @objc public var isAutoRenew: Bool {
         return autoRenew ?? false
     }
-    
+
     @objc public var isCurrentPlan: Bool {
         return currentPlan ?? false
     }
-    
+
     @objc public var isFreeTrial: Bool {
         return freeTrial ?? false
     }
-    
+
     @objc public var doesHaveDomainCredit: Bool {
         return hasDomainCredit ?? false
     }

--- a/WordPressKit/RemoteProfile.swift
+++ b/WordPressKit/RemoteProfile.swift
@@ -12,7 +12,6 @@ public class RemoteProfile {
     public let userID: Int
     public let username: String
 
-
     public init(dictionary: NSDictionary) {
         bio = dictionary.string(forKey: "bio") ?? ""
         displayName = dictionary.string(forKey: "display_name") ?? ""

--- a/WordPressKit/RemotePublicizeConnection.swift
+++ b/WordPressKit/RemotePublicizeConnection.swift
@@ -3,7 +3,7 @@ import Foundation
 @objc open class RemotePublicizeConnection: NSObject {
     @objc open var connectionID: NSNumber = 0
     @objc open var dateIssued = Date()
-    @objc open var dateExpires: Date? = nil
+    @objc open var dateExpires: Date?
     @objc open var externalID = ""
     @objc open var externalName = ""
     @objc open var externalDisplay = ""

--- a/WordPressKit/RemoteReaderCard.swift
+++ b/WordPressKit/RemoteReaderCard.swift
@@ -45,7 +45,7 @@ public struct RemoteReaderCard: Decodable {
             sites = sitesArray.compactMap {
                 // Since RemoteReaderSiteInfo is written in Obj-C and doesn't support decoding
                 // attempt to recast the response as a dictionary value to be passed to the init below
-                guard let dict = $0 as? [AnyHashable : Any] else {
+                guard let dict = $0 as? [AnyHashable: Any] else {
                     return nil
                 }
 

--- a/WordPressKit/RemoteReaderSiteInfoSubscription.swift
+++ b/WordPressKit/RemoteReaderSiteInfoSubscription.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// Mapping keys
 private struct CodingKeys {
     static let sendPost = "send_posts"
@@ -8,25 +7,21 @@ private struct CodingKeys {
     static let postDeliveryFrequency = "post_delivery_frequency"
 }
 
-
 /// Site Info Post Subscription model
 @objc public class RemoteReaderSiteInfoSubscriptionPost: NSObject {
     @objc public var sendPosts: Bool
-    
-    
+
     @objc required public init(dictionary: [String: Any]) {
         self.sendPosts = (dictionary[CodingKeys.sendPost] as? Bool) ?? false
         super.init()
     }
 }
 
-
 /// Site Info Email Subscription model
 @objc public class RemoteReaderSiteInfoSubscriptionEmail: RemoteReaderSiteInfoSubscriptionPost {
     @objc public var sendComments: Bool
     @objc public var postDeliveryFrequency: String
 
-    
     @objc required public init(dictionary: [String: Any]) {
         sendComments = (dictionary[CodingKeys.sendComments] as? Bool) ?? false
         postDeliveryFrequency = (dictionary[CodingKeys.postDeliveryFrequency] as? String) ?? ""

--- a/WordPressKit/RemoteRevision.swift
+++ b/WordPressKit/RemoteRevision.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// Revision model
 ///
 public struct RemoteRevision: Codable {

--- a/WordPressKit/ServiceRequest.swift
+++ b/WordPressKit/ServiceRequest.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-
 /// Enumeration to identify a service action
 enum ServiceRequestAction: String {
     case subscribe = "new"
@@ -8,16 +7,14 @@ enum ServiceRequestAction: String {
     case update = "update"
 }
 
-
 /// A protocol for a Service request
 protocol ServiceRequest {
     /// Returns a valid url path
     var path: String { get }
-    
+
     /// Returns the used API version
     var apiVersion: ServiceRemoteWordPressComRESTApiVersion { get }
 }
-
 
 /// Reader Topic Service request
 enum ReaderTopicServiceSubscriptionsRequest {
@@ -25,7 +22,6 @@ enum ReaderTopicServiceSubscriptionsRequest {
     case postsEmail(siteId: Int, action: ServiceRequestAction)
     case comments(siteId: Int, action: ServiceRequestAction)
 }
-
 
 extension ReaderTopicServiceSubscriptionsRequest: ServiceRequest {
     var apiVersion: ServiceRemoteWordPressComRESTApiVersion {
@@ -35,15 +31,15 @@ extension ReaderTopicServiceSubscriptionsRequest: ServiceRequest {
         case .comments: return ._1_2
         }
     }
-    
+
     var path: String {
         switch self {
         case .notifications(let siteId, let action):
             return "read/sites/\(siteId)/notification-subscriptions/\(action.rawValue)/"
-            
+
         case .postsEmail(let siteId, let action):
             return "read/site/\(siteId)/post_email_subscriptions/\(action.rawValue)/"
-            
+
         case .comments(let siteId, let action):
             return "read/site/\(siteId)/comment_email_subscriptions/\(action.rawValue)/"
         }

--- a/WordPressKit/SharingServiceRemote.swift
+++ b/WordPressKit/SharingServiceRemote.swift
@@ -2,7 +2,6 @@ import Foundation
 import NSObject_SafeExpectations
 import WordPressShared
 
-
 /// SharingServiceRemote is responsible for wrangling the REST API calls related to
 /// publiczice services, publicize connections, and keyring connections.
 ///
@@ -32,7 +31,6 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         return NSError(domain: domain, code: code, userInfo: userInfo)
     }
 
-
     // MARK: - Publicize Related Methods
 
     /// Fetches the list of Publicize services.
@@ -47,7 +45,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let params = ["type": "publicize"]
 
         wordPressComRestApi.GET(path,
-            parameters: params as [String : AnyObject]?,
+            parameters: params as [String: AnyObject]?,
             success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
                 guard let onSuccess = success else {
                     return
@@ -87,11 +85,10 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                 onSuccess(publicizeServices)
 
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+            failure: { (error: NSError, _: HTTPURLResponse?) in
                 failure?(error)
             })
     }
-
 
     /// Fetches the current user's list of keyring connections.
     ///
@@ -140,11 +137,10 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                 onSuccess(keyringConnections)
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+            failure: { (error: NSError, _: HTTPURLResponse?) in
                 failure?(error)
         })
     }
-
 
     /// Creates KeyringConnectionExternalUser instances from the past array of
     /// external user dictionaries.
@@ -166,7 +162,6 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         }
         return arr
     }
-
 
     /// Fetches the current user's list of Publicize connections for the specified site's ID.
     ///
@@ -199,11 +194,10 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                 onSuccess(publicizeConnections)
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+            failure: { (error: NSError, _: HTTPURLResponse?) in
                 failure?(error)
         })
     }
-
 
     /// Create a new Publicize connection bweteen the specified blog and
     /// the third-pary service represented by the keyring.
@@ -223,7 +217,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
             let endpoint = "sites/\(siteID)/publicize-connections/new"
             let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-            var parameters: [String : AnyObject] = [PublicizeConnectionParams.keyringConnectionID: keyringConnectionID]
+            var parameters: [String: AnyObject] = [PublicizeConnectionParams.keyringConnectionID: keyringConnectionID]
             if let userID = externalUserID {
                 parameters[PublicizeConnectionParams.externalUserID] = userID as AnyObject?
             }
@@ -243,11 +237,10 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                     onSuccess(conn)
                 },
-                failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+                failure: { (error: NSError, _: HTTPURLResponse?) in
                     failure?(error)
             })
     }
-
 
     /// Update the shared status of the specified publicize connection
     ///
@@ -274,7 +267,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
             ]
 
             wordPressComRestApi.POST(path,
-                parameters: parameters as [String : AnyObject]?,
+                parameters: parameters as [String: AnyObject]?,
                 success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
                     guard let onSuccess = success else {
                         return
@@ -288,11 +281,10 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                     onSuccess(conn)
                 },
-                failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+                failure: { (error: NSError, _: HTTPURLResponse?) in
                     failure?(error)
             })
     }
-
 
     /// Update the shared status of the specified publicize connection
     ///
@@ -315,7 +307,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
             ]
 
             wordPressComRestApi.POST(path,
-                parameters: parameters as [String : AnyObject]?,
+                parameters: parameters as [String: AnyObject]?,
                 success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
                     guard let onSuccess = success else {
                         return
@@ -329,11 +321,10 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                     onSuccess(conn)
                 },
-                failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+                failure: { (error: NSError, _: HTTPURLResponse?) in
                     failure?(error)
             })
     }
-
 
     /// Disconnects (deletes) the specified publicize connection
     ///
@@ -349,14 +340,13 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
         wordPressComRestApi.POST(path,
             parameters: nil,
-            success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+            success: { (_: AnyObject, _: HTTPURLResponse?) in
                 success?()
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+            failure: { (error: NSError, _: HTTPURLResponse?) in
                 failure?(error)
         })
     }
-
 
     /// Composees a `RemotePublicizeConnection` populated with values from the passed `NSDictionary`
     ///
@@ -406,7 +396,6 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         return conn
     }
 
-
     // MARK: - Sharing Button Related Methods
 
     /// Fetches the list of sharing buttons for a blog.
@@ -437,11 +426,10 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                 onSuccess(sharingButtons)
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+            failure: { (error: NSError, _: HTTPURLResponse?) in
                 failure?(error)
         })
     }
-
 
     /// Updates the list of sharing buttons for a blog.
     ///
@@ -458,7 +446,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let parameters = [SharingButtonsKeys.sharingButtons: buttons]
 
         wordPressComRestApi.POST(path,
-            parameters: parameters as [String : AnyObject]?,
+            parameters: parameters as [String: AnyObject]?,
             success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
                 guard let onSuccess = success else {
                     return
@@ -474,11 +462,10 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                 onSuccess(sharingButtons)
             },
-            failure: { (error: NSError, httpResponse: HTTPURLResponse?) in
+            failure: { (error: NSError, _: HTTPURLResponse?) in
                 failure?(error)
         })
     }
-
 
     /// Composees a `RemotePublicizeConnection` populated with values from the passed `NSDictionary`
     ///
@@ -509,7 +496,6 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         return sharingButtons
     }
 
-
     private func dictionariesFromRemoteSharingButtons(_ buttons: [RemoteSharingButton]) -> [NSDictionary] {
         return buttons.map({ (btn) -> NSDictionary in
 
@@ -528,7 +514,6 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
     }
 }
 
-
 // Keys for PublicizeService dictionaries
 private struct ServiceDictionaryKeys {
     static let connectURL = "connect_URL"
@@ -543,7 +528,6 @@ private struct ServiceDictionaryKeys {
     static let services = "services"
     static let type = "type"
 }
-
 
 // Keys for both KeyringConnection and PublicizeConnection dictionaries
 private struct ConnectionDictionaryKeys {
@@ -577,14 +561,12 @@ private struct ConnectionDictionaryKeys {
     static let siteID = "site_ID"
 }
 
-
 // Names of parameters passed when creating or updating a publicize connection
 private struct PublicizeConnectionParams {
     static let keyringConnectionID = "keyring_connection_ID"
     static let externalUserID = "external_user_ID"
     static let shared = "shared"
 }
-
 
 // Names of parameters used in SharingButton requests
 private struct SharingButtonsKeys {

--- a/WordPressKit/SiteDesignServiceRemote.swift
+++ b/WordPressKit/SiteDesignServiceRemote.swift
@@ -34,7 +34,7 @@ public class SiteDesignServiceRemote {
         "language": (WordPressComLanguageDatabase().deviceLanguage.slug as AnyObject)
     ]
 
-    private static func joinParameters(_ parameters: [String : AnyObject], additionalParameters: [String : AnyObject]?) -> [String: AnyObject] {
+    private static func joinParameters(_ parameters: [String: AnyObject], additionalParameters: [String: AnyObject]?) -> [String: AnyObject] {
         guard let additionalParameters = additionalParameters else { return parameters }
         return parameters.reduce(into: additionalParameters, { (result, element) in
             result[element.key] = element.value

--- a/WordPressKit/SiteManagementServiceRemote.swift
+++ b/WordPressKit/SiteManagementServiceRemote.swift
@@ -16,7 +16,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
 
         wordPressComRestApi.POST(path,
             parameters: nil,
-            success: { response, httpResponse in
+            success: { response, _ in
                 guard let results = response as? [String: AnyObject] else {
                     failure?(SiteError.deleteInvalidResponse.toNSError())
                     return
@@ -32,11 +32,10 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
 
                 success?()
             },
-            failure: { error, httpResponse in
+            failure: { error, _ in
                 failure?(error)
             })
     }
-
 
     /// Triggers content export of the specified WordPress.com site.
     ///
@@ -53,7 +52,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
 
         wordPressComRestApi.POST(path,
             parameters: nil,
-            success: { response, httpResponse in
+            success: { response, _ in
                 guard let results = response as? [String: AnyObject] else {
                     failure?(SiteError.exportInvalidResponse.toNSError())
                     return
@@ -69,7 +68,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
 
                 success?()
             },
-            failure: { error, httpResponse in
+            failure: { error, _ in
                 failure?(error)
         })
     }
@@ -87,7 +86,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
 
         wordPressComRestApi.GET(path,
             parameters: nil,
-            success: { response, httpResponse in
+            success: { response, _ in
                 guard let results = response as? [SitePurchase] else {
                     failure?(SiteError.purchasesInvalidResponse.toNSError())
                     return
@@ -96,11 +95,11 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
                 let actives = results.filter { $0[ResultKey.Active]?.boolValue == true }
                 success?(actives)
             },
-            failure: { error, httpResponse in
+            failure: { error, _ in
                 failure?(error)
         })
     }
-    
+
     /// Trigger a masterbar notification celebrating completion of mobile quick start.
     ///
     /// - Parameters:
@@ -114,10 +113,10 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
 
         wordPressComRestApi.POST(path,
                                  parameters: nil,
-                                 success: { response, httpResponse in
+                                 success: { _, _ in
                                     success?()
         },
-                                 failure: { error, httpResponse in
+                                 failure: { error, _ in
                                     failure?(error)
         })
     }

--- a/WordPressKit/StatsPostDetails.swift
+++ b/WordPressKit/StatsPostDetails.swift
@@ -117,7 +117,6 @@ extension StatsPostViews {
                 return nil
             }
 
-
             return StatsWeeklyBreakdown(startDay: mappedDays.first!.date,
                                         endDay: mappedDays.last!.date,
                                         totalViewsCount: totalViews,

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -25,7 +25,7 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
         cal.timeZone = siteTimezone
         return cal
     }()
-    
+
     public init(wordPressComRestApi api: WordPressComRestApi, siteID: Int, siteTimezone: TimeZone) {
         self.siteID = siteID
         self.siteTimezone = siteTimezone
@@ -58,7 +58,6 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
             completion(nil, error)
         })
     }
-
 
     /// Used to fetch data about site over a specific timeframe.
     /// - parameters:
@@ -156,7 +155,7 @@ extension StatsServiceRemoteV2 {
                     return
             }
 
-            self.getPostViews(for: postID) { (views, error) in
+            self.getPostViews(for: postID) { (views, _) in
                 guard
                     let views = views,
                     let insight = StatsLastPostInsight(jsonDictionary: post, views: views) else {
@@ -187,14 +186,14 @@ extension StatsServiceRemoteV2 {
                                             return
                                     }
                                     completion(views, nil)
-                                }, failure:  { (error, _) in
+                                }, failure: { (error, _) in
                                     completion(nil, error)
                                 }
         )
     }
 }
 
-// MARK - StatsPublishedPostsTimeIntervalData Handling
+// MARK: - StatsPublishedPostsTimeIntervalData Handling
 
 extension StatsServiceRemoteV2 {
 
@@ -252,7 +251,7 @@ extension StatsServiceRemoteV2 {
 // This serves both as a way to get the query properties in a "nice" way,
 // but also as a way to narrow down the generic type in `getInsight(completion:)` method.
 public protocol StatsInsightData {
-    static func queryProperties(with maxCount: Int) -> [String: String] 
+    static func queryProperties(with maxCount: Int) -> [String: String]
     static var pathComponent: String { get }
 
     init?(jsonDictionary: [String: AnyObject])

--- a/WordPressKit/Time Interval/StatsFileDownloadsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsFileDownloadsTimeIntervalData.swift
@@ -1,11 +1,11 @@
 public struct StatsFileDownloadsTimeIntervalData {
     public let period: StatsPeriodUnit
     public let periodEndDate: Date
-    
+
     public let totalDownloadsCount: Int
     public let otherDownloadsCount: Int
     public let fileDownloads: [StatsFileDownload]
-    
+
     public init(period: StatsPeriodUnit,
                 periodEndDate: Date,
                 fileDownloads: [StatsFileDownload],
@@ -22,7 +22,7 @@ public struct StatsFileDownloadsTimeIntervalData {
 public struct StatsFileDownload {
     public let file: String
     public let downloadCount: Int
-    
+
     public init(file: String,
                 downloadCount: Int) {
         self.file = file
@@ -34,28 +34,28 @@ extension StatsFileDownloadsTimeIntervalData: StatsTimeIntervalData {
     public static var pathComponent: String {
         return "stats/file-downloads"
     }
-    
+
     public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String: String] {
         // num = number of periods to include in the query. default: 1.
         return ["num": String(maxCount)]
     }
-    
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let fileDownloadsDict = unwrappedDays["files"] as? [[String: AnyObject]]
             else {
                 return nil
         }
-        
+
         let fileDownloads: [StatsFileDownload] = fileDownloadsDict.compactMap {
             guard let file = $0["filename"] as? String, let downloads = $0["downloads"] as? Int else {
                 return nil
             }
-            
+
             return StatsFileDownload(file: file, downloadCount: downloads)
         }
-        
+
         self.periodEndDate = date
         self.period = period
         self.fileDownloads = fileDownloads

--- a/WordPressKit/Time Interval/StatsPublishedPostsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsPublishedPostsTimeIntervalData.swift
@@ -18,14 +18,14 @@ extension StatsPublishedPostsTimeIntervalData: StatsTimeIntervalData {
         return "posts/"
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard let posts = jsonDictionary["posts"] as? [[String: AnyObject]] else {
             return nil
         }
 
         self.periodEndDate = date
         self.period = period
-        self.publishedPosts = posts.compactMap { StatsTopPost(postsJSONDictionary:$0) }
+        self.publishedPosts = posts.compactMap { StatsTopPost(postsJSONDictionary: $0) }
     }
 }
 

--- a/WordPressKit/Time Interval/StatsSearchTermTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsSearchTermTimeIntervalData.swift
@@ -38,7 +38,7 @@ extension StatsSearchTermTimeIntervalData: StatsTimeIntervalData {
         return "stats/search-terms"
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let totalSearchTerms = unwrappedDays["total_search_terms"] as? Int,
@@ -57,7 +57,6 @@ extension StatsSearchTermTimeIntervalData: StatsTimeIntervalData {
             return StatsSearchTerm(term: term, viewsCount: views)
         }
 
-
         self.periodEndDate = date
         self.period = period
         self.totalSearchTermsCount = totalSearchTerms
@@ -67,4 +66,3 @@ extension StatsSearchTermTimeIntervalData: StatsTimeIntervalData {
     }
 
 }
-

--- a/WordPressKit/Time Interval/StatsSummaryTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsSummaryTimeIntervalData.swift
@@ -56,13 +56,13 @@ extension StatsSummaryTimeIntervalData: StatsTimeIntervalData {
         return "stats/visits"
     }
 
-    public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String : String] {
+    public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String: String] {
         return ["unit": period.stringValue,
                 "quantity": String(maxCount),
                 "stat_fields": "views,visitors,comments"]
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let fieldsArray = jsonDictionary["fields"] as? [String],
             let data = jsonDictionary["data"] as? [[Any]]
@@ -199,7 +199,6 @@ private extension StatsSummaryData {
     }
 }
 
-
 /// So this is very awkward and neccessiated by our API. Turns out, calculating likes
 /// for long periods of times (months/years) on large sites takes _ages_ (up to a minute sometimes).
 /// Thankfully, calculating views/visitors/comments takes a much shorter time. (~2s, which is still suuuuuper long, but acceptable.)
@@ -226,13 +225,13 @@ extension StatsLikesSummaryTimeIntervalData: StatsTimeIntervalData {
         return "stats/visits"
     }
 
-    public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String : String] {
+    public static func queryProperties(with date: Date, period: StatsPeriodUnit, maxCount: Int) -> [String: String] {
         return ["unit": period.stringValue,
                 "quantity": String(maxCount),
                 "stat_fields": "likes"]
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let fieldsArray = jsonDictionary["fields"] as? [String],
             let data = jsonDictionary["data"] as? [[Any]]
@@ -257,4 +256,3 @@ extension StatsLikesSummaryTimeIntervalData: StatsTimeIntervalData {
                                                               commentsIndex: nil) }
     }
 }
-

--- a/WordPressKit/Time Interval/StatsTopAuthorsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopAuthorsTimeIntervalData.swift
@@ -39,7 +39,6 @@ public struct StatsTopPost {
         case homepage
     }
 
-
     public let title: String
     public let postID: Int
     public let postURL: URL?
@@ -64,7 +63,7 @@ extension StatsTopAuthorsTimeIntervalData: StatsTimeIntervalData {
         return "stats/top-authors/"
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let authors = unwrappedDays["authors"] as? [[String: AnyObject]]
@@ -138,4 +137,3 @@ extension StatsTopPost {
         }
     }
 }
-

--- a/WordPressKit/Time Interval/StatsTopClicksTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopClicksTimeIntervalData.swift
@@ -46,7 +46,7 @@ extension StatsTopClicksTimeIntervalData: StatsTimeIntervalData {
         return "stats/clicks"
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let clicks = unwrappedDays["clicks"] as? [[String: AnyObject]]

--- a/WordPressKit/Time Interval/StatsTopCountryTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopCountryTimeIntervalData.swift
@@ -27,7 +27,7 @@ public struct StatsCountry {
 
     public init(name: String,
                 code: String,
-                viewsCount: Int){
+                viewsCount: Int) {
         self.name = name
         self.code = code
         self.viewsCount = viewsCount
@@ -39,7 +39,7 @@ extension StatsTopCountryTimeIntervalData: StatsTimeIntervalData {
         return "stats/country-views"
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let countriesViews = unwrappedDays["views"] as? [[String: AnyObject]]

--- a/WordPressKit/Time Interval/StatsTopPostsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopPostsTimeIntervalData.swift
@@ -24,7 +24,7 @@ extension StatsTopPostsTimeIntervalData: StatsTimeIntervalData {
         return "stats/top-posts"
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let posts = unwrappedDays["postviews"] as? [[String: AnyObject]]

--- a/WordPressKit/Time Interval/StatsTopReferrersTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopReferrersTimeIntervalData.swift
@@ -46,7 +46,7 @@ extension StatsTopReferrersTimeIntervalData: StatsTimeIntervalData {
         return "stats/referrers"
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let referrers = unwrappedDays["groups"] as? [[String: AnyObject]]
@@ -91,7 +91,7 @@ extension StatsReferrer {
 
         if let childrenJSON = jsonDictionary["results"] as? [[String: AnyObject]] {
             children = childrenJSON.compactMap { StatsReferrer(jsonDictionary: $0) }
-        } else if let childrenJSON = jsonDictionary["children"] as? [[String: AnyObject]]  {
+        } else if let childrenJSON = jsonDictionary["children"] as? [[String: AnyObject]] {
             children = childrenJSON.compactMap { StatsReferrer(jsonDictionary: $0) }
         } else {
             children = []

--- a/WordPressKit/Time Interval/StatsTopVideosTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopVideosTimeIntervalData.swift
@@ -42,7 +42,7 @@ extension StatsTopVideosTimeIntervalData: StatsTimeIntervalData {
         return "stats/video-plays"
     }
 
-    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String : AnyObject]) {
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let totalPlayCount = unwrappedDays["total_plays"] as? Int,

--- a/WordPressKit/TransactionsServiceRemote.swift
+++ b/WordPressKit/TransactionsServiceRemote.swift
@@ -16,7 +16,7 @@ import CocoaLumberjack
                                             failure: @escaping (Error) -> Void) {
         let endPoint = "me/transactions/supported-countries/"
         let servicePath = path(forEndpoint: endPoint, withVersion: ._1_1)
-        
+
         wordPressComRestApi.GET(servicePath,
                                 parameters: nil,
                                 success: {
@@ -60,20 +60,18 @@ import CocoaLumberjack
                                  parameters: parameters,
                                  success: { (response, _) in
 
-
                                     guard let jsonResponse = response as? [String: AnyObject],
                                         let cart = CartResponse(jsonDictionary: jsonResponse),
                                         !cart.products.isEmpty else {
-                                            
+
                                         failure(TransactionsServiceRemote.ResponseError.decodingFailure)
                                         return
                                     }
 
                                     success(cart)
-        }) { (error, response) in
+        }) { (error, _) in
             failure(error)
         }
-
 
     }
 
@@ -92,9 +90,9 @@ import CocoaLumberjack
                                                "cart": cart.jsonRepresentation() as AnyObject,
                                                "payment": paymentDict as AnyObject]
 
-        wordPressComRestApi.POST(urlPath, parameters: parameters, success: { (response, _) in
+        wordPressComRestApi.POST(urlPath, parameters: parameters, success: { (_, _) in
             success()
-        }) { (error, response) in
+        }) { (error, _) in
             failure(error)
         }
     }
@@ -155,7 +153,6 @@ public struct Product {
         returnDict["product_id"] = productID as AnyObject
         returnDict["meta"] = meta as AnyObject
 
-
         if let extra = extra {
             returnDict["extra"] = extra as AnyObject
         }
@@ -163,4 +160,3 @@ public struct Product {
         return returnDict
     }
 }
-

--- a/WordPressKit/UsersServiceRemoteXMLRPC.swift
+++ b/WordPressKit/UsersServiceRemoteXMLRPC.swift
@@ -13,7 +13,7 @@ public class UsersServiceRemoteXMLRPC: ServiceRemoteWordPressXMLRPC {
     ///
     public func fetchProfile(_ success: @escaping ((RemoteProfile) -> Void), failure: @escaping ((NSError?) -> Void)) {
         let params = defaultXMLRPCArguments() as [AnyObject]
-        api.callMethod("wp.getProfile", parameters: params, success: { (responseObj, response) in
+        api.callMethod("wp.getProfile", parameters: params, success: { (responseObj, _) in
             guard let dict = responseObj as? NSDictionary else {
                 assertionFailure("A dictionary was expected but the API returned something different.")
                 failure(UsersServiceRemoteError.UnexpectedResponseData as NSError)
@@ -22,7 +22,7 @@ public class UsersServiceRemoteXMLRPC: ServiceRemoteWordPressXMLRPC {
             let profile = RemoteProfile(dictionary: dict)
             success(profile)
 
-        }, failure: { (error, response) in
+        }, failure: { (error, _) in
             failure(error)
         })
     }

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -38,12 +38,11 @@ public final class WordPressComOAuthClient: NSObject {
         }
     }
 
-
     @objc public static let WordPressComSocialLoginEndpointVersion = 1.0
 
     private let clientID: String
     private let secret: String
-    
+
     private let wordPressComBaseUrl: String
     private let wordPressComApiBaseUrl: String
 
@@ -121,8 +120,8 @@ public final class WordPressComOAuthClient: NSObject {
     @objc public func authenticateWithUsername(_ username: String,
                                   password: String,
                                   multifactorCode: String?,
-                                  success: @escaping (_ authToken: String?) -> (),
-                                  failure: @escaping (_ error: NSError) -> () ) {
+                                  success: @escaping (_ authToken: String?) -> Void,
+                                  failure: @escaping (_ error: NSError) -> Void ) {
         var parameters: [String: AnyObject] = [
             "username": username as AnyObject,
             "password": password as AnyObject,
@@ -168,7 +167,7 @@ public final class WordPressComOAuthClient: NSObject {
     ///     - failure: block to be called if authentication failed. The error object is passed as a parameter.
     ///
     @objc public func requestOneTimeCodeWithUsername(_ username: String, password: String,
-                                        success: @escaping () -> (), failure: @escaping (_ error: NSError) -> ()) {
+                                        success: @escaping () -> Void, failure: @escaping (_ error: NSError) -> Void) {
         let parameters = [
             "username": username,
             "password": password,
@@ -177,13 +176,13 @@ public final class WordPressComOAuthClient: NSObject {
             "client_secret": secret,
             "wpcom_supports_2fa": true,
             "wpcom_resend_otp": true
-        ] as [String : Any]
+        ] as [String: Any]
 
         oauth2SessionManager.request(WordPressComURL.oAuthBase.url(base: wordPressComApiBaseUrl), method: .post, parameters: parameters)
             .validate()
             .responseJSON(completionHandler: { response in
                 switch response.result {
-                case .success(_):
+                case .success:
                     success()
                 case .failure(let error):
                     let nserror = self.processError(response: response, originalError: error)
@@ -212,7 +211,7 @@ public final class WordPressComOAuthClient: NSObject {
             "client_secret": secret,
             "wpcom_supports_2fa": true,
             "wpcom_resend_otp": true
-            ] as [String : Any]
+            ] as [String: Any]
 
         socialNewSMS2FASessionManager.request(WordPressComURL.socialLoginNewSMS2FA.url(base: wordPressComBaseUrl), method: .post, parameters: parameters)
             .validate()
@@ -263,8 +262,8 @@ public final class WordPressComOAuthClient: NSObject {
             "client_secret": secret,
             "service": service,
             "get_bearer_token": true,
-            "id_token" : token,
-            ] as [String : Any]
+            "id_token": token
+            ] as [String: Any]
 
         // Passes an empty string for the path. The session manager was composed with the full endpoint path.
         socialSessionManager.request(WordPressComURL.socialLogin.url(base: wordPressComBaseUrl), method: .post, parameters: parameters)
@@ -330,7 +329,7 @@ public final class WordPressComOAuthClient: NSObject {
     ///
     /// - Return: SocialLogin2FANonceInfo
     ///
-    private func extractNonceInfo(data:[String: AnyObject]) -> SocialLogin2FANonceInfo {
+    private func extractNonceInfo(data: [String: AnyObject]) -> SocialLogin2FANonceInfo {
         let nonceInfo = SocialLogin2FANonceInfo()
 
         if let nonceAuthenticator = data["two_step_nonce_authenticator"] as? String {
@@ -382,14 +381,14 @@ public final class WordPressComOAuthClient: NSObject {
                                             success: @escaping (_ authToken: String?) -> Void,
                                             failure: @escaping (_ error: NSError) -> Void ) {
         let parameters = [
-            "user_id" : userID,
-            "auth_type" : authType,
+            "user_id": userID,
+            "auth_type": authType,
             "two_step_code": twoStepCode,
             "two_step_nonce": twoStepNonce,
             "get_bearer_token": true,
             "client_id": clientID,
-            "client_secret": secret,
-            ] as [String : Any]
+            "client_secret": secret
+            ] as [String: Any]
 
         // Passes an empty string for the path. The session manager was composed with the full endpoint path.
         social2FASessionManager.request(WordPressComURL.socialLogin2FA.url(base: wordPressComBaseUrl), method: .post, parameters: parameters)
@@ -523,7 +522,7 @@ extension WordPressComOAuthClient {
     ///   - newNonce: *optional* The new nonce provided when a 2FA fails
     /// - Returns: An NSError.
     @objc func errorFor(errorCode: String, errorDescription: String, responseObject: Any?, newNonce: String? = nil) -> NSError {
-        var userInfo:[String: AnyObject] = [NSLocalizedDescriptionKey: errorDescription as AnyObject]
+        var userInfo: [String: AnyObject] = [NSLocalizedDescriptionKey: errorDescription as AnyObject]
         if let responseObject = responseObject {
             userInfo[WordPressComOAuthClient.WordPressComOAuthErrorResponseObjectKey] = responseObject as AnyObject
         }

--- a/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 // MARK: - SiteCreationRequest
@@ -155,12 +154,12 @@ public enum SiteCreationResult {
     case failure(SiteCreationError)
 }
 
-public typealias SiteCreationResultHandler = ((SiteCreationResult) -> ())
+public typealias SiteCreationResultHandler = ((SiteCreationResult) -> Void)
 
 /// Site creation services, exclusive to WordPress.com.
 /// 
 public extension WordPressComServiceRemote {
-    
+
     /// Initiates a request to create a new WPCOM site.
     ///
     /// - Parameters:
@@ -172,7 +171,7 @@ public extension WordPressComServiceRemote {
         let endpoint = "sites/new"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        let requestParameters: [String : AnyObject]
+        let requestParameters: [String: AnyObject]
         do {
             requestParameters = try encodeRequestParameters(request: request)
         } catch {
@@ -211,15 +210,15 @@ public extension WordPressComServiceRemote {
 
 private extension WordPressComServiceRemote {
 
-    func encodeRequestParameters(request: SiteCreationRequest) throws -> [String : AnyObject] {
+    func encodeRequestParameters(request: SiteCreationRequest) throws -> [String: AnyObject] {
 
         let encoder = JSONEncoder()
 
         let jsonData = try encoder.encode(request)
         let serializedJSON = try JSONSerialization.jsonObject(with: jsonData, options: [])
 
-        let requestParameters: [String : AnyObject]
-        if let jsonDictionary = serializedJSON as? [String : AnyObject] {
+        let requestParameters: [String: AnyObject]
+        if let jsonDictionary = serializedJSON as? [String: AnyObject] {
             requestParameters = jsonDictionary
         } else {
             requestParameters = [:]

--- a/WordPressKit/WordPressComServiceRemote+SiteVerticals.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteVerticals.swift
@@ -65,7 +65,7 @@ public enum SiteVerticalsResult {
     case failure(SiteVerticalsError)
 }
 
-public typealias SiteVerticalsServiceCompletion = ((SiteVerticalsResult) -> ())
+public typealias SiteVerticalsServiceCompletion = ((SiteVerticalsResult) -> Void)
 
 /// Site verticals services, exclusive to WordPress.com.
 ///
@@ -82,7 +82,7 @@ public extension WordPressComServiceRemote {
         let endpoint = "verticals"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        let requestParameters: [String : AnyObject]
+        let requestParameters: [String: AnyObject]
         do {
             requestParameters = try encodeRequestParameters(request: request)
         } catch {
@@ -121,15 +121,15 @@ public extension WordPressComServiceRemote {
 
 private extension WordPressComServiceRemote {
 
-    func encodeRequestParameters(request: SiteVerticalsRequest) throws -> [String : AnyObject] {
+    func encodeRequestParameters(request: SiteVerticalsRequest) throws -> [String: AnyObject] {
 
         let encoder = JSONEncoder()
 
         let jsonData = try encoder.encode(request)
         let serializedJSON = try JSONSerialization.jsonObject(with: jsonData, options: [])
 
-        let requestParameters: [String : AnyObject]
-        if let jsonDictionary = serializedJSON as? [String : AnyObject] {
+        let requestParameters: [String: AnyObject]
+        if let jsonDictionary = serializedJSON as? [String: AnyObject] {
             requestParameters = jsonDictionary
         } else {
             requestParameters = [:]

--- a/WordPressKit/WordPressComServiceRemote+SiteVerticalsPrompt.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteVerticalsPrompt.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 // MARK: - Site Verticals Prompt : Request
@@ -11,13 +10,13 @@ public struct SiteVerticalsPrompt: Decodable {
     public let title: String
     public let subtitle: String
     public let hint: String
-    
+
     public init(title: String, subtitle: String, hint: String) {
         self.title = title
         self.subtitle = subtitle
         self.hint = hint
     }
-    
+
     private enum CodingKeys: String, CodingKey {
         case title      = "site_topic_header"
         case subtitle   = "site_topic_subheader"
@@ -25,12 +24,12 @@ public struct SiteVerticalsPrompt: Decodable {
     }
 }
 
-public typealias SiteVerticalsPromptServiceCompletion = ((SiteVerticalsPrompt?) -> ())
+public typealias SiteVerticalsPromptServiceCompletion = ((SiteVerticalsPrompt?) -> Void)
 
 /// Site verticals services, exclusive to WordPress.com.
 ///
 public extension WordPressComServiceRemote {
-    
+
     /// Retrieves the prompt information presented to users when searching Verticals.
     ///
     /// - Parameters:
@@ -38,24 +37,24 @@ public extension WordPressComServiceRemote {
     ///   - completion: a closure including the result of the request for site verticals.
     ///
     func retrieveVerticalsPrompt(request: SiteVerticalsPromptRequest, completion: @escaping SiteVerticalsPromptServiceCompletion) {
-        
+
         let endpoint = "verticals/prompt"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
-        
-        let requestParameters: [String : AnyObject] = [
-            "segment_id" : request as AnyObject
+
+        let requestParameters: [String: AnyObject] = [
+            "segment_id": request as AnyObject
         ]
-        
+
         wordPressComRestApi.GET(
             path,
             parameters: requestParameters,
             success: { [weak self] responseObject, httpResponse in
                 DDLogInfo("\(responseObject) | \(String(describing: httpResponse))")
-                
+
                 guard let self = self else {
                     return
                 }
-                
+
                 do {
                     let response = try self.decodeResponse(responseObject: responseObject)
                     completion(response)
@@ -71,17 +70,17 @@ public extension WordPressComServiceRemote {
     }
 }
 
-//// MARK: - Serialization support
+// MARK: - Serialization support
 //
 private extension WordPressComServiceRemote {
-    
+
     func decodeResponse(responseObject: AnyObject) throws -> SiteVerticalsPrompt {
-        
+
         let decoder = JSONDecoder()
-        
+
         let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
         let response = try decoder.decode(SiteVerticalsPrompt.self, from: data)
-        
+
         return response
     }
 }

--- a/WordPressKit/WordPressOrgRestApi.swift
+++ b/WordPressKit/WordPressOrgRestApi.swift
@@ -50,7 +50,7 @@ open class WordPressOrgRestApi: NSObject {
             progress.completedUnitCount = taskProgress.completedUnitCount
         }
 
-        let dataRequest = sessionManager.request(url, method: method, parameters: parameters, encoding:URLEncoding.default)
+        let dataRequest = sessionManager.request(url, method: method, parameters: parameters, encoding: URLEncoding.default)
             .validate()
             .responseJSON(completionHandler: { (response) in
             switch response.result {
@@ -83,7 +83,7 @@ open class WordPressOrgRestApi: NSObject {
     }()
 
     private func makeSessionManager(configuration sessionConfiguration: URLSessionConfiguration) -> Alamofire.SessionManager {
-        var additionalHeaders: [String : AnyObject] = [:]
+        var additionalHeaders: [String: AnyObject] = [:]
         if let userAgent = self.userAgent {
             additionalHeaders["User-Agent"] = userAgent as AnyObject?
         }

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -4,8 +4,8 @@ import Alamofire
 
 /// Class to connect to the XMLRPC API on self hosted sites.
 open class WordPressOrgXMLRPCApi: NSObject {
-    public typealias SuccessResponseBlock = (AnyObject, HTTPURLResponse?) -> ()
-    public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> ()
+    public typealias SuccessResponseBlock = (AnyObject, HTTPURLResponse?) -> Void
+    public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> Void
 
     private let endpoint: URL
     private let userAgent: String?
@@ -52,7 +52,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     }
 
     private func makeSessionManager(configuration sessionConfiguration: URLSessionConfiguration) -> Alamofire.SessionManager {
-        var additionalHeaders: [String : AnyObject] = ["Accept-Encoding": "gzip, deflate" as AnyObject]
+        var additionalHeaders: [String: AnyObject] = ["Accept-Encoding": "gzip, deflate" as AnyObject]
         if let userAgent = self.userAgent {
             additionalHeaders["User-Agent"] = userAgent as AnyObject?
         }
@@ -64,7 +64,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
         }
         sessionManager.delegate.sessionDidReceiveChallengeWithCompletion = sessionDidReceiveChallengeWithCompletion
 
-        let  taskDidReceiveChallengeWithCompletion: ((URLSession, URLSessionTask, URLAuthenticationChallenge,  @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [weak self] session, task, authenticationChallenge, completionHandler in
+        let  taskDidReceiveChallengeWithCompletion: ((URLSession, URLSessionTask, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [weak self] session, task, authenticationChallenge, completionHandler in
             self?.urlSession(session, task: task, didReceive: authenticationChallenge, completionHandler: completionHandler)
         }
         sessionManager.delegate.taskDidReceiveChallengeWithCompletion = taskDidReceiveChallengeWithCompletion
@@ -140,7 +140,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
                            parameters: [AnyObject]?,
                            success: @escaping SuccessResponseBlock,
                            failure: @escaping FailureReponseBlock) -> Progress? {
-        //Encode request
+        // Encode request
         let request: URLRequest
         do {
             request = try requestWithMethod(method, parameters: parameters)
@@ -192,7 +192,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
         progress.isCancellable = true
         DispatchQueue.global().async {
             let fileURL = self.URLForTemporaryFile()
-            //Encode request
+            // Encode request
             let request: URLRequest
             do {
                 request = try self.streamingRequestWithMethod(method, parameters: parameters, usingFileURLForCache: fileURL)
@@ -212,9 +212,9 @@ open class WordPressOrgXMLRPCApi: NSObject {
                         DispatchQueue.main.async {
                             success(responseObject, response.response)
                         }
-                    } catch let error as NSError {                        
+                    } catch let error as NSError {
                         DispatchQueue.main.async {
-                            failure(error, response.response)                            
+                            failure(error, response.response)
                         }
                         return
                     }
@@ -276,7 +276,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
         if (400..<600).contains(httpResponse.statusCode) {
             throw convertError(WordPressOrgXMLRPCApiError.httpErrorStatusCode as NSError, data: originalData, statusCode: httpResponse.statusCode)
         }
-        
+
         if ["application/xml", "text/xml"].filter({ (type) -> Bool in return contentType.hasPrefix(type)}).count == 0 {
             throw convertError(WordPressOrgXMLRPCApiError.responseSerializationFailed as NSError, data: originalData)
         }
@@ -305,7 +305,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyDataString] = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyStatusCode] = statusCode
-            return NSError(domain: error.domain, code: error.code, userInfo: userInfo as? [String : Any])
+            return NSError(domain: error.domain, code: error.code, userInfo: userInfo as? [String: Any])
         }
         return error
     }
@@ -372,7 +372,6 @@ extension WordPressOrgXMLRPCApi {
         }
     }
 }
-
 
 /// Error constants for the WordPress XMLRPC API
 ///     - RequestSerializationFailed:     The serialization of the request failed

--- a/WordPressKit/WordPressRSDParser.swift
+++ b/WordPressKit/WordPressRSDParser.swift
@@ -16,7 +16,6 @@ open class WordPressRSDParser: NSObject, XMLParserDelegate {
         parser.delegate = self
     }
 
-
     func parsedEndpoint() throws -> String? {
         if parser.parse() {
             return endpoint
@@ -32,7 +31,7 @@ open class WordPressRSDParser: NSObject, XMLParserDelegate {
                 didStartElement elementName: String,
                                 namespaceURI: String?,
                                 qualifiedName qName: String?,
-                                              attributes attributeDict: [String : String]) {
+                                              attributes attributeDict: [String: String]) {
         if elementName == "api" {
             if let apiName = attributeDict["name"], apiName == "WordPress" {
                 if let endpoint = attributeDict["apiLink"] {

--- a/WordPressKitTests/AccountServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/AccountServiceRemoteRESTTests.swift
@@ -68,7 +68,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.getAccountDetails(success: { remoteUser in
             XCTAssertEqual(remoteUser?.username, self.username, "The usernames should be identical")
             expect.fulfill()
-        }) { error in
+        }) { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
@@ -80,7 +80,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get account details server error failure")
 
         stubRemoteResponse(meEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getAccountDetails(success: { remoteUser in
+        remote.getAccountDetails(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -101,7 +101,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get account details with bad auth failure")
 
         stubRemoteResponse(meEndpoint, filename: getAccountDetailsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getAccountDetails(success: { remoteUser in
+        remote.getAccountDetails(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -122,10 +122,10 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get account details with invalid json response failure")
 
         stubRemoteResponse(meEndpoint, filename: getAccountDetailsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getAccountDetails(success: { remoteUser in
+        remote.getAccountDetails(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -141,7 +141,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.getBlogsWithSuccess({ blogs in
             XCTAssertEqual(blogs?.count, 3, "There should be 3 blogs here")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -156,7 +156,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.getBlogsWithSuccess({ blogs in
             XCTAssertEqual(blogs?.count, 0, "There should be 0 blogs here")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -168,7 +168,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs server error failure")
 
         stubRemoteResponse(meSitesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getBlogsWithSuccess({ blogs in
+        remote.getBlogsWithSuccess({ _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -189,7 +189,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs auth failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getBlogsWithSuccess({ blogs in
+        remote.getBlogsWithSuccess({ _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -210,10 +210,10 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs with invalid json response failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getBlogsWithSuccess({ blogs in
+        remote.getBlogsWithSuccess({ _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -229,7 +229,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.getVisibleBlogs(success: { blogs in
             XCTAssertEqual(blogs?.count, 3, "There should be 3 blogs here")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -244,7 +244,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.getVisibleBlogs(success: { blogs in
             XCTAssertEqual(blogs?.count, 0, "There should be 0 blogs here")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -256,7 +256,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get visible blogs server error failure")
 
         stubRemoteResponse(meSitesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getVisibleBlogs(success: { blogs in
+        remote.getVisibleBlogs(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -277,7 +277,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get visible blogs auth failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getVisibleBlogs(success: { blogs in
+        remote.getVisibleBlogs(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -298,10 +298,10 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get visible blogs with invalid json response failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getVisibleBlogs(success: { blogs in
+        remote.getVisibleBlogs(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -317,7 +317,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let blogsToChangeVisibility: [NSNumber: Bool] = [NSNumber(value: Int32(siteID)): true]
         remote.updateBlogsVisibility(blogsToChangeVisibility, success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -377,7 +377,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.updateBlogsVisibility(blogsToChangeVisibility, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -393,7 +393,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.isEmailAvailable(email, success: { isAvailable in
             XCTAssertTrue(isAvailable)
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -409,7 +409,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
             if !isAvailable {
                 expect.fulfill()
             }
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
         })
 
@@ -420,7 +420,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Email check server error failure")
 
         stubRemoteResponse(emailEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.isEmailAvailable(email, success: { isAvailable in
+        remote.isEmailAvailable(email, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -443,10 +443,10 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Passwordless check success")
 
         stubRemoteResponse(authOptionsEndpoint, filename: isPasswordlessAccountSuccessMockFilename, contentType: .JavaScript)
-        remote.isPasswordlessAccount(username, success: { passwordless in
+        remote.isPasswordlessAccount(username, success: { _ in
             XCTAssert(true)
             expect.fulfill()
-        }, failure: { error  in
+        }, failure: { _  in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -458,7 +458,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Passwordless check fails with 404")
 
         stubRemoteResponse(authOptionsEndpoint, filename: isPasswordlessAccountNoAccountFoundMockFilename, contentType: .JavaScript, status: 404)
-        remote.isPasswordlessAccount(username, success: { passwordless in
+        remote.isPasswordlessAccount(username, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -484,7 +484,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.isUsernameAvailable(username, success: { isAvailable in
             XCTAssertTrue(isAvailable)
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -499,7 +499,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         remote.isUsernameAvailable(username, success: { isAvailable in
             XCTAssertFalse(isAvailable)
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
         })
 
@@ -510,7 +510,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Username check server error failure")
 
         stubRemoteResponse(usernameEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.isUsernameAvailable(username, success: { isAvailable in
+        remote.isUsernameAvailable(username, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -535,7 +535,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(linkEndpoint, filename: requestLinkSuccessMockFilename, contentType: .ApplicationJSON)
         remote.requestWPComAuthLink(forEmail: email, clientID: "client123", clientSecret: "shhh", source: .default, wpcomScheme: "wordpress", success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })

--- a/WordPressKitTests/AccountSettingsRemoteTests.swift
+++ b/WordPressKitTests/AccountSettingsRemoteTests.swift
@@ -67,7 +67,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(settings.webAddress, self.userURL, "The web addresses should be equal.")
             XCTAssertEqual(settings.primarySiteID, self.siteID, "The primary site ID's should be equal.")
             expect.fulfill()
-        }) { error in
+        }) { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
@@ -79,7 +79,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get account settings server error failure")
 
         stubRemoteResponse(meSettingsEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getSettings(success: { settings in
+        remote.getSettings(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -96,7 +96,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get account settings with bad auth failure")
 
         stubRemoteResponse(meSettingsEndpoint, filename: getAccountSettingsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getSettings(success: { settings in
+        remote.getSettings(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -113,10 +113,10 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get account settings with invalid json response failure")
 
         stubRemoteResponse(meSettingsEndpoint, filename: getAccountSettingsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getSettings(success: { settings in
+        remote.getSettings(success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -132,7 +132,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let change = AccountSettingsChange.email(changedEmail)
         remote.updateSetting(change, success: { () in
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -146,7 +146,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(meSettingsEndpoint, filename: updateSettingsRevertEmailSuccessMockFilename, contentType: .ApplicationJSON)
         remote.updateSetting(.emailRevertPendingChange, success: { () in
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -161,7 +161,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let change = AccountSettingsChange.primarySite(changedSiteID)
         remote.updateSetting(change, success: { () in
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -176,7 +176,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let change = AccountSettingsChange.webAddress(changedUserURL)
         remote.updateSetting(change, success: { () in
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -191,7 +191,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let change = AccountSettingsChange.aboutMe(changedAboutMe)
         remote.updateSetting(change, success: { () in
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -206,7 +206,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let change = AccountSettingsChange.firstName(changedFirstName)
         remote.updateSetting(change, success: { () in
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -221,7 +221,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let change = AccountSettingsChange.lastName(changedLastName)
         remote.updateSetting(change, success: { () in
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -236,7 +236,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         let change = AccountSettingsChange.displayName(changedDisplayName)
         remote.updateSetting(change, success: { () in
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -270,7 +270,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         remote.updateSetting(change, success: { () in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
 
-    /// MARK: - Constants
+    // MARK: - Constants
 
     let siteID = 321
     let rewindID = "33"
@@ -25,7 +25,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     let rewindStatusRestoreInProgressMockFilename = "activity-rewind-status-restore-in-progress.json"
     let rewindStatusRestoreQueuedMockFilename = "activity-rewind-status-restore-queued.json"
 
-    /// MARK: - Properties
+    // MARK: - Properties
 
     var siteActivityEndpoint: String { return "sites/\(siteID)/activity" }
     var siteActivityGroupsEndpoint: String { return "sites/\(siteID)/activity/count/group" }
@@ -35,7 +35,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
     var remoteV1: ActivityServiceRemote_ApiVersion1_0!
     var remote: ActivityServiceRemote!
 
-    /// MARK: - Overridden Methods
+    // MARK: - Overridden Methods
 
     override func setUp() {
         super.setUp()
@@ -56,7 +56,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         NSTimeZone.default = NSTimeZone.local
     }
 
-    /// MARK: - Get Activity Tests
+    // MARK: - Get Activity Tests
 
     func testGetActivitySucceedsOne() {
         let expect = expectation(description: "Get activity for site success one")
@@ -69,7 +69,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                       XCTAssertEqual(activities.count, 8, "The activity count should be 8")
                                       XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
                                       expect.fulfill()
-                                  }, failure: { error in
+                                  }, failure: { _ in
                                       XCTFail("This callback shouldn't get called")
                                       expect.fulfill()
                                   })
@@ -87,7 +87,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                       XCTAssertEqual(activities.count, 20, "The activity count should be 20")
                                       XCTAssertEqual(hasMore, true, "The value of hasMore should be true")
                                       expect.fulfill()
-                                  }, failure: { error in
+                                  }, failure: { _ in
                                       XCTFail("This callback shouldn't get called")
                                       expect.fulfill()
                                   })
@@ -106,7 +106,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                       XCTAssertEqual(activities.count, 19, "The activity count should be 19")
                                       XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
                                       expect.fulfill()
-                                  }, failure: { error in
+                                  }, failure: { _ in
                                       XCTFail("This callback shouldn't get called")
                                       expect.fulfill()
                                   })
@@ -129,7 +129,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                       XCTAssertEqual(activities.count, 19, "The activity count should be 19")
                                       XCTAssertEqual(hasMore, false, "The value of hasMore should be false")
                                       expect.fulfill()
-                                  }, failure: { error in
+                                  }, failure: { _ in
                                       XCTFail("This callback shouldn't get called")
                                       expect.fulfill()
                                   })
@@ -145,9 +145,9 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.getActivityForSite(siteID,
                                   count: 20,
                                   after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
-                                  success: { (activities, hasMore) in
+                                  success: { (_, _) in
                                       expect.fulfill()
-                                  }, failure: { error in
+                                  }, failure: { _ in
                                       XCTFail("This callback shouldn't get called")
                                       expect.fulfill()
                                   })
@@ -161,7 +161,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(siteActivityEndpoint, filename: getActivityAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
         remote.getActivityForSite(siteID,
                                   count: 20,
-                                  success: { (activities, hasMore) in
+                                  success: { (_, _) in
                                       XCTFail("This callback shouldn't get called")
                                       expect.fulfill()
                                   }, failure: { error in
@@ -180,10 +180,10 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(siteActivityEndpoint, filename: getActivityBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
         remote.getActivityForSite(siteID,
                                   count: 20,
-                                  success: { (activities, hasMore) in
+                                  success: { (_, _) in
                                       XCTFail("This callback shouldn't get called")
                                       expect.fulfill()
-                                 }, failure: { error in
+                                 }, failure: { _ in
                                       expect.fulfill()
                                  })
 
@@ -203,7 +203,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                             XCTAssertTrue(groups.contains(where: { $0.key == "rewind" && $0.name == "Backups and Restores" && $0.count == 10}))
                                             expect.fulfill()
                                         },
-                                        failure: { error in
+                                        failure: { _ in
                                             XCTFail("This callback shouldn't get called")
                                             expect.fulfill()
                                         })
@@ -218,10 +218,10 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.getActivityGroupsForSite(siteID,
                                         after: dateFormatter.date(from: "1970-01-01T10:44:00+0000"),
                                         before: dateFormatter.date(from: "1970-01-02T10:44:00+0000"),
-                                        success: { groups in
+                                        success: { _ in
                                             expect.fulfill()
                                         },
-                                        failure: { error in
+                                        failure: { _ in
                                             XCTFail("This callback shouldn't get called")
                                             expect.fulfill()
                                         })
@@ -238,7 +238,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                         success: { groups in
                                             XCTAssertEqual(groups.count, 4, "The activity count should be 4")
                                             expect.fulfill()
-                                        }, failure: { error in
+                                        }, failure: { _ in
                                             XCTFail("This callback shouldn't get called")
                                             expect.fulfill()
                                         })
@@ -251,10 +251,10 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteActivityGroupsEndpoint, filename: getActivityGroupsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
         remote.getActivityGroupsForSite(siteID,
-                                  success: { groups in
+                                  success: { _ in
                                       XCTFail("This callback shouldn't get called")
                                       expect.fulfill()
-                                 }, failure: { error in
+                                 }, failure: { _ in
                                       expect.fulfill()
                                  })
 
@@ -265,20 +265,20 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Trigger restore success")
 
         stubRemoteResponse(restoreEndpoint, filename: restoreSuccessMockFilename, contentType: .ApplicationJSON)
-        
+
         remoteV1.restoreSite(siteID,
                              rewindID: rewindID,
                              success: { (restoreID, jobID) in
                                 XCTAssertEqual(restoreID, self.restoreID)
                                 XCTAssertEqual(jobID, self.jobID)
                                 expect.fulfill()
-                             }, failure: { error in
+                             }, failure: { _ in
                                 XCTFail("This callback shouldn't get called")
                                 expect.fulfill()
                              })
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testRestoreSucceedsWithParameters() {
         let expect = expectation(description: "Trigger restore success")
 
@@ -298,7 +298,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(restoreID, self.restoreID)
                                 XCTAssertEqual(jobID, self.jobID)
                                 expect.fulfill()
-                             }, failure: { error in
+                             }, failure: { _ in
                                 XCTFail("This callback shouldn't get called")
                                 expect.fulfill()
                              })
@@ -334,7 +334,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                    XCTAssertNotNil(rewindStatus.lastUpdated)
                                    XCTAssertNil(rewindStatus.restore)
                                    expect.fulfill()
-                               }, failure: { error in
+                               }, failure: { _ in
                                     XCTFail("This callback shouldn't get called")
                                     expect.fulfill()
                                })
@@ -354,7 +354,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                    XCTAssertEqual(rewindStatus.restore!.progress, 100)
                                    XCTAssertNil(rewindStatus.restore!.failureReason)
                                    expect.fulfill()
-                                }, failure: { error in
+                                }, failure: { _ in
                                    XCTFail("This callback shouldn't get called")
                                    expect.fulfill()
                                 })
@@ -375,7 +375,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                    XCTAssertNotNil(rewindStatus.restore!.failureReason)
                                    XCTAssert(rewindStatus.restore!.failureReason!.count > 0)
                                    expect.fulfill()
-                                }, failure: { error in
+                                }, failure: { _ in
                                    expect.fulfill()
                                 })
         waitForExpectations(timeout: timeout, handler: nil)
@@ -394,7 +394,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                    XCTAssert(rewindStatus.restore!.progress > 0)
                                    XCTAssertNil(rewindStatus.restore!.failureReason)
                                    expect.fulfill()
-                               }, failure: { error in
+                               }, failure: { _ in
                                    expect.fulfill()
                                })
         waitForExpectations(timeout: timeout, handler: nil)
@@ -413,10 +413,9 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                    XCTAssertEqual(rewindStatus.restore!.progress, 0)
                                    XCTAssertNil(rewindStatus.restore!.failureReason)
                                    expect.fulfill()
-                               }, failure: { error in
+                               }, failure: { _ in
                                    expect.fulfill()
                                })
         waitForExpectations(timeout: timeout, handler: nil)
     }
 }
-

--- a/WordPressKitTests/AtomicAuthenticationServiceRemoteTests.swift
+++ b/WordPressKitTests/AtomicAuthenticationServiceRemoteTests.swift
@@ -2,32 +2,32 @@ import XCTest
 @testable import WordPressKit
 
 class AtomicAuthenticationServiceRemoteTests: RemoteTestCase, RESTTestable {
-    
+
     // MARK: - Data
-    
+
     let testSiteID = 2020
-    
+
     // MARK: - Endpoints
-    
+
     let getAuthCookieEndpoint = "sites/2020/atomic-auth-proxy/read-access-cookies"
-    
+
     // MARK: - Mock Response Filenames
-    
+
     let getAuthCookieSuccessMockFilename = "atomic-get-auth-cookie-success.json"
-    
+
     func testGetAuthCookie() {
         let remote = AtomicAuthenticationServiceRemote(wordPressComRestApi: getRestApi())
         let expectation = self.expectation(description: "We should get the requested auth cookie.")
-        
+
         stubRemoteResponse(getAuthCookieEndpoint, filename: getAuthCookieSuccessMockFilename, contentType: .ApplicationJSON)
-        
+
         remote.getAuthCookie(siteID: testSiteID, success: { cookie in
             XCTAssertEqual(cookie.name, "name")
             XCTAssertEqual(cookie.value, "value")
             XCTAssertEqual(cookie.domain, "someblog.wordpress.com")
             XCTAssertEqual(cookie.path, "/")
             XCTAssertEqual(cookie.expiresDate, Date(timeIntervalSince1970: TimeInterval(1583364400)))
-            
+
             expectation.fulfill()
         }, failure: { error in
             XCTFail("❗️ Test failure: \(error)")

--- a/WordPressKitTests/AuthenticatorTests.swift
+++ b/WordPressKitTests/AuthenticatorTests.swift
@@ -56,7 +56,7 @@ class AuthenticatorTests: XCTestCase {
 
     // MARK: - CookieNonce Retrier tests
     func testCookieNonceAuthenticatorRetriesOnlyOnce() {
-        stub(condition: isLoginRequest()) { request in
+        stub(condition: isLoginRequest()) { _ in
             let stubPath = OHPathForFile("wp-admin-post-new.html", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "text/html" as AnyObject])
         }
@@ -64,7 +64,7 @@ class AuthenticatorTests: XCTestCase {
         let authenticator = CookieNonceAuthenticator(username: "user", password: "pass", loginURL: loginURL, adminURL: adminURL)
         let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 401))
         let completionExpectation = expectation(description: "First retry completion is called")
-        var shouldRetry: Bool? = nil
+        var shouldRetry: Bool?
         let completion: (Bool, TimeInterval) -> Void = { (retry, _) in
             shouldRetry = retry
             completionExpectation.fulfill()
@@ -74,8 +74,7 @@ class AuthenticatorTests: XCTestCase {
         wait(for: [completionExpectation], timeout: 2)
         XCTAssertEqual(shouldRetry, true, "CookieNonceAuthenticator should retry request with 401 error if everything goes well")
     }
-    
-    
+
 }
 
 private extension AuthenticatorTests {

--- a/WordPressKitTests/DomainsServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/DomainsServiceRemoteRESTTests.swift
@@ -3,11 +3,11 @@ import XCTest
 @testable import WordPressKit
 
 class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
-    
+
     // MARK: - Constants
-    
+
     let siteID = 12345
-    
+
     let domainServiceAllDomainsMockFilename     = "domain-service-all-domain-types.json"
     let domainServiceAuthFailureMockFilename    = "site-export-auth-failure.json"
     let domainServiceBadJsonFailureMockFilename = "domain-service-bad-json.json"
@@ -17,18 +17,18 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
     let validateDomainContactInformationFail    = "validate-domain-contact-information-response-fail.json"
     let validateDomainContactInformationSuccess = "validate-domain-contact-information-response-success.json"
     let getDomainContactInformationSuccess      = "domain-contact-information-response-success.json"
-    
+
     // MARK: - Properties
-    
+
     var domainsEndpoint: String { return "sites/\(siteID)/domains" }
-    
+
     var remote: DomainsServiceRemote!
-    
+
     // MARK: - Overridden Methods
 
     override func setUp() {
         super.setUp()
-        
+
         remote = DomainsServiceRemote(wordPressComRestApi: getRestApi())
     }
 
@@ -42,41 +42,41 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
 
     func testGetDomainsSucceeds() {
         let expect = expectation(description: "Get domains success")
-        
+
         stubRemoteResponse(domainsEndpoint, filename: domainServiceAllDomainsMockFilename, contentType: .ApplicationJSON)
         remote.getDomainsForSite(siteID, success: { domains in
             XCTAssertNotNil(domains, "Domains array should not be nil.")
             XCTAssertEqual(domains.count, 4, "There should be four domains returned.")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetDomainsWithEmptyResponseSucceeds() {
         let expect = expectation(description: "Get domains with empty response success")
-        
+
         stubRemoteResponse(domainsEndpoint, filename: domainServiceEmptyResponseMockFilename, contentType: .ApplicationJSON)
         remote.getDomainsForSite(siteID, success: { domains in
             XCTAssertNotNil(domains, "Domains array should not be nil.")
             XCTAssertEqual(domains.count, 0, "There should be zero domains returned.")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetDomainsWithServerErrorFails() {
         let expect = expectation(description: "Get domains server error failure")
-        
+
         stubRemoteResponse(domainsEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getDomainsForSite(siteID, success: { domains in
+        remote.getDomainsForSite(siteID, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -85,15 +85,15 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetDomainsWithBadAuthFails() {
         let expect = expectation(description: "Get domains with bad auth failure")
-        
+
         stubRemoteResponse(domainsEndpoint, filename: domainServiceAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getDomainsForSite(siteID, success: { domains in
+        remote.getDomainsForSite(siteID, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -102,24 +102,24 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
     func testGetDomainsWithBadJsonFails() {
         let expect = expectation(description: "Get domains with invalid json response failure")
-        
+
         stubRemoteResponse(domainsEndpoint, filename: domainServiceBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getDomainsForSite(siteID, success: { domains in
+        remote.getDomainsForSite(siteID, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetStatesSuccess() {
         let expect = expectation(description: "Get states for coutry code")
         let countryCode = "US"
@@ -127,20 +127,20 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                            filename: domainServiceSupportedStatesSuccess,
                            contentType: .ApplicationJSON,
                            status: 200)
-        
+
         remote.getStates(for: countryCode,
                          success: { (stateList) in
             XCTAssert(stateList.count == 61)
             XCTAssert(stateList[0].code == "AL")
             XCTAssert(stateList[0].name == "Alabama")
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetStatesSuccessEmpty() {
         let expect = expectation(description: "Get states for coutry code")
         let countryCode = "TR"
@@ -148,12 +148,12 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                            filename: domainServiceSupportedStatesEmpty,
                            contentType: .ApplicationJSON,
                            status: 200)
-        
+
         remote.getStates(for: countryCode,
                          success: { (stateList) in
                             XCTAssert(stateList.count == 0)
                             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
@@ -175,32 +175,32 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 XCTAssert(reponse.messages!.postalCode![0] == "This field is required.")
                 XCTAssert(reponse.messages!.email![0] == "The 'Email' field does not appear to be valid.")
                 expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testValidateDomainContactInformationSuccess() {
         let expect = expectation(description: "Validate domain contact information")
         stubRemoteResponse("me/domain-contact-information/validate",
                            filename: validateDomainContactInformationSuccess,
                            contentType: .ApplicationJSON,
                            status: 200)
-        
+
         remote.validateDomainContactInformation(
             contactInformation: [:],
             domainNames: ["someblog.blog"], success: { (reponse) in
                 XCTAssert(reponse.success)
                 expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetDomainContactInformationSuccess() {
         let expect = expectation(description: "Validate domain contact information")
         stubRemoteResponse("me/domain-contact-information",
@@ -214,7 +214,7 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 XCTAssert(reponse.lastName == nil)
                 XCTAssert(reponse.postalCode == "12345")
                 expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }

--- a/WordPressKitTests/DynamicMockProvider.swift
+++ b/WordPressKitTests/DynamicMockProvider.swift
@@ -10,36 +10,36 @@ protocol DynamicMockProvider {
 internal extension DynamicMockProvider {
     static func randomString(length: Int = 50) -> String {
       let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-      return String((0..<length).map{ _ in letters.randomElement()! })
+      return String((0..<length).map { _ in letters.randomElement()! })
     }
-    
+
     static func randomInt(limit: Int = 1000) -> Int {
-        return Int.random(in:0..<limit)
+        return Int.random(in: 0..<limit)
     }
-    
+
     static func randomURLAsString(length: Int = 50) -> String {
         let host = "https://"
         let tlds = [".com", ".org", ".blog", ".co.nz", ".co.uk", ".edu", ".gov"]
-        
+
         return host + randomString(length: length) + tlds[Int.random(in: 0 ..< (tlds.count-1))]
     }
-    
+
     static func randomURLAsString(withLength length: Int, subDirectories: [String]?, file: String?) -> String {
         var urlString = randomURLAsString(length: length)
-        
+
         if let subDirectories = subDirectories {
             for directory in subDirectories {
                 urlString += "/\(directory)"
             }
         }
-        
+
         if let file = file {
             urlString += "/\(file)"
         }
-        
+
         return urlString
     }
-    
+
     static func randomIntAsString(limit: Int = 10000) -> String {
         return String(randomInt(limit: limit))
     }

--- a/WordPressKitTests/EditorServiceRemoteTests.swift
+++ b/WordPressKitTests/EditorServiceRemoteTests.swift
@@ -57,10 +57,10 @@ class EditorServiceRemoteTests: XCTestCase {
         let expec = expectation(description: "success")
         let response: [String: String] = [
             "editor_mobile_bad": "gutenberg",
-            "editor_web": "gutenberg",
+            "editor_web": "gutenberg"
         ]
 
-        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { editor in
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { _ in
             XCTFail("This should fail")
             expec.fulfill()
         }) { (error) in
@@ -77,9 +77,9 @@ class EditorServiceRemoteTests: XCTestCase {
         let expec = expectation(description: "success")
         let response: [String: String] = [
             "editor_mobile": "guten_BORG",
-            "editor_web": "guten_WRONG",
+            "editor_web": "guten_WRONG"
         ]
-        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { editor in
+        editorServiceRemote.postDesignateMobileEditor(siteID, editor: .gutenberg, success: { _ in
             XCTFail("This should throw an error")
             expec.fulfill()
         }) { (error) in
@@ -167,7 +167,7 @@ class EditorServiceRemoteTests: XCTestCase {
         let expec = expectation(description: "success")
         let errorExpec = NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil)
 
-        editorServiceRemote.getEditorSettings(siteID, success: { (editor) in
+        editorServiceRemote.getEditorSettings(siteID, success: { (_) in
             XCTFail("This call should error")
             expec.fulfill()
         }) { (error) in
@@ -186,7 +186,7 @@ class EditorServiceRemoteTests: XCTestCase {
 
         let response: [String: String] = [
             "1": editor.rawValue,
-            "2": editor.rawValue,
+            "2": editor.rawValue
         ]
 
         let expected: [Int: EditorSettings.Mobile] = [
@@ -197,7 +197,7 @@ class EditorServiceRemoteTests: XCTestCase {
         editorServiceRemote.postDesignateMobileEditorForAllSites(editor, success: {
             XCTAssertEqual($0, expected)
             expec.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This call should NOT error")
             expec.fulfill()
         }
@@ -214,7 +214,7 @@ class EditorServiceRemoteTests: XCTestCase {
 
         let response: [String: String] = [
             "1": editor.rawValue,
-            "2": editor.rawValue,
+            "2": editor.rawValue
         ]
 
         let expected: [Int: EditorSettings.Mobile] = [
@@ -225,7 +225,7 @@ class EditorServiceRemoteTests: XCTestCase {
         editorServiceRemote.postDesignateMobileEditorForAllSites(editor, success: {
             XCTAssertEqual($0, expected)
             expec.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This call should NOT error")
             expec.fulfill()
         }
@@ -241,7 +241,7 @@ extension EditorServiceRemoteTests {
     func mockResponse(forMobile mobile: EditorSettings.Mobile, andWeb web: EditorSettings.Web) -> [String: String] {
         return [
             "editor_mobile": mobile.rawValue,
-            "editor_web": web.rawValue,
+            "editor_web": web.rawValue
         ]
     }
 }

--- a/WordPressKitTests/JSONLoader.swift
+++ b/WordPressKitTests/JSONLoader.swift
@@ -1,8 +1,7 @@
-
 import Foundation
 
 @objc open class JSONLoader: NSObject {
-    public typealias JSONDictionary = Dictionary<String, AnyObject>
+    public typealias JSONDictionary = [String: AnyObject]
 
     /**
     *  @brief      Loads the specified json file name and returns a dictionary representing it.
@@ -39,7 +38,7 @@ import Foundation
     }
 
     private func parseData(_ data: Data) -> JSONDictionary? {
-        let options: JSONSerialization.ReadingOptions = [.mutableContainers , .mutableLeaves]
+        let options: JSONSerialization.ReadingOptions = [.mutableContainers, .mutableLeaves]
 
         do {
             let parseResult = try JSONSerialization.jsonObject(with: data as Data, options: options)

--- a/WordPressKitTests/JetpackBackupServiceRemoteTests.swift
+++ b/WordPressKitTests/JetpackBackupServiceRemoteTests.swift
@@ -7,7 +7,7 @@ class JetpackBackupServiceRemoteTests: RemoteTestCase, RESTTestable {
     let mockRemoteApi = MockWordPressComRestApi()
     var service: JetpackBackupServiceRemote!
 
-    /// MARK: - Constants
+    // MARK: - Constants
 
     let siteID = 1
     let downloadID = 283844

--- a/WordPressKitTests/JetpackServiceRemoteTests.swift
+++ b/WordPressKitTests/JetpackServiceRemoteTests.swift
@@ -7,10 +7,10 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
     let encodedURL = "http%3A%2F%2Fwww.wordpress.com"
     let username = "username"
     let password = "qwertyuiop"
-    
+
     let jetpackRemoteSuccessMockFilename = "jetpack-service-success.json"
     let jetpackRemoteFailureMockFilename = "jetpack-service-failure.json"
-    
+
     let jetpackRemoteErrorUnknownMockFilename = "jetpack-service-error-unknown.json"
     let jetpackRemoteErrorInvalidCredentialsMockFilename = "jetpack-service-error-invalid-credentials.json"
     let jetpackRemoteErrorForbiddenMockFilename = "jetpack-service-error-forbidden.json"
@@ -21,7 +21,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
     let jetpackRemoteErrorActivationInstallMockFilename = "jetpack-service-error-activation-install.json"
     let jetpackRemoteErrorActivationResponseMockFilename = "jetpack-service-error-activation-response.json"
     let jetpackRemoteErrorActivationFailureMockFilename = "jetpack-service-error-activation-failure.json"
-    
+
     let jetpackRemoteCheckSiteSuccessMockFilename = "jetpack-service-check-site-success.json"
     let jetpackRemoteCheckSiteFailureMockFilename = "jetpack-service-check-site-success-no-jetpack.json"
     let jetpackRemoteCheckSiteDataFailureMockFilename = "jetpack-service-check-site-failure-data.json"
@@ -30,33 +30,33 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
     var checkSiteEndpoint: String { return "connect/site-info" }
 
     var remote: JetpackServiceRemote!
-    
+
     // MARK: - Overridden Methods
-    
+
     override func setUp() {
         super.setUp()
-        
+
         remote = JetpackServiceRemote(wordPressComRestApi: getRestApi())
     }
-    
+
     override func tearDown() {
         super.tearDown()
-        
+
         remote = nil
     }
-    
+
     func testCheckSiteHasJetpackSuccess() {
         let expect = expectation(description: "Check if the site has Jetpack success")
-        
+
         stubRemoteResponse(checkSiteEndpoint, filename: jetpackRemoteCheckSiteSuccessMockFilename, contentType: .ApplicationJSON, status: 200)
         remote.checkSiteHasJetpack(URL(string: url)!, success: { (success) in
             XCTAssertTrue(success, "Success should be true")
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
@@ -67,7 +67,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.checkSiteHasJetpack(URL(string: url)!, success: { (success) in
             XCTAssertFalse(success, "Success should be false")
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
@@ -78,14 +78,14 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Check if the site has Jetpack network failure")
 
         stubRemoteResponse(checkSiteEndpoint, filename: jetpackRemoteCheckSiteSuccessMockFilename, contentType: .ApplicationJSON, status: 400)
-        remote.checkSiteHasJetpack(URL(string: url)!, success: { (success) in
+        remote.checkSiteHasJetpack(URL(string: url)!, success: { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }) { (error) in
             XCTAssertNotNil(error, "Error shouldn't be nil")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
@@ -93,7 +93,7 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Check if the site has Jetpack data failure")
 
         stubRemoteResponse(checkSiteEndpoint, filename: jetpackRemoteCheckSiteDataFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.checkSiteHasJetpack(URL(string: url)!, success: { (success) in
+        remote.checkSiteHasJetpack(URL(string: url)!, success: { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }) { (error) in
@@ -103,158 +103,158 @@ class JetpackServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationSuccess() {
         let expect = expectation(description: "Install Jetpack success")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteSuccessMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.installJetpack(url: url, username: username, password: password) { (success, error) in
+        remote.installJetpack(url: url, username: username, password: password) { (success, _) in
             XCTAssertTrue(success, "Success should be true")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationFailure() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.installJetpack(url: url, username: username, password: password) { (success, error) in
+        remote.installJetpack(url: url, username: username, password: password) { (success, _) in
             XCTAssertFalse(success, "Success should be false")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationErrorInvalidCredentials() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorInvalidCredentialsMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .invalidCredentials)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationErrorUnknown() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorUnknownMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .unknown)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationErrorForbidden() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorForbiddenMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .forbidden)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationInstallFailure() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorInstallFailureMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .installFailure)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationInstallResponse() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorInstallResponseMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .installResponseError)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationLoginFailure() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorLoginFailureMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .loginFailure)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationSiteIsJetpack() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorSiteIsJetpackMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .siteIsJetpack)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationActivationInstall() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorActivationInstallMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .activationOnInstallFailure)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationActivationResponse() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorActivationResponseMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .activationResponseError)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testJetpackRemoteInstallationActivationFailure() {
         let expect = expectation(description: "Install Jetpack failure")
-        
+
         stubRemoteResponse(endpoint, filename: jetpackRemoteErrorActivationFailureMockFilename, contentType: .ApplicationJSON, status: 400)
         remote.installJetpack(url: url, username: username, password: password) { (success, error) in
             XCTAssertFalse(success, "Success should be false")
             XCTAssertEqual(error?.type, .activationFailure)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
 }

--- a/WordPressKitTests/MediaServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/MediaServiceRemoteRESTTests.swift
@@ -36,7 +36,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
 
         let id = 1
         let response = ["ID": id]
-        var remoteMedia: RemoteMedia? = nil
+        var remoteMedia: RemoteMedia?
         mediaServiceRemote.getMediaWithID(id as NSNumber, success: {
             remoteMedia = $0
             }, failure: nil)
@@ -47,7 +47,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
 
     func testCreateMediaPath() {
 
-        var progress: Progress? = nil
+        var progress: Progress?
         let expectedPath = mediaServiceRemote.path(forEndpoint: "sites/\(siteID)/media/new", withVersion: ._1_1)
         let media = mockRemoteMedia()
         mediaServiceRemote.uploadMedia(media, progress: &progress, success: nil, failure: nil)
@@ -59,8 +59,8 @@ class MediaServiceRemoteRESTTests: XCTestCase {
 
         let response = ["media": [["ID": 1]]]
         let media = mockRemoteMedia()
-        var progress: Progress? = nil
-        var remoteMedia: RemoteMedia? = nil
+        var progress: Progress?
+        var remoteMedia: RemoteMedia?
         mediaServiceRemote.uploadMedia(media, progress: &progress, success: {
             remoteMedia = $0
             }, failure: nil)
@@ -72,7 +72,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
 
         let response = ["errors": ["some error"]]
         let media = mockRemoteMedia()
-        var progress: Progress? = nil
+        var progress: Progress?
         var errorDescription = ""
         mediaServiceRemote.uploadMedia(media, progress: &progress, success: nil, failure: {
             errorDescription = ($0?.localizedDescription)!
@@ -83,7 +83,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
 
     func testCreateMultipleMedia() {
 
-        let response = ["media": [["ID": 1],["ID": 1]]]
+        let response = ["media": [["ID": 1], ["ID": 1]]]
         let media = [mockRemoteMedia(), mockRemoteMedia()]
         var remoteMedia: [RemoteMedia]?
         mediaServiceRemote.uploadMedia(media, requestEnqueued: { _ in }, success: {
@@ -132,19 +132,19 @@ class MediaServiceRemoteRESTTests: XCTestCase {
         let response = ["alt": alt]
         let media = mockRemoteMedia()
         media.alt = alt
-        var remoteMedia: RemoteMedia? = nil
+        var remoteMedia: RemoteMedia?
         mediaServiceRemote.update(media, success: {
             remoteMedia = $0
         }, failure: nil)
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertEqual(remoteMedia?.alt, alt)
     }
-    
+
     func testUpdateMedia() {
 
         let response = ["ID": 1]
         let media = mockRemoteMedia()
-        var remoteMedia: RemoteMedia? = nil
+        var remoteMedia: RemoteMedia?
         mediaServiceRemote.update(media, success: {
             remoteMedia = $0
             }, failure: nil)
@@ -242,7 +242,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
         let height = 321
         let width = 432
 
-        let jsonDictionary: [String : Any] = ["ID": id,
+        let jsonDictionary: [String: Any] = ["ID": id,
                                                       "URL": url,
                                                       "guid": guid,
                                                       "date": date,
@@ -288,7 +288,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
         let height = 321
         let width = 432
 
-        let jsonDictionary1: [String : Any] = ["ID": id,
+        let jsonDictionary1: [String: Any] = ["ID": id,
                                               "URL": url,
                                               "guid": guid,
                                               "date": date,
@@ -302,7 +302,7 @@ class MediaServiceRemoteRESTTests: XCTestCase {
                                               "height": height,
                                               "width": width]
 
-        let jsonDictionary2: [String : Any] = ["ID": id2,
+        let jsonDictionary2: [String: Any] = ["ID": id2,
                                                "URL": url,
                                                "guid": guid,
                                                "date": date,
@@ -316,7 +316,6 @@ class MediaServiceRemoteRESTTests: XCTestCase {
                                                "height": height,
                                                "width": width]
         let jsonArray = [jsonDictionary1, jsonDictionary2]
-
 
         let remoteMediaArray: [RemoteMedia] = MediaServiceRemoteREST.remoteMedia(fromJSONArray: jsonArray) as! [RemoteMedia]
 

--- a/WordPressKitTests/MockPluginDirectoryEntryProvider.swift
+++ b/WordPressKitTests/MockPluginDirectoryEntryProvider.swift
@@ -30,7 +30,7 @@ struct MockPluginDirectoryProvider {
 
         return description
     }
-    
+
     static func getJetpackFAQHTML() -> String? {
         let loader = JSONLoader()
         let pluginDirectoryJson = loader.loadFile("plugin-directory-jetpack", type: "json")!
@@ -75,5 +75,3 @@ struct MockPluginDirectoryProvider {
     }
 
 }
-
-

--- a/WordPressKitTests/MockPluginStateProvider.swift
+++ b/WordPressKitTests/MockPluginStateProvider.swift
@@ -19,7 +19,6 @@ struct MockPluginStateProvider: DynamicMockProvider {
         return jetpackDevPlugin
     }
 
-    
     static func getDynamicValuePluginState(setToActive active: Bool = false, autoupdate: Bool = false, automanaged: Bool = false, updateState: PluginState.UpdateState = PluginState.UpdateState.updated) -> PluginState {
         return PluginState(id: MockPluginStateProvider.getDynamicPluginID(),
                            slug: MockPluginStateProvider.randomIntAsString(limit: 25),
@@ -34,7 +33,7 @@ struct MockPluginStateProvider: DynamicMockProvider {
                            settingsURL: nil
         )
     }
-    
+
     static func getDynamicPluginStateJSONResponse() throws -> Data {
         let slug = randomString(length: 10)
 
@@ -52,7 +51,7 @@ struct MockPluginStateProvider: DynamicMockProvider {
 
         let jsonEncoder = JSONEncoder()
         let data = try jsonEncoder.encode(pluginState)
-        
+
         return data
     }
 
@@ -76,19 +75,19 @@ struct MockPluginStateProvider: DynamicMockProvider {
 
             return data
         }
-    
+
     private static func getDynamicPluginID() -> String {
         let id = MockPluginStateProvider.randomString(length: 10)
-        
+
         return id + "/" + id
     }
-    
+
     static func getEncodedUpdateState(state: PluginState.UpdateState) throws -> Data {
         var data = Data()
         let encoder = JSONEncoder()
 
         data = try encoder.encode(state)
-        
+
         return data
     }
 
@@ -128,4 +127,3 @@ struct EncodableMockPluginState: Encodable {
         case settingsURL = "Settings"
     }
 }
-

--- a/WordPressKitTests/MockServiceRequest.swift
+++ b/WordPressKitTests/MockServiceRequest.swift
@@ -1,12 +1,11 @@
 import Foundation
 @testable import WordPressKit
 
-
 struct MockServiceRequest: ServiceRequest {
     var path: String {
         return "localhost/path/"
     }
-    
+
     var apiVersion: ServiceRemoteWordPressComRESTApiVersion {
         return ._1_2
     }

--- a/WordPressKitTests/MockWordPressComRestApi.swift
+++ b/WordPressKitTests/MockWordPressComRestApi.swift
@@ -30,7 +30,7 @@ class MockWordPressComRestApi: WordPressComRestApi {
     }
 
     override func multipartPOST(_ URLString: String,
-                                parameters: [String : AnyObject]?,
+                                parameters: [String: AnyObject]?,
                                 fileParts: [FilePart],
                                 requestEnqueued: RequestEnqueuedBlock? = nil,
                                 success: @escaping SuccessResponseBlock,

--- a/WordPressKitTests/NotificationSyncServiceRemoteTests.swift
+++ b/WordPressKitTests/NotificationSyncServiceRemoteTests.swift
@@ -5,33 +5,33 @@ import XCTest
 // MARK: - NotificationSyncServiceRemoteTests
 //
 class NotificationSyncServiceRemoteTests: RemoteTestCase, RESTTestable {
-    
+
     // MARK: - Constants
-    
+
     let notificationsEndpoint       = "notifications/"
     let notificationsReadEndpoint   = "notifications/read"
     let notificationsSeenEndpoint   = "notifications/seen"
-    
+
     let notificationServiceLoadAllMockFilename      = "notifications-load-all.json"
     let notificationServiceLoadHashMockFilename     = "notifications-load-hash.json"
     let notificationServiceMarkReadMockFilename     = "notifications-mark-as-read.json"
     let notificationServiceLastSeenMockFilename     = "notifications-last-seen.json"
 
     // MARK: - Properties
-    
+
     var remote: NotificationSyncServiceRemote!
 
     // MARK: - Overriden Methods
-    
+
     override func setUp() {
         super.setUp()
-        
+
         remote = NotificationSyncServiceRemote(wordPressComRestApi: getRestApi())
     }
 
     override func tearDown() {
         super.tearDown()
-        
+
         remote = nil
     }
 
@@ -64,10 +64,10 @@ class NotificationSyncServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testLoadNotesWithServerErrorFails() {
         let expect = expectation(description: "Load all notifications server error failure")
-        
+
         stubRemoteResponse(notificationsEndpoint, data: Data(), contentType: .NoContentType, status: 500)
         remote.loadNotes { error, notes in
             guard let error = error as NSError? else {
@@ -124,7 +124,7 @@ class NotificationSyncServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertNil(error)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
 

--- a/WordPressKitTests/PeopleServiceRemoteTests.swift
+++ b/WordPressKitTests/PeopleServiceRemoteTests.swift
@@ -144,7 +144,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
                            contentType: .ApplicationJSON)
         remote.deleteUser(siteID, userID: userID, success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -176,7 +176,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.deleteUser(siteID, userID: userID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -227,7 +227,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
                            contentType: .ApplicationJSON)
         remote.deleteFollower(siteID, userID: followerID, success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -259,7 +259,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.deleteFollower(siteID, userID: followerID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -276,7 +276,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.deleteViewer(siteID, userID: viewerID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -290,7 +290,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
                            contentType: .ApplicationJSON)
         remote.deleteViewer(siteID, userID: viewerID, success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -339,7 +339,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.deleteViewer(siteID, userID: viewerID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -357,7 +357,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertFalse(roles.isEmpty, "The returned roles array should not be empty")
             XCTAssertTrue(roles.count == 4, "There should be 4 roles returned")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -369,7 +369,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get site roles with server error failure")
 
         stubRemoteResponse(siteRolesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getUserRoles(siteID, success: { roles in
+        remote.getUserRoles(siteID, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -386,7 +386,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get site roles with bad auth failure")
 
         stubRemoteResponse(siteRolesEndpoint, filename: getRolesBadAuthMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getUserRoles(siteID, success: { roles in
+        remote.getUserRoles(siteID, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -403,10 +403,10 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get site roles with invalid json response failure")
 
         stubRemoteResponse(siteRolesEndpoint, filename: getRolesBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getUserRoles(siteID, success: { roles in
+        remote.getUserRoles(siteID, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -421,7 +421,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.updateUserRole(siteID, userID: userID, newRole: change, success: { updatedPerson in
             XCTAssertEqual(updatedPerson.role, change, "The returned user's role should be the same as the updated role.")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -434,10 +434,10 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteUnknownUserEndpoint, filename: updateRoleUnknownUserFailureMockFilename, contentType: .ApplicationJSON, status: 404)
         let change = "administrator"
-        remote.updateUserRole(siteID, userID: invalidUserID, newRole: change, success: { updatedPerson in
+        remote.updateUserRole(siteID, userID: invalidUserID, newRole: change, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -449,10 +449,10 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(unknownSiteUserEndpoint, filename: updateRoleUnknownSiteFailureMockFilename, contentType: .ApplicationJSON, status: 403)
         let change = "administrator"
-        remote.updateUserRole(invalidSiteID, userID: userID, newRole: change, success: { updatedPerson in
+        remote.updateUserRole(invalidSiteID, userID: userID, newRole: change, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -464,7 +464,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteUserEndpoint, data: Data(), contentType: .NoContentType, status: 500)
         let change = "administrator"
-        remote.updateUserRole(siteID, userID: userID, newRole: change, success: { updatedPerson in
+        remote.updateUserRole(siteID, userID: userID, newRole: change, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -482,10 +482,10 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         stubRemoteResponse(siteUserEndpoint, filename: updateRoleBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
         let change = "administrator"
-        remote.updateUserRole(siteID, userID: userID, newRole: change, success: { updatedPerson in
+        remote.updateUserRole(siteID, userID: userID, newRole: change, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -501,7 +501,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.sendInvitation(siteID, usernameOrEmail: invalidUsername, role: "follower", message: "", success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -514,7 +514,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(newInviteEndpoint, filename: sendSuccessMockFilename, contentType: .ApplicationJSON)
         remote.sendInvitation(siteID, usernameOrEmail: validUsername, role: "follower", message: "", success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -529,7 +529,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.validateInvitation(siteID, usernameOrEmail: invalidUsername, role: "follower", success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -542,7 +542,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(validateInviteEndpoint, filename: validationSuccessMockFilename, contentType: .ApplicationJSON)
         remote.validateInvitation(siteID, usernameOrEmail: validUsername, role: "follower", success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -559,7 +559,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertFalse(invites.isEmpty, "The returned array should not be empty")
             XCTAssertTrue(invites.count == 5, "There should be 5 invites returned")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -576,7 +576,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertFalse(invites.isEmpty, "The returned array should not be empty")
             XCTAssertTrue(invites.count == 5, "There should be 5 invites returned")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -593,7 +593,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertFalse(invites.isEmpty, "The returned array should not be empty")
             XCTAssertTrue(invites.count == 5, "There should be 5 invites returned")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -609,7 +609,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.disableInviteLinks(siteID, success: { invites in
             XCTAssertTrue(invites.isEmpty, "The returned array should be empty")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })

--- a/WordPressKitTests/PlanServiceRemoteTests.swift
+++ b/WordPressKitTests/PlanServiceRemoteTests.swift
@@ -15,7 +15,6 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
     let getWpcomPlansSuccessMockFilename                 = "plans-mobile-success.json"
     let getPlansMeSitesSuccessMockFilename               = "plans-me-sites-success.json"
 
-
     // MARK: - Properties
 
     var sitePlansEndpoint: String { return "sites/\(siteID)/plans" }
@@ -24,7 +23,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     var remote: PlanServiceRemote!
     var remoteV3: PlanServiceRemote_ApiVersion1_3!
-    
+
     // MARK: - Overridden Methods
 
     override func setUp() {
@@ -44,26 +43,26 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     func testGetPlansSucceeds_ApiVersion1_3() {
         let expect = expectation(description: "Get plans for site success")
-        
+
         stubRemoteResponse(sitePlansEndpoint, filename: getPlansSuccessMockFilename_ApiVersion1_3, contentType: .ApplicationJSON)
-        
+
         remoteV3.getPlansForSite(siteID, success: { sitePlans in
             XCTAssertEqual(sitePlans.activePlan.hasDomainCredit, true, "Active plan should have domain credit")
             XCTAssertEqual(sitePlans.availablePlans.count, 7, "The availible plans count should be 7")
             expect.fulfill()
-        }) { error in
+        }) { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetPlansWithEmptyResponseArrayFails_ApiVersion1_3() {
         let expect = expectation(description: "Get plans with empty response array success")
-        
+
         stubRemoteResponse(sitePlansEndpoint, filename: getPlansEmptyFailureMockFilename_ApiVersion1_3, contentType: .ApplicationJSON)
-        remoteV3.getPlansForSite(siteID, success: { sitePlans in
+        remoteV3.getPlansForSite(siteID, success: { _ in
             XCTFail("The site should always return plans.")
             expect.fulfill()
         }, failure: { error in
@@ -72,21 +71,21 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error.code, PlanServiceRemote.ResponseError.noActivePlan.rawValue, "The error code should be 2 - no active plan")
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetPlansWithBadJsonFails_ApiVersion1_3() {
         let expect = expectation(description: "Get plans with invalid json response failure")
-        
+
         stubRemoteResponse(sitePlansEndpoint, filename: getPlansBadJsonFailureMockFilename_ApiVersion1_3, contentType: .ApplicationJSON, status: 200)
-        remoteV3.getPlansForSite(siteID, success: { sitePlans in
+        remoteV3.getPlansForSite(siteID, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
@@ -103,7 +102,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(plans.groups.count, 2, "The number of groups returned should be 2.")
 
             expect.fulfill()
-        }) { error in
+        }) { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
@@ -115,7 +114,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get plans server error failure")
 
         stubRemoteResponse(plansMobileEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getWpcomPlans({ plans in
+        remote.getWpcomPlans({ _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -132,10 +131,10 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get plans with invalid json response failure")
 
         stubRemoteResponse(plansMobileEndpoint, filename: getPlansBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getWpcomPlans({ plans in
+        remote.getWpcomPlans({ _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -180,7 +179,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         }
         """
         let data = str.data(using: .utf8)!
-        let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as! [String : AnyObject]
+        let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as! [String: AnyObject]
         XCTAssertNotNil(remote.parseWpcomPlan(json))
     }
 
@@ -192,7 +191,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         }
         """
         let data = str.data(using: .utf8)!
-        let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as! [String : AnyObject]
+        let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as! [String: AnyObject]
         XCTAssertNotNil(remote.parsePlanGroup(json))
     }
 
@@ -205,7 +204,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         }
         """
         let data = str.data(using: .utf8)!
-        let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as! [String : AnyObject]
+        let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as! [String: AnyObject]
         XCTAssertNotNil(remote.parsePlanFeature(json))
     }
 
@@ -216,7 +215,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         }
         """
         let data = str.data(using: .utf8)!
-        let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as! [String : AnyObject]
+        let json = (try? JSONSerialization.jsonObject(with: data, options: [])) as! [String: AnyObject]
         XCTAssertNil(remote.parseWpcomPlan(json))
         XCTAssertNil(remote.parsePlanGroup(json))
         XCTAssertNil(remote.parsePlanFeature(json))
@@ -231,7 +230,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.getPlanDescriptionsForAllSitesForLocale("en", success: { (response) in
             XCTAssertEqual(response.count, 5)
             expect.fulfill()
-        }) { error in
+        }) { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
@@ -243,7 +242,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get plan descriptions failure")
         stubRemoteResponse(meSitesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
 
-        remote.getPlanDescriptionsForAllSitesForLocale("en", success: { (response) in
+        remote.getPlanDescriptionsForAllSitesForLocale("en", success: { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }) { error in
@@ -270,13 +269,12 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         }
         """
         let data1 = str1.data(using: .utf8)!
-        let json1 = (try? JSONSerialization.jsonObject(with: data1, options: [])) as! [String : AnyObject]
+        let json1 = (try? JSONSerialization.jsonObject(with: data1, options: [])) as! [String: AnyObject]
 
         let result = remote.parsePlanDescriptionForSite(json1)!
 
         XCTAssertEqual(result.siteID, 1)
         XCTAssertTrue(result.plan.name.contains(jetpackFlag))
-
 
         let str2 = """
         {
@@ -289,7 +287,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
         }
         """
         let data2 = str2.data(using: .utf8)!
-        let json2 = (try? JSONSerialization.jsonObject(with: data2, options: [])) as! [String : AnyObject]
+        let json2 = (try? JSONSerialization.jsonObject(with: data2, options: [])) as! [String: AnyObject]
 
         let result2 = remote.parsePlanDescriptionForSite(json2)!
 

--- a/WordPressKitTests/PluginDirectoryTests.swift
+++ b/WordPressKitTests/PluginDirectoryTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import WordPressKit
 
 class PluginDirectoryTests: XCTestCase {
-    
+
     func testPluginDirectoryEntryDecodingJetpack() {
-        let data = try! MockPluginDirectoryProvider.getPluginDirectoryMockData(with: "plugin-directory-jetpack", sender: type(of:self))
+        let data = try! MockPluginDirectoryProvider.getPluginDirectoryMockData(with: "plugin-directory-jetpack", sender: type(of: self))
         let endpoint = PluginDirectoryGetInformationEndpoint(slug: "jetpack")
 
         do {
@@ -13,7 +13,7 @@ class PluginDirectoryTests: XCTestCase {
             XCTAssertEqual(plugin.slug, "jetpack")
             XCTAssertEqual(plugin.version, "5.5.1")
             XCTAssertEqual(plugin.author, "Automattic")
-            XCTAssertEqual(plugin.authorURL, URL(string:"https://jetpack.com"))
+            XCTAssertEqual(plugin.authorURL, URL(string: "https://jetpack.com"))
             XCTAssertNotNil(plugin.icon)
             XCTAssertNotNil(plugin.banner)
 
@@ -72,7 +72,7 @@ class PluginDirectoryTests: XCTestCase {
 
         XCTAssertThrowsError(try endpoint.validate(request: request, response: response, data: "null".data(using: .utf8)))
     }
-    
+
     func testValidatePluginDirectoryFeedResponseSucceeds() throws {
         let endpoint = PluginDirectoryFeedEndpoint(feedType: .popular)
 
@@ -81,7 +81,7 @@ class PluginDirectoryTests: XCTestCase {
 
         XCTAssertNoThrow(try endpoint.validate(request: request, response: response, data: "null".data(using: .utf8)))
     }
-    
+
     func testValidatePluginDirectoryFeedResponseFails() {
         let endpoint = PluginDirectoryFeedEndpoint(feedType: .popular)
 
@@ -154,7 +154,7 @@ class PluginDirectoryTests: XCTestCase {
             XCTFail("Failed decoding plugin \(error)")
         }
     }
-    
+
     func testPluginDirectoryFeedPageDecoderSucceeds() {
         let data = try! MockPluginDirectoryProvider.getPluginDirectoryMockData(with: "plugin-directory-new", sender: type(of: self))
 
@@ -168,16 +168,16 @@ class PluginDirectoryTests: XCTestCase {
 
             let slugs = response.plugins.map { $0.slug }
             XCTAssertEqual(response.pageMetadata.pluginSlugs, slugs)
-            
+
         } catch {
             XCTFail("Failed decoding plugin \(error)")
         }
     }
-    
+
     func testPluginFeedPageDirectoryEquatable() {
         let data = try! MockPluginDirectoryProvider.getPluginDirectoryMockData(with: "plugin-directory-jetpack", sender: type(of: self))
         let endpoint = PluginDirectoryGetInformationEndpoint(slug: "jetpack")
-        
+
         do {
             let response = try endpoint.parseResponse(data: data)
             let sameResponse = try endpoint.parseResponse(data: data)
@@ -192,7 +192,6 @@ class PluginDirectoryTests: XCTestCase {
         let jetpackEndpoint = PluginDirectoryGetInformationEndpoint(slug: "jetpack")
         let jetpackBetaData = try! MockPluginDirectoryProvider.getPluginDirectoryMockData(with: "plugin-directory-jetpack-beta", sender: type(of: self))
         let jetpackBetaEndpoint = PluginDirectoryGetInformationEndpoint(slug: "jetpack-beta")
-
 
         do {
             let jetpackResponse = try jetpackEndpoint.parseResponse(data: jetpackData)
@@ -209,11 +208,11 @@ class PluginDirectoryTests: XCTestCase {
 
         let newData = try! MockPluginDirectoryProvider.getPluginDirectoryMockData(with: "plugin-directory-new", sender: type(of: self))
         let newEndpoint = PluginDirectoryFeedEndpoint(feedType: .newest)
-        
+
         do {
             let popularPluginFeedPage = try popularEndpoint.parseResponse(data: popularData)
             let newestPluginFeedPage = try newEndpoint.parseResponse(data: newData)
-            
+
             XCTAssertFalse(popularPluginFeedPage == newestPluginFeedPage)
         } catch {
             XCTFail("Couldn't decode feed pages")
@@ -228,7 +227,6 @@ class PluginDirectoryTests: XCTestCase {
         XCTAssertEqual(plugin.installationText, expectedInstallationText)
         XCTAssertEqual(plugin.faqText, expectedFAQText)
     }
-
 
     func testDirectoryEntryStarRatingOutput() {
         let plugin = MockPluginDirectoryProvider.getPluginDirectoryEntry()
@@ -252,7 +250,7 @@ class PluginDirectoryTests: XCTestCase {
     func testInitFromResponseObjectOutput() {
         let jetpackPluginMockPath = Bundle(for: type(of: self)).path(forResource: "plugin-directory-jetpack", ofType: "json")!
         let json = JSONLoader().loadFile(jetpackPluginMockPath) as AnyObject
-        guard let response = json as? [String : AnyObject] else {
+        guard let response = json as? [String: AnyObject] else {
             return
         }
 
@@ -269,7 +267,7 @@ class PluginDirectoryTests: XCTestCase {
         }
     }
 
-    func testEcodeableDecodeableReturnsCorrectly(){
+    func testEcodeableDecodeableReturnsCorrectly() {
         let plugin = MockPluginDirectoryProvider.getPluginDirectoryEntry()
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
@@ -298,7 +296,7 @@ class PluginDirectoryTests: XCTestCase {
 
         do {
             XCTAssertNoThrow(try encoder.encode(plugin), "Could not encode plugin to Json")
-            let _ = try encoder.encode(plugin)
+            _ = try encoder.encode(plugin)
         } catch {
             XCTFail("Convert to JSON Failed")
         }

--- a/WordPressKitTests/PluginServiceRemoteTests.swift
+++ b/WordPressKitTests/PluginServiceRemoteTests.swift
@@ -20,12 +20,11 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
     let postPluginInstallGenericError = "plugin-install-generic-error.json"
     let postPluginModifyMalformed = "plugin-modify-malformed-response.json"
     let getPluginDirectoryNew = "plugin-directory-new.json"
-    
+
     let remoteFeaturedPluginsEndpoint = "wpcom/v2/plugins/featured"
     var sitePluginsEndpoint: String {
         return "sites/\(siteID)/plugins"
     }
-    
 
     var remote: PluginServiceRemote!
 
@@ -56,7 +55,7 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertTrue(sitePlugins.capabilities.autoupdate)
             XCTAssertTrue(sitePlugins.capabilities.modify)
             expect.fulfill()
-        }, failure: { (error) in
+        }, failure: { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -82,7 +81,7 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetSitePluginFailsMalformed() {
         let expect = expectation(description: "Get site plugins fails")
 
@@ -101,178 +100,178 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetFeaturedPluginSucceeds() {
         let expect = expectation(description: "Get Featured Plugins Succeeds")
-        
+
         stubRemoteResponse(remoteFeaturedPluginsEndpoint,
                            filename: getFeaturedPluginsMockFile,
                            contentType: .ApplicationJSON)
-        
+
         remote.getFeaturedPlugins(success: { (featuredPlugins) in
             XCTAssertEqual(featuredPlugins.count, 6)
             XCTAssertEqual(featuredPlugins[1].name, "Yoast SEO")
             XCTAssertEqual(featuredPlugins[3].slug, "tinymce-advanced")
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetFeaturedPluginFailsMalformedJSON() {
         let expect = expectation(description: "Get Featured Plugins Fails")
-        
+
         stubRemoteResponse(remoteFeaturedPluginsEndpoint,
                            filename: getFeaturedPluginsMalformedMockFile,
                            contentType: .ApplicationJSON)
-        
-        remote.getFeaturedPlugins(success: { (featuredPlugins) in
+
+        remote.getFeaturedPlugins(success: { (_) in
             XCTFail("Callback should not get called")
             expect.fulfill()
         }) { (error) in
             let error = error as NSError
             let expected = WordPressComRestApiError.responseSerializationFailed as NSError
             XCTAssertEqual(error, expected)
-            
+
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetFeaturedPluginFailsInvalidResponse() {
         let expect = expectation(description: "Get Featured Plugins Fails")
-        
+
         stubRemoteResponse(remoteFeaturedPluginsEndpoint,
                            filename: getFeaturedPluginsInvalidResponse,
                            contentType: .ApplicationJSON)
-        
-        remote.getFeaturedPlugins(success: { (featuredPlugins) in
+
+        remote.getFeaturedPlugins(success: { (_) in
             XCTFail("Callback should not get called")
             expect.fulfill()
         }) { (error) in
             let error = error as NSError
             let expected = PluginServiceRemote.ResponseError.decodingFailure as NSError
             XCTAssertEqual(error, expected)
-            
+
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testGetFeaturedPluginFailsIncorrectResponse() {
         let expect = expectation(description: "Get Featured Plugins Fails")
-        
+
         stubRemoteResponse(remoteFeaturedPluginsEndpoint,
                            filename: getPluginsErrorMockFilename,
                            contentType: .ApplicationJSON)
-        
-        remote.getFeaturedPlugins(success: { (featuredPlugins) in
+
+        remote.getFeaturedPlugins(success: { (_) in
             XCTFail("Callback should not get called")
             expect.fulfill()
         }) { (error) in
             let error = error as NSError
             let expected = PluginServiceRemote.ResponseError.decodingFailure as NSError
             XCTAssertEqual(error, expected)
-            
+
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testPluginIDEncoding() {
         let pluginID = "jetpack/jetpack"
         let encoded = remote.encoded(pluginID: pluginID)
-        
+
         let escapedPluginID = "jetpack%2Fjetpack"
-        
+
         XCTAssertEqual(encoded, escapedPluginID)
     }
-    
+
     func testUpdatePluginUpToDate() {
         let expect = expectation(description: "Plugin is already up to date")
-        
+
         preparePostStubRemoteResponseWith(plugID: "jetpack/jetpack",
                                       pluginSlug: "jetpack",
                                       endpointAction: .update,
                                       responseFile: postRemotePluginUpdateJetpack)
-        
+
         remote.updatePlugin(pluginID: "jetpack/jetpack", siteID: siteID, success: { (pluginState) in
             XCTAssertEqual(pluginState.slug, "jetpack")
             XCTAssertEqual(pluginState.name, "Jetpack by WordPress.com")
             XCTAssertEqual(pluginState.version, "8.6.1")
             XCTAssertEqual(pluginState.autoupdate, false)
             XCTAssertEqual(pluginState.updateState, PluginState.UpdateState.updated)
-            
+
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testUpdatePluginNeedsUpdate() {
         let expect = expectation(description: "Plugin is updated successfully")
-        
+
         preparePostStubRemoteResponseWith(plugID: "gutenberg/gutenberg",
                                       pluginSlug: "gutenberg",
                                       endpointAction: .update,
                                       responseFile: postRemotePluginUpdateGutenberg)
-        
+
         remote.updatePlugin(pluginID: "gutenberg/gutenberg", siteID: siteID, success: { (pluginState) in
             XCTAssertEqual(pluginState.slug, "gutenberg")
             XCTAssertEqual(pluginState.name, "Gutenberg")
             XCTAssertEqual(pluginState.version, "7.2.1")
             XCTAssertEqual(pluginState.autoupdate, false)
             XCTAssertEqual(pluginState.updateState, PluginState.UpdateState.available("8.3.0"))
-            
+
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testUpdatePluginAuthFails() {
         let expect = expectation(description: "Plugin is updated successfully")
-        
+
         preparePostStubRemoteResponseWith(plugID: "gutenberg/gutenberg",
                                       pluginSlug: "gutenberg",
                                       endpointAction: .update,
                                       responseFile: postRemotePluginUpdateAuthFailure)
-        
-        remote.updatePlugin(pluginID: "gutenberg/gutenberg", siteID: siteID, success: { (pluginState) in
+
+        remote.updatePlugin(pluginID: "gutenberg/gutenberg", siteID: siteID, success: { (_) in
             XCTFail("This callback should not be called")
             expect.fulfill()
         }) { (error) in
             let error = error as NSError
             let expected = PluginServiceRemote.ResponseError.unauthorized as NSError
-            
+
             XCTAssertEqual(error, expected)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testUpdatePluginFailsMalformedJSON() {
         let expect = expectation(description: "Plugin is updated successfully")
-        
+
         preparePostStubRemoteResponseWith(plugID: "gutenberg/gutenberg",
                                       pluginSlug: "gutenberg",
                                       endpointAction: .update,
                                       responseFile: postRemotePluginUpdateMalformed)
-        
-        remote.updatePlugin(pluginID: "gutenberg/gutenberg", siteID: siteID, success: { (pluginState) in
+
+        remote.updatePlugin(pluginID: "gutenberg/gutenberg", siteID: siteID, success: { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }) { (error) in
@@ -281,41 +280,40 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error, expected)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testInstallPluginSucceeds() {
         let expect = expectation(description: "Plugin install succeeds")
         preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                       pluginSlug: "code-snippets",
                                       endpointAction: .install,
                                       responseFile: postPluginInstallSucceeds)
-        
-        
-        remote.install(pluginSlug: "code-snippets",siteID: siteID, success: { (pluginState) in
+
+        remote.install(pluginSlug: "code-snippets", siteID: siteID, success: { (pluginState) in
             XCTAssertEqual(pluginState.slug, "code-snippets")
             XCTAssertEqual(pluginState.name, "Code Snippets")
             XCTAssertEqual(pluginState.version, "2.14.0")
             XCTAssertEqual(pluginState.autoupdate, false)
-            
+
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testInstallPluginAlreadyInstalled() {
         let expect = expectation(description: "Plugin install fails.  Plugin already installed")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .install,
                                              responseFile: postPluginInstallAlreadyInstalled)
-        
-        remote.install(pluginSlug: "code-snippets",siteID: siteID, success: { (pluginState) in
+
+        remote.install(pluginSlug: "code-snippets", siteID: siteID, success: { (_) in
            XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }) { (error) in
@@ -324,18 +322,18 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error, expected)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testInstallPluginGenericError() {
         let expect = expectation(description: "Plugin install fails.  Generic Error")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .install,
                                              responseFile: postPluginInstallGenericError)
-        
-        remote.install(pluginSlug: "code-snippets",siteID: siteID, success: { (pluginState) in
+
+        remote.install(pluginSlug: "code-snippets", siteID: siteID, success: { (_) in
            XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }) { (error) in
@@ -344,18 +342,18 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error, expected)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testInstallPluginMalformed() {
         let expect = expectation(description: "Plugin Install returns malformed JSON")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .install,
                                              responseFile: postPluginModifyMalformed)
-        
-        remote.install(pluginSlug: "code-snippets",siteID: siteID, success: { (pluginState) in
+
+        remote.install(pluginSlug: "code-snippets", siteID: siteID, success: { (_) in
            XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }) { (error) in
@@ -364,17 +362,17 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error, expected)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testRemovePluginMalformed() {
         let expect = expectation(description: "Plugin Remove returns malformed JSON")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .remove,
                                              responseFile: postPluginModifyMalformed)
-        
+
         remote.remove(pluginID: "code-snippets/code-snippets", siteID: siteID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
@@ -384,17 +382,17 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error, expected)
             expect.fulfill()
         }
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testActivatePluginFailsWithMalformedJSON() {
         let expect = expectation(description: "Plugin Activate returns malformed JSON")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .modify,
                                              responseFile: postPluginModifyMalformed)
-        
+
         remote.activatePlugin(pluginID: "code-snippets/code-snippets", siteID: siteID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
@@ -407,14 +405,14 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testDeactivePluginFailsWithMalformedJSON() {
         let expect = expectation(description: "Plugin Deactivate returns malformed JSON")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .modify,
                                              responseFile: postPluginModifyMalformed)
-        
+
         remote.deactivatePlugin(pluginID: "code-snippets/code-snippets", siteID: siteID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
@@ -427,14 +425,14 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testEnableAutoupdatesFailsWithMalformedJSON() {
         let expect = expectation(description: "Plugin Enable Auto Updates returns malformed JSON")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .modify,
                                              responseFile: postPluginModifyMalformed)
-        
+
         remote.enableAutoupdates(pluginID: "code-snippets/code-snippets", siteID: siteID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
@@ -447,14 +445,14 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testDisableAutoupdatesFailsWithMalformedJSON() {
         let expect = expectation(description: "Plugin Disable Auto Updates returns malformed JSON")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .modify,
                                              responseFile: postPluginModifyMalformed)
-        
+
         remote.disableAutoupdates(pluginID: "code-snippets/code-snippets", siteID: siteID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
@@ -467,14 +465,14 @@ class PluginServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testActivateAndEnableAutoUpdatedFailsWithMalformedJSON() {
         let expect = expectation(description: "Plugin Activate and Enable Auto Updates returns malformed JSON")
          preparePostStubRemoteResponseWith(plugID: "code-snippets/code-snippets",
                                              pluginSlug: "code-snippets",
                                              endpointAction: .modify,
                                              responseFile: postPluginModifyMalformed)
-        
+
         remote.activateAndEnableAutoupdated(pluginID: "code-snippets/code-snippets", siteID: siteID, success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
@@ -496,13 +494,13 @@ extension PluginServiceRemoteTests {
         case remove = "delete"
         case modify
     }
-    
+
     func preparePostStubRemoteResponseWith(plugID: String, pluginSlug: String, endpointAction: EndpointAction, responseFile: String) {
         guard let escapedPluginID = remote.encoded(pluginID: plugID) else {
             return
         }
         var pluginEndpoint = ""
-        
+
         switch endpointAction {
         case .install:
             pluginEndpoint = sitePluginsEndpoint + "/\(pluginSlug)" + "/\(endpointAction.rawValue)"
@@ -516,14 +514,14 @@ extension PluginServiceRemoteTests {
                            filename: responseFile,
                            contentType: .ApplicationJSON)
     }
-    
+
     func testPluginStateDecodingWitnDynamicJSON() {
         let data = try! MockPluginStateProvider.getDynamicPluginStateJSONResponse()
-        let json = try! JSONSerialization.jsonObject(with: data, options: []) as! [String : AnyObject]
+        let json = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: AnyObject]
 
         do {
             XCTAssertNoThrow(try remote.pluginState(response: json))
-            let _ = try remote.pluginState(response: json)
+            _ = try remote.pluginState(response: json)
         } catch {
             XCTFail("Could not decode plugin")
         }

--- a/WordPressKitTests/PluginStateTests.swift
+++ b/WordPressKitTests/PluginStateTests.swift
@@ -2,125 +2,124 @@ import Foundation
 import XCTest
 @testable import WordPressKit
 
-
 class PluginStateTests: XCTestCase {
-    
+
     func testPluginStateEquatable() {
-        
+
         let lhs = MockPluginStateProvider.getPluginState()
         let rhs = MockPluginStateProvider.getPluginState()
-        
+
         XCTAssertEqual(lhs, rhs)
     }
-    
+
     func testSiteDescriptionNotActiveNotAutoupdated() {
-        let plugin = MockPluginStateProvider.getPluginState(setToActive:false, autoupdate:false)
-        
+        let plugin = MockPluginStateProvider.getPluginState(setToActive: false, autoupdate: false)
+
         let expected = "Inactive, Autoupdates off"
-        
+
         XCTAssertEqual(plugin.active, false)
         XCTAssertEqual(plugin.autoupdate, false)
         XCTAssertEqual(plugin.stateDescription, expected)
     }
-    
+
     func testSiteDescriptionNotActiveAutoupdated() {
         let plugin = MockPluginStateProvider.getPluginState(setToActive: false, autoupdate: true)
-        
+
         let expected = "Inactive, Autoupdates on"
-        
+
         XCTAssertEqual(plugin.active, false)
         XCTAssertEqual(plugin.autoupdate, true)
         XCTAssertEqual(plugin.stateDescription, expected)
     }
-    
+
     func testSiteDescriptionActiveNotAutoupdated() {
-        let plugin = MockPluginStateProvider.getPluginState(setToActive:true, autoupdate: false)
-        
+        let plugin = MockPluginStateProvider.getPluginState(setToActive: true, autoupdate: false)
+
         let expected = "Active, Autoupdates off"
-        
+
         XCTAssertEqual(plugin.active, true)
         XCTAssertEqual(plugin.autoupdate, false)
         XCTAssertEqual(plugin.stateDescription, expected)
     }
-    
+
     func testSiteDescriptionActiveAutoupdated() {
-        let plugin = MockPluginStateProvider.getPluginState(setToActive:true, autoupdate: true)
-        
+        let plugin = MockPluginStateProvider.getPluginState(setToActive: true, autoupdate: true)
+
         let expected = "Active, Autoupdates on"
-        
+
         XCTAssertEqual(plugin.active, true)
         XCTAssertEqual(plugin.autoupdate, true)
         XCTAssertEqual(plugin.stateDescription, expected)
     }
-    
+
     func testPluginHomeURLEqualsPluginURL() {
         let plugin = MockPluginStateProvider.getPluginState()
-        
+
         let expected = URL(string: "https://jetpack.com/")
-        
+
         XCTAssertEqual(plugin.slug, "jetpack-dev")
         XCTAssertEqual(plugin.homeURL, plugin.url)
         XCTAssertEqual(plugin.homeURL, expected)
     }
-    
+
     func testPluginDirectoryURL() {
         let plugin = MockPluginStateProvider.getPluginState()
-        
+
         let expected = URL(string: "https://wordpress.org/plugins/\(plugin.slug)")
-        
+
         XCTAssertEqual(plugin.slug, "jetpack-dev")
         XCTAssertEqual(plugin.directoryURL, expected)
     }
-    
+
     func testDeactivateNotAlowed() {
         let plugin = MockPluginStateProvider.getPluginState(setToActive: true, autoupdate: false)
-        
+
         let expected = false
-        
+
         XCTAssertEqual(plugin.slug, "jetpack-dev")
         XCTAssertEqual(plugin.automanaged, false)
         XCTAssertEqual(plugin.deactivateAllowed, expected)
     }
-    
+
     func testUpdateStateEncodeDoesNotThrow() {
         let updateState = PluginState.UpdateState.updated
         let encoder = JSONEncoder()
-        
+
         do {
             XCTAssertNoThrow(try encoder.encode(updateState), "encode did not throw an error")
-            let _ = try encoder.encode(updateState)
+            _ = try encoder.encode(updateState)
         } catch {
             XCTFail("Ecode Threw an Error")
         }
     }
-    
+
     func testDynmicValuePluginStateEncodeDoesNotThrow() {
         let plugin = MockPluginStateProvider.getDynamicValuePluginState()
         let encoder = JSONEncoder()
-        
+
         do {
             XCTAssertNoThrow(try encoder.encode(plugin), "encode did not throw an error")
-            let _ = try encoder.encode(plugin)
+            _ = try encoder.encode(plugin)
         } catch {
             XCTFail("Ecode Threw an Error")
         }
     }
-    
+
     func testDynmicValuePluginStateDecodeSucceeds() {
         let plugin = MockPluginStateProvider.getDynamicValuePluginState()
         let encoder = JSONEncoder()
         let decoder = JSONDecoder()
-        
+
         let expectedSlug = plugin.slug
         let expectedVersion = plugin.version
         let expectedid = plugin.id
-        
+
         do {
             let data = try encoder.encode(plugin)
-            
+
             XCTAssertNoThrow(try decoder.decode(PluginState.self, from: data))
             let decoded = try decoder.decode(PluginState.self, from: data)
-            
+
             XCTAssertEqual(decoded.slug, expectedSlug)
             XCTAssertEqual(decoded.version, expectedVersion)
             XCTAssertEqual(decoded.id, expectedid)
@@ -128,64 +127,64 @@ class PluginStateTests: XCTestCase {
             XCTFail("Ecode Threw an Error")
         }
     }
-    
+
     func testPluginStateDecodeFromDynamicPluginState() {
         let data = try! MockPluginStateProvider.getEncodedDynamicPluginState()
         let decoder = JSONDecoder()
-        
+
         do {
             XCTAssertNoThrow(try decoder.decode(PluginState.self, from: data))
-            let _ = try decoder.decode(PluginState.self, from: data)
+            _ = try decoder.decode(PluginState.self, from: data)
         } catch {
             XCTFail("Could not decode \(error.localizedDescription)")
         }
     }
-    
+
     func testUpdateStateUpdatedDecodeSucceeds() {
         guard let data = try? MockPluginStateProvider.getEncodedUpdateState(state: PluginState.UpdateState.updated) else {
             XCTFail("Could not get update state")
             return
         }
-        
+
         let decoder = JSONDecoder()
         do {
             XCTAssertNoThrow(try decoder.decode(PluginState.UpdateState.self, from: data), "Decode from JSON successful")
             let decoded = try decoder.decode(PluginState.UpdateState.self, from: data)
-            
+
             XCTAssertEqual(decoded, PluginState.UpdateState.updated)
         } catch {
             XCTFail("Could not decode")
         }
     }
-    
+
     func testUpdateStateAvailableDecodeSucceeds() {
         guard let data = try? MockPluginStateProvider.getEncodedUpdateState(state: PluginState.UpdateState.available("4.0")) else {
             XCTFail("Could not get update state")
             return
         }
-        
+
         let decoder = JSONDecoder()
         do {
             XCTAssertNoThrow(try decoder.decode(PluginState.UpdateState.self, from: data), "Decode from JSON successful")
             let decoded = try decoder.decode(PluginState.UpdateState.self, from: data)
-            
+
             XCTAssertEqual(decoded, PluginState.UpdateState.available("4.0"))
         } catch {
             XCTFail("Could not decode")
         }
     }
-    
+
     func testUpdateStateUpdatingDecodeSucceeds() {
         guard let data = try? MockPluginStateProvider.getEncodedUpdateState(state: PluginState.UpdateState.updating("4.0")) else {
             XCTFail("Could not get update state")
             return
         }
-        
+
         let decoder = JSONDecoder()
         do {
             XCTAssertNoThrow(try decoder.decode(PluginState.UpdateState.self, from: data), "Decode from JSON successful")
             let decoded = try decoder.decode(PluginState.UpdateState.self, from: data)
-            
+
             XCTAssertEqual(decoded, PluginState.UpdateState.updating("4.0"))
         } catch {
             XCTFail("Could not decode")
@@ -195,35 +194,35 @@ class PluginStateTests: XCTestCase {
     func testUpdateStateEquatableWhenAvailable() {
         let lhs = PluginState.UpdateState.available("4.4.1")
         let rhs = PluginState.UpdateState.available("4.4.1")
-        
+
         XCTAssertTrue(lhs == rhs)
     }
-    
+
     func testUpdateStateNotEquatableWhenAvailableDifferentVersion() {
         let lhs = PluginState.UpdateState.available("4.4.1")
         let rhs = PluginState.UpdateState.available("3.4.1")
-        
+
         XCTAssertFalse(lhs == rhs)
     }
-    
+
     func testUpdateStateEquatableWhenUpdating() {
         let lhs = PluginState.UpdateState.updating("4.4.1")
         let rhs = PluginState.UpdateState.updating("4.4.1")
-        
+
         XCTAssertTrue(lhs == rhs)
     }
-    
+
     func testUpdateStateNotEquatableWhenUpdatingDifferentVersion() {
         let lhs = PluginState.UpdateState.updating("4.4.1")
         let rhs = PluginState.UpdateState.updating("3.4.1")
-        
+
         XCTAssertFalse(lhs == rhs)
     }
-    
+
     func testUpdateStateNotEquatable() {
         let lhs = PluginState.UpdateState.updated
         let rhs = PluginState.UpdateState.available("4.4.1")
-        
+
         XCTAssertFalse(lhs == rhs)
     }
 }

--- a/WordPressKitTests/PostServiceRemoteRESTAutosaveTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTAutosaveTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 @testable import WordPressKit
 
-
 class PostServiceRemoteRESTAutosaveTests: RemoteTestCase, RESTTestable {
     private let performPostsAutosaveSuccessFilename = "post-autosave-mapping-success.json"
     private let siteId = 0
@@ -21,7 +20,6 @@ class PostServiceRemoteRESTAutosaveTests: RemoteTestCase, RESTTestable {
         super.tearDown()
         remote = nil
     }
-
 
     // MARK: Perform tests
 

--- a/WordPressKitTests/PostServiceRemoteRESTRevisionsTest.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTRevisionsTest.swift
@@ -3,7 +3,6 @@ import XCTest
 
 @testable import WordPressKit
 
-
 class PostServiceRemoteRESTRevisionsTest: RemoteTestCase, RESTTestable {
     private let performRevisionsSuccessFilename = "post-revisions-success.json"
     private let performRevisionsMappingSuccessFilename = "post-revisions-mapping-success.json"
@@ -15,46 +14,44 @@ class PostServiceRemoteRESTRevisionsTest: RemoteTestCase, RESTTestable {
     private var performEndpoint: String {
         return "sites/\(siteId)/post/\(postId)/diffs"
     }
-    
-    
+
     override func setUp() {
         super.setUp()
-        
+
         remote = PostServiceRemoteREST(wordPressComRestApi: getRestApi(), siteID: NSNumber(value: siteId))
     }
-    
+
     override func tearDown() {
         super.tearDown()
-        
+
         remote = nil
     }
 
-    
     // MARK: Perform tests
-    
+
     func testPerformRevisionsSuccessfully() {
         let expect = expectation(description: "Perform Post Revisions successfully")
-        
+
         stubRemoteResponse(performEndpoint, filename: performRevisionsSuccessFilename, contentType: .ApplicationJSON)
         remote.getPostRevisions(for: siteId,
                                 postId: postId,
                                 success: { (revisions) in
                                     XCTAssertNotNil(revisions, "Revisions shouldn't be nil")
                                     expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testPerformRevisionsFailure() {
         let expect = expectation(description: "Perform Post Revisions failure")
-        
+
         stubRemoteResponse(performEndpoint, filename: performRevisionsFailureFilename, contentType: .ApplicationJSON)
         remote.getPostRevisions(for: siteId,
                                 postId: postId,
-                                success: { (revisions) in
+                                success: { (_) in
                                     XCTFail("This callback shouldn't get called")
                                     expect.fulfill()
         }) { (error) in
@@ -63,10 +60,10 @@ class PostServiceRemoteRESTRevisionsTest: RemoteTestCase, RESTTestable {
         }
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testPerformRevisionsMappingSuccessfully() {
         let expect = expectation(description: "Perform Post Revisions successfully")
-        
+
         stubRemoteResponse(performEndpoint, filename: performRevisionsMappingSuccessFilename, contentType: .ApplicationJSON)
         remote.getPostRevisions(for: siteId,
                                 postId: postId,
@@ -86,37 +83,37 @@ class PostServiceRemoteRESTRevisionsTest: RemoteTestCase, RESTTestable {
                                     XCTAssertEqual(revision.postModifiedGmt, "2018-10-24 15:38:28Z")
                                     XCTAssertEqual(revision.postTitle, "Lorem ipsum dolor sit amet")
                                     XCTAssertEqual(revision.postContent, "Etiam in convallis orci. Dolor sit amet, consectetur adipiscing elit. Cras eget consequat magna, quis gravida sapien.")
-                                    
+
                                     XCTAssertEqual(diff.toRevisionId, revision.id)
                                     XCTAssertEqual(diff.values.totals?.totalAdditions, 2)
                                     XCTAssertEqual(diff.values.totals?.totalDeletions, 2)
-                                    
+
                                     XCTAssertFalse(diff.values.titleDiffs.isEmpty)
                                     XCTAssertFalse(diff.values.contentDiffs.isEmpty)
-                                    
+
                                     XCTAssertEqual(diff.values.titleDiffs.first?.value, "Lorem ipsum dolor sit amet")
                                     XCTAssertEqual(diff.values.titleDiffs.first?.operation, .copy)
 
                                     XCTAssertEqual(diff.values.contentDiffs[0].value, "Lorem ipsum d")
                                     XCTAssertEqual(diff.values.contentDiffs[0].operation, .del)
-                                    
+
                                     XCTAssertEqual(diff.values.contentDiffs[1].value, "Etiam in convallis orci. D")
                                     XCTAssertEqual(diff.values.contentDiffs[1].operation, .add)
-                                    
+
                                     XCTAssertEqual(diff.values.contentDiffs[2].value, "olor sit amet, consectetur adipiscing elit. ")
                                     XCTAssertEqual(diff.values.contentDiffs[2].operation, .copy)
-                                    
+
                                     XCTAssertEqual(diff.values.contentDiffs[3].value, "Aenean et urna libero.")
                                     XCTAssertEqual(diff.values.contentDiffs[3].operation, .del)
-                                    
+
                                     XCTAssertEqual(diff.values.contentDiffs[4].value, "Cras eget consequat magna, quis gravida sapien.")
                                     XCTAssertEqual(diff.values.contentDiffs[4].operation, .add)
-                                    
+
                                     XCTAssertEqual(diff.values.contentDiffs[5].value, "\n")
                                     XCTAssertEqual(diff.values.contentDiffs[5].operation, .copy)
-                                    
+
                                     expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }

--- a/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/PostServiceRemoteXMLRPCTests.swift
@@ -53,7 +53,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 XCTAssertEqual(post?.postID, self.postID, "The post ids should be equal")
                 XCTAssertEqual(post?.title, self.postTitle, "The post titles should be equal")
                 expect.fulfill()
-            }) { error in
+            }) { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }
@@ -68,7 +68,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
         stubRemoteResponse(XMLRPCTestableConstants.xmlRpcUrl, filename: getPostBadPostIdFailureFilename, contentType: .XML)
 
         if let remoteInstance = remote as? PostServiceRemote {
-            remoteInstance.getPostWithID(postID, success: { post in
+            remoteInstance.getPostWithID(postID, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }) { error in
@@ -92,7 +92,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
         stubRemoteResponse(XMLRPCTestableConstants.xmlRpcUrl, filename: XMLRPCTestableConstants.xmlRpcBadAuthFailureFilename, contentType: .XML)
 
         if let remoteInstance = remote as? PostServiceRemote {
-            remoteInstance.getPostWithID(postID, success: { post in
+            remoteInstance.getPostWithID(postID, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }) { error in
@@ -116,10 +116,10 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
         stubRemoteResponse(XMLRPCTestableConstants.xmlRpcUrl, filename: getPostBadXMLFailureFilename, contentType: .XML)
 
         if let remoteInstance = remote as? PostServiceRemote {
-            remoteInstance.getPostWithID(postID, success: { post in
+            remoteInstance.getPostWithID(postID, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
-            }) { error in
+            }) { _ in
                 expect.fulfill()
             }
         }
@@ -152,7 +152,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 XCTAssertEqual(post?.title, remotePost.title, "The post titles should be equal")
                 XCTAssertEqual(post?.content, remotePost.content, "The posts' content should be equal")
                 expect.fulfill()
-            }) { error in
+            }) { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }
@@ -178,7 +178,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 return post
             }()
 
-            remoteInstance.createPost(remotePost, success: { post in
+            remoteInstance.createPost(remotePost, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }) { error in
@@ -210,10 +210,10 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 return post
             }()
 
-            remoteInstance.createPost(remotePost, success: { post in
+            remoteInstance.createPost(remotePost, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
-            }) { error in
+            }) { _ in
                 expect.fulfill()
             }
         }
@@ -235,7 +235,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 return post
             }()
 
-            remoteInstance.createPost(remotePost, success: { post in
+            remoteInstance.createPost(remotePost, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }) { error in
@@ -278,7 +278,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 XCTAssertEqual(post?.title, remotePost.title, "The post titles should be equal")
                 XCTAssertEqual(post?.content, remotePost.content, "The posts' content should be equal")
                 expect.fulfill()
-            }) { error in
+            }) { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }
@@ -302,7 +302,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 return post
             }()
 
-            remoteInstance.update(remotePost, success: { post in
+            remoteInstance.update(remotePost, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }) { error in
@@ -337,7 +337,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 return post
             }()
 
-            remoteInstance.update(remotePost, success: { post in
+            remoteInstance.update(remotePost, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }) { error in
@@ -369,10 +369,10 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 return post
             }()
 
-            remoteInstance.update(remotePost, success: { post in
+            remoteInstance.update(remotePost, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
-            }) { error in
+            }) { _ in
                 expect.fulfill()
             }
         }
@@ -394,7 +394,7 @@ class PostServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 return post
             }()
 
-            remoteInstance.update(remotePost, success: { post in
+            remoteInstance.update(remotePost, success: { _ in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             }) { error in

--- a/WordPressKitTests/PushAuthenticationServiceRemoteTests.swift
+++ b/WordPressKitTests/PushAuthenticationServiceRemoteTests.swift
@@ -34,7 +34,7 @@ class PushAuthenticationServiceRemoteTests: XCTestCase {
 
     func testAuthorizeLoginCallsSuccessBlock() {
         var successBlockCalled = false
-        pushAuthenticationServiceRemote!.authorizeLogin(token, success: { () -> () in
+        pushAuthenticationServiceRemote!.authorizeLogin(token, success: { () -> Void in
            successBlockCalled = true
         }, failure: nil)
         mockRemoteApi.successBlockPassedIn?(NSString(), HTTPURLResponse())
@@ -45,7 +45,7 @@ class PushAuthenticationServiceRemoteTests: XCTestCase {
 
     func testAuthorizeLoginCallsFailureBlock() {
         var failureBlockCalled = false
-        pushAuthenticationServiceRemote.authorizeLogin(token, success: nil, failure: { () -> () in
+        pushAuthenticationServiceRemote.authorizeLogin(token, success: nil, failure: { () -> Void in
             failureBlockCalled = true
         })
         mockRemoteApi.failureBlockPassedIn?(NSError(domain: "UnitTest", code: 0, userInfo: nil), HTTPURLResponse())

--- a/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+CardsTests.swift
@@ -76,7 +76,7 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Returns next page handle")
         stubRemoteResponse("read/tags/cards?tags%5B%5D=dogs", filename: "reader-cards-success.json", contentType: .ApplicationJSON)
 
-        readerPostServiceRemote.fetchCards(for: ["dogs"], success: { cards, nextPageHandle in
+        readerPostServiceRemote.fetchCards(for: ["dogs"], success: { _, nextPageHandle in
             XCTAssertTrue(nextPageHandle == "ZnJvbT0xMCZiZWZvcmU9MjAyMC0wNy0yNlQxMyUzQTU1JTNBMDMlMkIwMSUzQTAw")
             expect.fulfill()
         }, failure: { _ in })
@@ -101,7 +101,7 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
     func testCallAPIWithPopularityAsTheGivenSortingOption() {
         let readerPostServiceRemote = ReaderPostServiceRemote(wordPressComRestApi: mockRemoteApi)
 
-        readerPostServiceRemote.fetchCards(for: [], sortingOption: .popularity, success: { _¨, _ in }, failure: { _ in })
+        readerPostServiceRemote.fetchCards(for: [], sortingOption: .popularity, success: { _, _ in }, failure: { _ in })
 
         XCTAssertTrue(mockRemoteApi.getMethodCalled)
 
@@ -113,7 +113,7 @@ class ReaderPostServiceRemoteCardTests: RemoteTestCase, RESTTestable {
     func testCallAPIWithDateAsTheGivenSortingOption() {
         let readerPostServiceRemote = ReaderPostServiceRemote(wordPressComRestApi: mockRemoteApi)
 
-        readerPostServiceRemote.fetchCards(for: [], sortingOption: .date, success: { _¨, _ in }, failure: { _ in })
+        readerPostServiceRemote.fetchCards(for: [], sortingOption: .date, success: { _, _ in }, failure: { _ in })
 
         XCTAssertTrue(mockRemoteApi.getMethodCalled)
 

--- a/WordPressKitTests/ReaderPostServiceRemote+SubscriptionTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+SubscriptionTests.swift
@@ -3,31 +3,31 @@ import XCTest
 @testable import WordPressKit
 
 class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
-    
+
     // MARK: - Constants
-    
+
     let siteID: Int = 0
     let postID: Int = 0
     let response = [String: AnyObject]()
-    
+
     let fetchSubscriptionStatusEndpoint = "sites/0/posts/0/subscribers/mine"
     let subscribeToPostEndpoint = "sites/0/posts/0/subscribers/new"
     let unsubscribeFromPostEndpoint = "sites/0/posts/0/subscribers/mine/delete"
-    
+
     let fetchSubscriptionStatusSuccessMockFilename = "reader-post-comments-subscription-status-success.json"
     let subscribeToPostSuccessMockFilename = "reader-post-comments-subscribe-success.json"
     let subscribeToPostSuccessFalseMockFilename = "reader-post-comments-subscribe-failure.json"
     let unsubscribeFromPostSuccessMockFilename = "reader-post-comments-unsubscribe-success.json"
-    
+
     // MARK: - Properties
-    
+
     var readerPostServiceRemote: ReaderPostServiceRemote!
 
     override func setUp() {
         super.setUp()
         readerPostServiceRemote = ReaderPostServiceRemote(wordPressComRestApi: getRestApi())
     }
-    
+
     func testReturnSubscriptionStatus() {
         stubRemoteResponse(fetchSubscriptionStatusEndpoint,
                            filename: fetchSubscriptionStatusSuccessMockFilename,
@@ -37,31 +37,30 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
         readerPostServiceRemote.fetchSubscriptionStatus(for: postID, from: siteID, success: { (success) in
             XCTAssertTrue(success, "Success should be true")
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testSubscribeToCommentsInPost() {
         stubRemoteResponse(subscribeToPostEndpoint,
                            filename: subscribeToPostSuccessMockFilename,
                            contentType: .ApplicationJSON)
 
         let expect = expectation(description: "Subscribe to comments for a post")
-        readerPostServiceRemote.subscribeToPost(with: postID, for: siteID,  success: { (success) in
+        readerPostServiceRemote.subscribeToPost(with: postID, for: siteID, success: { (success) in
             XCTAssertTrue(success, "Success should be true")
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-
 
     /// Test that the attempt to subscribe to comments in a post returns `success: false`
     /// while "Block emails" is enabled on https://wordpress.com/me/notifications/subscriptions
@@ -72,10 +71,10 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
                            contentType: .ApplicationJSON)
 
         let expect = expectation(description: "Subscribe to comments for a post")
-        readerPostServiceRemote.subscribeToPost(with: postID, for: siteID,  success: { (successfullySubscribed) in
+        readerPostServiceRemote.subscribeToPost(with: postID, for: siteID, success: { (successfullySubscribed) in
             XCTAssertFalse(successfullySubscribed, "Success response should be false")
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }
@@ -95,7 +94,7 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
         readerPostServiceRemote.unsubscribeFromPost(with: postID, for: siteID, success: { (success) in
             XCTAssertTrue(success, "Success should be true")
             expect.fulfill()
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }

--- a/WordPressKitTests/ReaderSiteSearchServiceRemoteTests.swift
+++ b/WordPressKitTests/ReaderSiteSearchServiceRemoteTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
 
-    /// MARK: - Constants
+    // MARK: - Constants
 
     let performSearchSuccessFilename = "reader-site-search-success.json"
     let performSearchSuccessNoIconFilename = "reader-site-search-success-no-icon.json"
@@ -14,13 +14,13 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
     let performSearchBlogIDFallbackFilename = "reader-site-search-blog-id-fallback.json"
     let performSearchFailsWithNoBlogOrFeedIDFilename = "reader-site-search-no-blog-or-feed-id.json"
 
-    /// MARK: - Properties
+    // MARK: - Properties
 
     var performSearchEndpoint: String { return "read/feed" }
 
     var remote: ReaderSiteSearchServiceRemote!
 
-    /// MARK: - Overridden Methods
+    // MARK: - Overridden Methods
 
     override func setUp() {
         super.setUp()
@@ -34,7 +34,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote = nil
     }
 
-    /// MARK: - Perform Search Tests
+    // MARK: - Perform Search Tests
 
     func testPerformSearchSuccessfully() {
         let expect = expectation(description: "Perform Reader site search successfully")
@@ -46,7 +46,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(totalFeeds, 2, "The total feed count should be 2")
                                 XCTAssertFalse(hasMore, "The value of hasMore should be false")
                                 expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -76,7 +76,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertNil(feed.blavatarURL)
 
                                 expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -107,7 +107,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
 
                                 expect.fulfill()
 
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -124,7 +124,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(totalFeeds, 3, "The total feed count should be 3")
                                 XCTAssertTrue(hasMore, "The value of hasMore should be true")
                                 expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -141,7 +141,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(totalFeeds, 2, "The total feed count should be 2")
                                 XCTAssertFalse(hasMore, "The value of hasMore should be false")
                                 expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -192,7 +192,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(feed.feedDescription, "The Art and Craft of Blogging")
 
                                 expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -221,7 +221,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(feed.feedDescription, "A daily selection of the best content published on WordPress, collected for you by humans who love to read.")
 
                                 expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })

--- a/WordPressKitTests/ReaderSiteServiceRemoteTests.swift
+++ b/WordPressKitTests/ReaderSiteServiceRemoteTests.swift
@@ -253,7 +253,7 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
 
         let expectedPath = readerSiteServiceRemote.path(forEndpoint: "me/block/sites/1/delete",
                                                         withVersion: ._1_1)
-        readerSiteServiceRemote.flagSite(withID: 1, asBlocked: false, success: nil, failure:  nil)
+        readerSiteServiceRemote.flagSite(withID: 1, asBlocked: false, success: nil, failure: nil)
         XCTAssertTrue(mockRemoteApi.postMethodCalled, "Wrong method")
         XCTAssertEqual(mockRemoteApi.URLStringPassedIn, expectedPath, "Wrong path")
     }
@@ -292,7 +292,7 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
     func testCheckSiteExistsAtURLSuccess() {
         let testURLString = "http://www.wordpress.com"
         let testURL = URL(string: testURLString)!
-        stub(condition:{request in request.url?.absoluteString == testURLString}) { request in
+        stub(condition: {request in request.url?.absoluteString == testURLString}) { _ in
             let stubPath = OHPathForFile("empty.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -301,7 +301,7 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
         readerSiteServiceRemote.checkSiteExists(at: testURL, success: {
             expect.fulfill()
             XCTAssertTrue(true)
-        },failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTFail("This call should be successfull")
         })
@@ -311,16 +311,16 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
     func testCheckSiteExistsAtURLFailure() {
         let testURLString = "http://www.wordpress.com"
         let testURL = URL(string: testURLString)!
-        stub(condition:{request in request.url?.absoluteString == testURLString}) { request in
+        stub(condition: {request in request.url?.absoluteString == testURLString}) { _ in
             let stubPath = OHPathForFile("empty.json", type(of: self))
-            return fixture(filePath: stubPath!, status:400, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
+            return fixture(filePath: stubPath!, status: 400, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
         readerSiteServiceRemote.checkSiteExists(at: testURL, success: {
             expect.fulfill()
             XCTAssertTrue(false, "This call should be unsuccessfull")
-        },failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTAssertTrue(true)
         })
@@ -330,7 +330,7 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
     func testCheckSiteExistsAtURLFailureNetworkError() {
         let testURLString = "http://www.wordpress.com"
         let testURL = URL(string: testURLString)!
-        stub(condition:{request in request.url?.absoluteString == testURLString}) { request in
+        stub(condition: {request in request.url?.absoluteString == testURLString}) { _ in
             return HTTPStubsResponse(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorUnknown, userInfo: nil))
         }
 
@@ -338,7 +338,7 @@ class ReaderSiteServiceRemoteTests: XCTestCase {
         readerSiteServiceRemote.checkSiteExists(at: testURL, success: {
             expect.fulfill()
             XCTAssertTrue(false, "This call should be unsuccessfull")
-        },failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTAssertTrue(true)
         })

--- a/WordPressKitTests/ReaderTopicServiceRemoteTest+Subscriptions.swift
+++ b/WordPressKitTests/ReaderTopicServiceRemoteTest+Subscriptions.swift
@@ -1,14 +1,13 @@
 import XCTest
 @testable import WordPressKit
 
-
 class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
     let mockRemoteApi = MockWordPressComRestApi()
     let response = [String: AnyObject]()
     let siteId = 0
     var failure: ((ReaderTopicServiceError?) -> Void)!
     var readerTopicServiceRemote: ReaderTopicServiceRemote!
-    
+
     override func setUp() {
         super.setUp()
         readerTopicServiceRemote = ReaderTopicServiceRemote(wordPressComRestApi: mockRemoteApi)
@@ -16,7 +15,7 @@ class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
             fatalError()
         }
     }
-    
+
     func testSubscribeNotification() {
         var success = false
         let expectedPath = "wpcom/v2/read/sites/0/notification-subscriptions/new/"
@@ -28,7 +27,7 @@ class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(success)
     }
-    
+
     func testUnsubscribeNotification() {
         var success = false
         let expectedPath = "wpcom/v2/read/sites/0/notification-subscriptions/delete/"
@@ -40,7 +39,7 @@ class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(success)
     }
-    
+
     func testSubscribeComments() {
         var success = false
         let expectedPath = "rest/v1.2/read/site/0/comment_email_subscriptions/new/"
@@ -52,7 +51,7 @@ class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(success)
     }
-    
+
     func testUnsubscribeComments() {
         var success = false
         let expectedPath = "rest/v1.2/read/site/0/comment_email_subscriptions/delete/"
@@ -64,7 +63,7 @@ class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(success)
     }
-    
+
     func testSubscribePostsEmail() {
         var success = false
         let expectedPath = "rest/v1.2/read/site/0/post_email_subscriptions/new/"
@@ -76,7 +75,7 @@ class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(success)
     }
-    
+
     func testUnsubscribePostsEmail() {
         var success = false
         let expectedPath = "rest/v1.2/read/site/0/post_email_subscriptions/delete/"
@@ -88,11 +87,11 @@ class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(success)
     }
-    
+
     func testUdatePostsEmail() {
         var success = false
         let expectedPath = "rest/v1.2/read/site/0/post_email_subscriptions/update/"
-        
+
         readerTopicServiceRemote.updateFrequencyPostsEmail(with: siteId, frequency: .weekly, {
             success = true
         }, failure)
@@ -100,12 +99,12 @@ class ReaderTopicServiceRemoteTestSubscriptions: XCTestCase {
         XCTAssertEqual(mockRemoteApi.URLStringPassedIn, expectedPath, "Wrong path")
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(success)
-        
+
         guard let parameters = mockRemoteApi.parametersPassedIn as? [String: AnyObject],
             let frequency = parameters["delivery_frequency"] as? String else {
             fatalError()
         }
-        
+
         XCTAssertEqual(frequency, ReaderServiceDeliveryFrequency.weekly.rawValue)
     }
 }

--- a/WordPressKitTests/RemoteNotificationTests.swift
+++ b/WordPressKitTests/RemoteNotificationTests.swift
@@ -28,7 +28,6 @@ class RemoteNotificationTests: XCTestCase {
         XCTAssertNotNil(remote.meta)
     }
 
-
     /// Tests that a Remote Notification doesn't initialize whenever the ID field is missing.
     ///
     func testRemoteNotificationInitializerReturnsNilWheneverNoteIdIsMissing() {
@@ -38,7 +37,6 @@ class RemoteNotificationTests: XCTestCase {
         let remote = RemoteNotification(document: document)
         XCTAssertNil(remote)
     }
-
 
     /// Tests that a Remote Notification doesn't initialize whenever the ID field is missing.
     ///
@@ -50,7 +48,6 @@ class RemoteNotificationTests: XCTestCase {
         XCTAssertNil(remote)
     }
 }
-
 
 // MARK: - Private Helpers
 //

--- a/WordPressKitTests/RemoteReaderPostTests+V2.swift
+++ b/WordPressKitTests/RemoteReaderPostTests+V2.swift
@@ -45,7 +45,7 @@ class RemoteReaderPostTestsV2: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Returns next page handle")
         stubRemoteResponse("read/tags/posts?tags%5B%5D=dogs", filename: "reader-posts-success.json", contentType: .ApplicationJSON)
 
-        readerPostServiceRemote.fetchPosts(for: ["dogs"], success: { cards, nextPageHandle in
+        readerPostServiceRemote.fetchPosts(for: ["dogs"], success: { _, nextPageHandle in
             XCTAssertTrue(nextPageHandle == "ZnJvbT0xMCZiZWZvcmU9MjAyMC0wOS0zMFQxNyUzQTAzJTNBMjAlMkIwMCUzQTAw")
             expect.fulfill()
         }, failure: { _ in })

--- a/WordPressKitTests/RemoteReaderSiteInfoSubscriptionTests.swift
+++ b/WordPressKitTests/RemoteReaderSiteInfoSubscriptionTests.swift
@@ -1,14 +1,13 @@
 import XCTest
 @testable import WordPressKit
 
-
 class RemoteReaderSiteInfoSubscriptionTests: XCTestCase {
     func testRemoteReaderSiteInfoSubscriptionPost() {
         let postSubscription = RemoteReaderSiteInfoSubscriptionPost(dictionary: ["send_posts": false])
         XCTAssertNotNil(postSubscription)
         XCTAssertFalse(postSubscription.sendPosts)
     }
-    
+
     func testRemoteReaderSiteInfoSubscriptionEmail() {
         let emailSubscription = RemoteReaderSiteInfoSubscriptionEmail(dictionary: ["send_posts": true,
                                                                                    "send_comments": false,

--- a/WordPressKitTests/RemoteTestCase.swift
+++ b/WordPressKitTests/RemoteTestCase.swift
@@ -21,7 +21,6 @@ class RemoteTestCase: XCTestCase {
 
     let timeout = TimeInterval(5)
 
-
     // MARK: - Overridden Methods
 
     override func setUp() {
@@ -35,7 +34,6 @@ class RemoteTestCase: XCTestCase {
         HTTPStubs.removeAllStubs()
     }
 }
-
 
 // MARK: - Remote testing helpers
 //
@@ -54,7 +52,7 @@ extension RemoteTestCase {
             return request.url?.absoluteString.range(of: endpoint) != nil
         }) { _ in
             let stubPath = OHPathForFile(filename, type(of: self))
-            var headers: Dictionary<NSObject, AnyObject>?
+            var headers: [NSObject: AnyObject]?
 
             if contentType != .NoContentType {
                 headers = ["Content-Type" as NSObject: contentType.rawValue as AnyObject]
@@ -75,7 +73,7 @@ extension RemoteTestCase {
         stub(condition: { request in
             return request.url?.absoluteString.range(of: endpoint) != nil
         }) { _ in
-            var headers: Dictionary<NSObject, AnyObject>?
+            var headers: [NSObject: AnyObject]?
 
             if contentType != .NoContentType {
                 headers = ["Content-Type" as NSObject: contentType.rawValue as AnyObject]
@@ -106,18 +104,18 @@ extension RemoteTestCase {
             guard files.indices.contains(callCounter) else {
                 // An extra call was made to this stub and no corresponding response file existed.
                 XCTFail("Unexpected network request was made to: \(response.url!.absoluteString)")
-                let notConnectedError = NSError(domain:NSURLErrorDomain, code:Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue), userInfo:nil)
-                return HTTPStubsResponse(error:notConnectedError)
+                let notConnectedError = NSError(domain: NSURLErrorDomain, code: Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue), userInfo: nil)
+                return HTTPStubsResponse(error: notConnectedError)
             }
-            
+
             let stubPath = OHPathForFile(files[callCounter], type(of: self))
             callCounter += 1
-            
-            var headers: Dictionary<NSObject, AnyObject>?
+
+            var headers: [NSObject: AnyObject]?
             if contentType != .NoContentType {
                 headers = ["Content-Type" as NSObject: contentType.rawValue as AnyObject]
             }
-            
+
             return fixture(filePath: stubPath!, status: status, headers: headers)
         }
     }
@@ -131,12 +129,12 @@ extension RemoteTestCase {
     ///         https://github.com/AliSoftware/OHHTTPStubs/wiki/Usage-Examples#stack-multiple-stubs-and-remove-installed-stubs
     ///
     func stubAllNetworkRequestsWithNotConnectedError() {
-        stub(condition: { request in
+        stub(condition: { _ in
             return true
         }) { response in
             XCTFail("Unexpected network request was made to: \(response.url!.absoluteString)")
-            let notConnectedError = NSError(domain:NSURLErrorDomain, code:Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue), userInfo:nil)
-            return HTTPStubsResponse(error:notConnectedError)
+            let notConnectedError = NSError(domain: NSURLErrorDomain, code: Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue), userInfo: nil)
+            return HTTPStubsResponse(error: notConnectedError)
         }
     }
 
@@ -150,7 +148,7 @@ extension RemoteTestCase {
             if let documentPath = cacheDirectory.path {
                 let fileNames = try FileManager.default.contentsOfDirectory(atPath: "\(documentPath)")
                 for fileName in fileNames {
-                    if (fileName.hasSuffix(".json")) {
+                    if fileName.hasSuffix(".json") {
                         print("Removing \(fileName) from cache.")
                         let filePathName = "\(documentPath)/\(fileName)"
                         try FileManager.default.removeItem(atPath: filePathName)

--- a/WordPressKitTests/Scan/JetpackScanServiceRemoteTests.swift
+++ b/WordPressKitTests/Scan/JetpackScanServiceRemoteTests.swift
@@ -186,7 +186,6 @@ class JetpackScanServiceRemoteTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
-
     /// Fixable threat object is set correctly
     func testFixableThreat() {
         let expect = expectation(description: "Threat is fixable")
@@ -206,7 +205,6 @@ class JetpackScanServiceRemoteTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
-
     /// Fixable property is set correctly for unfixable threats
     func testNotFixableThreat() {
         let expect = expectation(description: "Threat is not fixable")
@@ -221,7 +219,6 @@ class JetpackScanServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-
 
     /// Make sure the threat context object is set correctly
     func testThreatContext() {

--- a/WordPressKitTests/ServiceRequestTest.swift
+++ b/WordPressKitTests/ServiceRequestTest.swift
@@ -1,14 +1,12 @@
 import XCTest
 @testable import WordPressKit
 
-
 class ServiceRequestTest: XCTestCase {
     let mockRequest = MockServiceRequest()
     var notificationsRequest: ReaderTopicServiceSubscriptionsRequest!
     var postsEmailRequest: ReaderTopicServiceSubscriptionsRequest!
     var commentsRequest: ReaderTopicServiceSubscriptionsRequest!
 
-    
     override func setUp() {
         super.setUp()
 
@@ -16,22 +14,22 @@ class ServiceRequestTest: XCTestCase {
         postsEmailRequest = .postsEmail(siteId: 0, action: .unsubscribe)
         commentsRequest = .comments(siteId: 0, action: .update)
     }
-    
+
     func testMockServiceRequest() {
         XCTAssertEqual(mockRequest.path, "localhost/path/")
         XCTAssertEqual(mockRequest.apiVersion, ._1_2)
     }
-    
+
     func testNotificationsRequest() {
         XCTAssertEqual(notificationsRequest.apiVersion, ._2_0)
         XCTAssertEqual(notificationsRequest.path, "read/sites/0/notification-subscriptions/new/")
     }
-    
+
     func testPostsEmailRequest() {
         XCTAssertEqual(postsEmailRequest.apiVersion, ._1_2)
         XCTAssertEqual(postsEmailRequest.path, "read/site/0/post_email_subscriptions/delete/")
     }
-    
+
     func testCommentsRequest() {
         XCTAssertEqual(commentsRequest.apiVersion, ._1_2)
         XCTAssertEqual(commentsRequest.path, "read/site/0/comment_email_subscriptions/update/")

--- a/WordPressKitTests/SiteCreationRequestEncodingTests.swift
+++ b/WordPressKitTests/SiteCreationRequestEncodingTests.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 @testable import WordPressKit
 
@@ -182,7 +181,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
 /// Mark - Validations
 extension SiteCreationRequestEncodingTests {
 
-    private func encodeRequest(_ request: SiteCreationRequest) -> [String : AnyObject] {
+    private func encodeRequest(_ request: SiteCreationRequest) -> [String: AnyObject] {
         let encoder = JSONEncoder()
 
         XCTAssertNoThrow(try encoder.encode(request))
@@ -191,13 +190,13 @@ extension SiteCreationRequestEncodingTests {
         XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
         let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
 
-        if let _ = serializedJSON as? [String : AnyObject] {} else {
+        if let _ = serializedJSON as? [String: AnyObject] {} else {
             XCTFail("Failed to encode a proper JSON dictionary!")
         }
-        return serializedJSON as! [String : AnyObject]
+        return serializedJSON as! [String: AnyObject]
     }
 
-    private func validate(_ jsonDictionary: [String : AnyObject],
+    private func validate(_ jsonDictionary: [String: AnyObject],
                           expectedSegmentId: Int64? = SiteCreationRequestEncodingTests.expectedSegmentId,
                           expectedSiteDesign: String? = SiteCreationRequestEncodingTests.expectedSiteDesign,
                           expectedPublicValue: Bool = SiteCreationRequestEncodingTests.expectedPublicValue,
@@ -229,7 +228,7 @@ extension SiteCreationRequestEncodingTests {
         let actualValidateValue = jsonDictionary["validate"] as? Bool
         XCTAssertNotNil(actualValidateValue)
 
-        let actualOptions = jsonDictionary["options"] as? [String : AnyObject]
+        let actualOptions = jsonDictionary["options"] as? [String: AnyObject]
         XCTAssertNotNil(actualOptions)
 
         let actualSegmentId = actualOptions!["site_segment"] as? Int64
@@ -238,7 +237,7 @@ extension SiteCreationRequestEncodingTests {
         let actualVerticalId = actualOptions!["site_vertical"] as? String
         XCTAssertEqual(expectedVerticalId, actualVerticalId)
 
-        let actualSiteInfo = actualOptions!["site_information"] as? [String : AnyObject]
+        let actualSiteInfo = actualOptions!["site_information"] as? [String: AnyObject]
         let actualTagline = actualSiteInfo?["site_tagline"] as? String
         XCTAssertEqual(expectedTagline, actualTagline)
 

--- a/WordPressKitTests/SiteCreationResponseDecodingTests.swift
+++ b/WordPressKitTests/SiteCreationResponseDecodingTests.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 @testable import WordPressKit
 

--- a/WordPressKitTests/SiteCreationSegmentsTests.swift
+++ b/WordPressKitTests/SiteCreationSegmentsTests.swift
@@ -23,7 +23,7 @@ final class SiteCreationSegmentsTests: RemoteTestCase, RESTTestable {
                 let mobileSegmentsCount = segments.count
                 XCTAssertEqual(mobileSegmentsCount, expectedSegmentsCount)
 
-            case .failure(_):
+            case .failure:
                 XCTFail()
             }
         })

--- a/WordPressKitTests/SiteManagementServiceRemoteTests.swift
+++ b/WordPressKitTests/SiteManagementServiceRemoteTests.swift
@@ -48,12 +48,11 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     override func tearDown() {
         super.tearDown()
-        
+
         remote = nil
     }
 
     // MARK: - Delete Site Tests
-
 
     func testDeleteSiteSucceeds() {
         let expect = expectation(description: "Delete site success")
@@ -61,7 +60,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(siteDeleteEndpoint, filename: deleteSiteSuccessMockFilename, contentType: .ApplicationJSON)
         remote.deleteSite(NSNumber(value: Int32(siteID)), success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -118,7 +117,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.deleteSite(NSNumber(value: Int32(siteID)), success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -175,7 +174,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(siteExportStartEndpoint, filename: exportContentSuccessMockFilename, contentType: .ApplicationJSON)
         remote.exportContent(NSNumber(value: Int32(siteID)), success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -253,7 +252,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.exportContent(NSNumber(value: Int32(siteID)), success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -311,7 +310,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { purchases in
             XCTAssertEqual(purchases.count, 2, "There should be 2 purchases here")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -326,7 +325,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { purchases in
             XCTAssertEqual(purchases.count, 0, "There should be 0 purchases here")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -341,7 +340,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { purchases in
             XCTAssertEqual(purchases.count, 0, "There should be 0 purchases here")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -353,7 +352,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get active purchases server error failure")
 
         stubRemoteResponse(sitePurchasesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { purchases in
+        remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -374,7 +373,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get active purchases with bad auth failure")
 
         stubRemoteResponse(sitePurchasesEndpoint, filename: getActivePurchasesAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { purchases in
+        remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -395,10 +394,10 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get active purchases with invalid json response failure")
 
         stubRemoteResponse(sitePurchasesEndpoint, filename: getActivePurchasesBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { purchases in
+        remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
 
@@ -409,7 +408,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get active purchases with unexpected (valid) json response failure")
 
         stubRemoteResponse(sitePurchasesEndpoint, filename: deleteSiteUnexpectedJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { purchases in
+        remote.getActivePurchases(NSNumber(value: Int32(siteID)), success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -425,34 +424,34 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     // MARK: - Mark Site Quick Start As Completed Tests
-    
+
     func testMarkQuickStartAsCompletedSuccess() {
         let expect = expectation(description: "Mark Site Quick Start as Completed success test")
-        
+
         stubRemoteResponse(siteMarkQuickStartAsCompletedEndPoint, filename: markQuickStartAsCompletedSuccessMockFilename, contentType: .ApplicationJSON)
         remote.markQuickStartChecklistAsComplete(NSNumber(value: Int32(siteID)), success: {
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
     func testMarkQuickStartAsCompletedFailure() {
         let expect = expectation(description: "Mark Site Quick Start as Completed failure test")
-        
+
         stubRemoteResponse(siteMarkQuickStartAsCompletedEndPoint, filename: markQuickStartAsCompletedFailureMockFilename, contentType: .ApplicationJSON, status: 403)
         remote.markQuickStartChecklistAsComplete(NSNumber(value: Int32(siteID)), success: {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expect.fulfill()
         })
-        
+
         waitForExpectations(timeout: timeout, handler: nil)
     }
 

--- a/WordPressKitTests/SitePluginTests.swift
+++ b/WordPressKitTests/SitePluginTests.swift
@@ -6,14 +6,14 @@ class SitePluginTests: XCTestCase {
     func testSitePluginCapabilitiesEquatableSucceeds() {
         let sitePluginCapabilitiesA = SitePluginCapabilities(modify: true, autoupdate: true)
         let sitePluginCapabilitiesB = SitePluginCapabilities(modify: true, autoupdate: true)
-        
+
         XCTAssertEqual(sitePluginCapabilitiesA, sitePluginCapabilitiesB)
     }
-    
+
     func testSitePluginCapabilitiesFails() {
         let sitePluginCapabilitiesA = SitePluginCapabilities(modify: true, autoupdate: true)
         let sitePluginCapabilitiesB = SitePluginCapabilities(modify: false, autoupdate: false)
-        
+
         XCTAssertNotEqual(sitePluginCapabilitiesA, sitePluginCapabilitiesB)
     }
 }

--- a/WordPressKitTests/SiteSegmentsResponseDecodingTests.swift
+++ b/WordPressKitTests/SiteSegmentsResponseDecodingTests.swift
@@ -13,11 +13,10 @@ final class SiteSegmentsResponseDecodingTests: XCTestCase {
 
     private var segment: SiteSegment?
 
-
     override func setUp() {
         super.setUp()
 
-        let mockFileURL = Bundle(for: type(of:self)).url(forResource: "site-segments-single", withExtension: "json")!
+        let mockFileURL = Bundle(for: type(of: self)).url(forResource: "site-segments-single", withExtension: "json")!
 
         let json = try! Data(contentsOf: mockFileURL)
 

--- a/WordPressKitTests/SiteVerticalsPromptResponseDecodingTests.swift
+++ b/WordPressKitTests/SiteVerticalsPromptResponseDecodingTests.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 @testable import WordPressKit
 

--- a/WordPressKitTests/SiteVerticalsRequestEncodingTests.swift
+++ b/WordPressKitTests/SiteVerticalsRequestEncodingTests.swift
@@ -19,7 +19,7 @@ final class SiteVerticalsRequestEncodingTests: XCTestCase {
         XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
         let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
 
-        guard let jsonDictionary = serializedJSON as? [String : AnyObject] else {
+        guard let jsonDictionary = serializedJSON as? [String: AnyObject] else {
             XCTFail("Failed to encode a proper JSON dictionary!")
             return
         }
@@ -50,7 +50,7 @@ final class SiteVerticalsRequestEncodingTests: XCTestCase {
         XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
         let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
 
-        guard let jsonDictionary = serializedJSON as? [String : AnyObject] else {
+        guard let jsonDictionary = serializedJSON as? [String: AnyObject] else {
             XCTFail("Failed to encode a proper JSON dictionary!")
             return
         }
@@ -81,7 +81,7 @@ final class SiteVerticalsRequestEncodingTests: XCTestCase {
         XCTAssertNoThrow(try JSONSerialization.jsonObject(with: encodedJSON, options: []))
         let serializedJSON = try! JSONSerialization.jsonObject(with: encodedJSON, options: [])
 
-        guard let jsonDictionary = serializedJSON as? [String : AnyObject] else {
+        guard let jsonDictionary = serializedJSON as? [String: AnyObject] else {
             XCTFail("Failed to encode a proper JSON dictionary!")
             return
         }

--- a/WordPressKitTests/StatsRemoteV2Tests.swift
+++ b/WordPressKitTests/StatsRemoteV2Tests.swift
@@ -44,12 +44,12 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
     override func setUp() {
         super.setUp()
-        
+
         // standardize timezone to GMT+0
         if let timezone = TimeZone(abbreviation: "GMT") {
             NSTimeZone.default = timezone
         }
-        
+
         remote = StatsServiceRemoteV2(wordPressComRestApi: getRestApi(), siteID: siteID, siteTimezone: .autoupdatingCurrent)
     }
 
@@ -116,7 +116,6 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         let dec31 = DateComponents(year: 2018, month: 12, day: 31)
         let date = Calendar.autoupdatingCurrent.date(from: dec31)!
 
-
         remote.getData(for: .year, endingOn: date) { (topAuthors: StatsTopAuthorsTimeIntervalData?, error: Error?) in
             XCTAssertNil(error)
             XCTAssertNotNil(topAuthors)
@@ -146,7 +145,6 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         let dec31 = DateComponents(year: 2019, month: 12, day: 31)
         let date = Calendar.autoupdatingCurrent.date(from: dec31)!
-
 
         remote.getData(for: .year, endingOn: date) { (videos: StatsTopVideosTimeIntervalData?, error: Error?) in
             XCTAssertNil(error)
@@ -180,7 +178,6 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         let dec31 = DateComponents(year: 2018, month: 12, day: 31)
         let date = Calendar.autoupdatingCurrent.date(from: dec31)!
 
-
         remote.getData(for: .year, endingOn: date) { (countries: StatsTopCountryTimeIntervalData?, error: Error?) in
             XCTAssertNil(error)
             XCTAssertNotNil(countries)
@@ -198,7 +195,6 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(countries?.countries.last!.name, "Netherlands")
             XCTAssertEqual(countries?.countries.last!.code, "NL")
 
-
             expect.fulfill()
         }
 
@@ -212,7 +208,6 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         let dec31 = DateComponents(year: 2018, month: 12, day: 31)
         let date = Calendar.autoupdatingCurrent.date(from: dec31)!
-
 
         remote.getData(for: .year, endingOn: date) { (clicks: StatsTopClicksTimeIntervalData?, error: Error?) in
             XCTAssertNil(error)
@@ -311,10 +306,10 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "It should return posts data for a year")
 
         stubRemoteResponse(sitePostsDataEndpoint, filename: getPostsMockFilename, contentType: .ApplicationJSON)
-      
+
         let jan31 = DateComponents(year: 2019, month: 1, day: 31)
         let date = Calendar.autoupdatingCurrent.date(from: jan31)!
-      
+
         remote.getData(for: .month, endingOn: date) { (topPosts: StatsTopPostsTimeIntervalData?, error: Error?) in
             XCTAssertNil(error)
             XCTAssertNotNil(topPosts)
@@ -341,12 +336,12 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(topPosts?.topPosts[2].title, "Dundee, Scotland")
             XCTAssertEqual(topPosts?.topPosts[2].postID, 2413)
             XCTAssertEqual(topPosts?.topPosts[2].postURL, URL(string: "http://officetoday.wordpress.com/2019/01/24/dundee-scotland-2/"))
-                                                     
+
             expect.fulfill()
         }
 
-        waitForExpectations(timeout: timeout, handler: nil)                                                    
-    }                                                    
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
 
     func testsPublishedPosts() {
         let expect = expectation(description: "It should return published posts for a specified window")
@@ -374,7 +369,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
     func testFetchDownloadsData() {
         let expect = expectation(description: "It should return file download data for a month")
-        
+
         let dateComponents = DateComponents(year: 2019, month: 7, day: 29)
         let date = Calendar.autoupdatingCurrent.date(from: dateComponents)!
 
@@ -388,7 +383,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(fileDownloads?.totalDownloadsCount, 15)
 
             XCTAssertEqual(fileDownloads?.fileDownloads.count, 2)
-            
+
             XCTAssertEqual(fileDownloads?.fileDownloads.first!.file, "/2019/07/test.pdf")
             XCTAssertEqual(fileDownloads?.fileDownloads.first!.downloadCount, 11)
 
@@ -397,7 +392,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-    
+
   func testVisitsForDay() {
         let expect = expectation(description: "It should return visits data for a day")
 
@@ -436,10 +431,10 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "It should return post detail")
 
         stubRemoteResponse(sitePostDetailsEndpoint, filename: getPostsDetailsFilename, contentType: .ApplicationJSON)
-      
+
         let feb21 = DateComponents(year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
-      
+
         remote.getDetails(forPostID: 9001) { (postDetails, error) in
             XCTAssertNil(error)
             XCTAssertNotNil(postDetails)
@@ -500,7 +495,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(mostRecentWeek?.days.last?.date, mostRecentWeek?.endDay)
             XCTAssertEqual(mostRecentWeek?.days.first?.viewsCount, 157)
             XCTAssertEqual(mostRecentWeek?.days.last?.viewsCount, 324)
-                                            
+
             expect.fulfill()
         }
 
@@ -553,7 +548,6 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         let feb21 = DateComponents(year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
-        
         remote.getData(for: .month, endingOn: date) { (summary: StatsSummaryTimeIntervalData?, error: Error?) in
             XCTAssertNil(error)
             XCTAssertNotNil(summary)
@@ -577,7 +571,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             let nineMonthsFromMay1 = Calendar.autoupdatingCurrent.date(byAdding: .month, value: 9, to: may1Date)!
 
             XCTAssertEqual(summary?.summaryData[9].periodStartDate, nineMonthsFromMay1)
-            
+
             expect.fulfill()
         }
 
@@ -591,7 +585,6 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         let feb21 = DateComponents(year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
-
 
         remote.getData(for: .month, endingOn: date) { (summary: StatsLikesSummaryTimeIntervalData?, error: Error?) in
             XCTAssertNil(error)

--- a/WordPressKitTests/TimeZoneServiceRemoteTests.swift
+++ b/WordPressKitTests/TimeZoneServiceRemoteTests.swift
@@ -45,7 +45,7 @@ class TimeZoneServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(results[0].name, "Africa")
             XCTAssertEqual(results[10].name, "Manual Offsets")
             expect.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })

--- a/WordPressKitTests/TransactionsServiceRemoteTests.swift
+++ b/WordPressKitTests/TransactionsServiceRemoteTests.swift
@@ -4,7 +4,7 @@ import CocoaLumberjack
 @testable import WordPressKit
 
 class TransactionsServiceRemoteTests: RemoteTestCase, RESTTestable {
-    
+
     let supportedCountriesSuccessFileName = "supported-countries-success.json"
     var remote: TransactionsServiceRemote!
 
@@ -12,21 +12,21 @@ class TransactionsServiceRemoteTests: RemoteTestCase, RESTTestable {
         super.setUp()
         remote = TransactionsServiceRemote(wordPressComRestApi: getRestApi())
     }
-    
+
     func testGetSupportedCountries() {
         let expect = expectation(description: "Get supported countries success")
-        
+
         stubRemoteResponse("me/transactions/supported-countries/",
                            filename: supportedCountriesSuccessFileName,
                            contentType: .ApplicationJSON,
                            status: 200)
-        
+
         remote.getSupportedCountries(success: { (countryList) in
             expect.fulfill()
             XCTAssert(countryList.count == 239)
             XCTAssert(countryList[0].code == "TR")
             XCTAssert(countryList[0].name == "Turkey")
-        }) { (error) in
+        }) { (_) in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }

--- a/WordPressKitTests/UsersServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/UsersServiceRemoteXMLRPCTests.swift
@@ -29,7 +29,6 @@ class UsersServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
 
     // MARK: - Tests
 
-
     func testFetchProfileSucceeds() {
         let expect = expectation(description: "Get user profile")
 
@@ -50,7 +49,7 @@ class UsersServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
 
                 expect.fulfill()
 
-            }, failure: { (error) in
+            }, failure: { (_) in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             })
@@ -58,7 +57,6 @@ class UsersServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
-
 
     func testFetchProfileDoesNotCrashWhenReceivingMissingData() {
         let expect = expectation(description: "Get user profile")
@@ -80,7 +78,7 @@ class UsersServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
 
                 expect.fulfill()
 
-            }, failure: { (error) in
+            }, failure: { (_) in
                 XCTFail("This callback shouldn't get called")
                 expect.fulfill()
             })

--- a/WordPressKitTests/Utilities/FeatureFlagRemoteTests.swift
+++ b/WordPressKitTests/Utilities/FeatureFlagRemoteTests.swift
@@ -8,7 +8,7 @@ class FeatureFlagRemoteTests: RemoteTestCase, RESTTestable {
     func testThatResponsesAreHandledCorrectly() throws {
         let flags = [
             FeatureFlag(title: UUID().uuidString, value: true),
-            FeatureFlag(title: UUID().uuidString, value: false),
+            FeatureFlag(title: UUID().uuidString, value: false)
         ].sorted()
 
         let data = try JSONEncoder().encode(flags.dictionaryValue)
@@ -64,7 +64,7 @@ class FeatureFlagRemoteTests: RemoteTestCase, RESTTestable {
         let expectation = XCTestExpectation()
 
         FeatureFlagRemote(wordPressComRestApi: getRestApi()).getRemoteFeatureFlags(forDeviceId: "Test") { result in
-            if case .success(_) = result {
+            if case .success = result {
                 XCTFail()
             }
             expectation.fulfill()

--- a/WordPressKitTests/WordPressComOAuthTests.swift
+++ b/WordPressKitTests/WordPressComOAuthTests.swift
@@ -28,9 +28,8 @@ class WordPressComOAuthTests: XCTestCase {
         }
     }
 
-
     func testAuthenticateUsernameNo2FASuccessCase() {
-        stub(condition: isOauthTokenRequest(url:.oAuthTokenUrl)) { request in
+        stub(condition: isOauthTokenRequest(url: .oAuthTokenUrl)) { _ in
             let stubPath = OHPathForFile("WordPressComOAuthSuccess.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -41,7 +40,7 @@ class WordPressComOAuthTests: XCTestCase {
             expect.fulfill()
             XCTAssert(!token!.isEmpty, "There should be a token available")
             XCTAssert(token == "fakeToken", "There should be a token available")
-        }, failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTFail("This call should be successfull")
         })
@@ -49,14 +48,14 @@ class WordPressComOAuthTests: XCTestCase {
     }
 
     func testAuthenticateUsernameNo2FAFailureWrongPasswordCase() {
-        stub(condition: isOauthTokenRequest(url:.oAuthTokenUrl)) { request in
+        stub(condition: isOauthTokenRequest(url: .oAuthTokenUrl)) { _ in
             let stubPath = OHPathForFile("WordPressComOAuthWrongPasswordFail.json", type(of: self))
             return fixture(filePath: stubPath!, status: 400, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
-        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil, success: { (token) in
+        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil, success: { (_) in
             expect.fulfill()
             XCTFail("This call should fail")
         }, failure: { (error) in
@@ -68,14 +67,14 @@ class WordPressComOAuthTests: XCTestCase {
     }
 
     func testAuthenticateUsername2FAWrong2FACase() {
-        stub(condition: isOauthTokenRequest(url:.oAuthTokenUrl)) { request in
+        stub(condition: isOauthTokenRequest(url: .oAuthTokenUrl)) { _ in
             let stubPath = OHPathForFile("WordPressComOAuthNeeds2FAFail.json", type(of: self))
             return fixture(filePath: stubPath!, status: 400, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
 
         let expect = self.expectation(description: "Call should complete")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
-        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil, success: { (token) in
+        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil, success: { (_) in
             expect.fulfill()
             XCTFail("This call should fail")
         }, failure: { (error) in
@@ -86,7 +85,7 @@ class WordPressComOAuthTests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
 
         let expectation2 = self.expectation(description: "Call should complete")
-        client.authenticateWithUsername("fakeUser", password: "fakePassword", multifactorCode: "fakeMultifactor", success: { (token) in
+        client.authenticateWithUsername("fakeUser", password: "fakePassword", multifactorCode: "fakeMultifactor", success: { (_) in
             expectation2.fulfill()
             XCTFail("This call should fail")
         }, failure: { (error) in
@@ -98,7 +97,7 @@ class WordPressComOAuthTests: XCTestCase {
     }
 
     func testRequestOneTimeCodeWithUsername() {
-        stub(condition: isOauthTokenRequest(url:.oAuthTokenUrl)) { request in
+        stub(condition: isOauthTokenRequest(url: .oAuthTokenUrl)) { _ in
             let stubPath = OHPathForFile("WordPressComOAuthNeeds2FAFail.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -108,7 +107,7 @@ class WordPressComOAuthTests: XCTestCase {
         client.requestOneTimeCodeWithUsername("fakeUser", password: "fakePassword",
                                               success: { () in
                                                 expect.fulfill()
-        }, failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTFail("This call should be successful")
 
@@ -117,7 +116,7 @@ class WordPressComOAuthTests: XCTestCase {
     }
 
     func testRequestSocial2FACodeWithUserID() {
-        stub(condition: isOauthTokenRequest(url:.socialLoginNewSMS2FA)) { request in
+        stub(condition: isOauthTokenRequest(url: .socialLoginNewSMS2FA)) { _ in
             let stubPath = OHPathForFile("WordPressComSocial2FACodeSuccess.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -129,7 +128,7 @@ class WordPressComOAuthTests: XCTestCase {
             expect.fulfill()
             XCTAssert(!newNonce.isEmpty, "There should be a newNonce available")
             XCTAssert(newNonce == "two_step_nonce_sms", "The newNonce should match")
-        }, failure: { (error, newretry) in
+        }, failure: { (_, _) in
             expect.fulfill()
             XCTFail("This call should be successful")
 
@@ -138,7 +137,7 @@ class WordPressComOAuthTests: XCTestCase {
     }
 
     func testAuthenticateWithIDToken() {
-        stub(condition: isOauthTokenRequest(url:.socialLogin)) { request in
+        stub(condition: isOauthTokenRequest(url: .socialLogin)) { _ in
             let stubPath = OHPathForFile("WordPressComAuthenticateWithIDTokenBearerTokenSuccess.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -151,13 +150,13 @@ class WordPressComOAuthTests: XCTestCase {
                                         expect.fulfill()
                                         XCTAssert(!token!.isEmpty, "There should be a token available")
                                         XCTAssert(token == "bearer_token", "The newNonce should match")
-        },needsMultifactor: { (userID, nonceInfo) in
+        }, needsMultifactor: { (_, _) in
             expect.fulfill()
             XCTFail("This call should be successful")
-        },existingUserNeedsConnection: { email in
+        }, existingUserNeedsConnection: { _ in
             expect.fulfill()
             XCTFail("This call should be successful")
-        },failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTFail("This call should be successful")
 
@@ -166,7 +165,7 @@ class WordPressComOAuthTests: XCTestCase {
     }
 
     func testAuthenticateWithIDToken2FANeeded() {
-        stub(condition: isOauthTokenRequest(url:.socialLogin)) { request in
+        stub(condition: isOauthTokenRequest(url: .socialLogin)) { _ in
             let stubPath = OHPathForFile("WordPressComAuthenticateWithIDToken2FANeededSuccess.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -175,17 +174,17 @@ class WordPressComOAuthTests: XCTestCase {
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
         client.authenticateWithIDToken("token",
                                        service: "google",
-                                       success: { (token) in
+                                       success: { (_) in
                                         expect.fulfill()
                                         XCTFail("This call should need multifactor")
-        },needsMultifactor: { (userID, nonceInfo) in
+        }, needsMultifactor: { (userID, nonceInfo) in
             expect.fulfill()
             XCTAssertEqual(userID, 1)
             XCTAssertEqual(nonceInfo.nonceBackup, "two_step_nonce_backup")
-        },existingUserNeedsConnection: { email in
+        }, existingUserNeedsConnection: { _ in
             expect.fulfill()
             XCTFail("This call should need multifactor")
-        },failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTFail("This call should need multifactor")
 
@@ -194,7 +193,7 @@ class WordPressComOAuthTests: XCTestCase {
     }
 
     func testAuthenticateWithIDTokenUserNeedsConnection() {
-        stub(condition: isOauthTokenRequest(url:.socialLogin)) { request in
+        stub(condition: isOauthTokenRequest(url: .socialLogin)) { _ in
             let stubPath = OHPathForFile("WordPressComAuthenticateWithIDTokenExistingUserNeedsConnection.json", type(of: self))
             return fixture(filePath: stubPath!, status: 400, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -203,16 +202,16 @@ class WordPressComOAuthTests: XCTestCase {
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
         client.authenticateWithIDToken("token",
                                        service: "google",
-                                       success: { (token) in
+                                       success: { (_) in
                                         expect.fulfill()
                                         XCTFail("This call should invoke user needs connection")
-        },needsMultifactor: { (userID, nonceInfo) in
+        }, needsMultifactor: { (_, _) in
             expect.fulfill()
             XCTFail("This call should invoke user needs connection")
-        },existingUserNeedsConnection: { email in
+        }, existingUserNeedsConnection: { email in
             expect.fulfill()
             XCTAssertEqual(email, "email")
-        },failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTFail("This call should invoke user needs connection")
 
@@ -221,19 +220,19 @@ class WordPressComOAuthTests: XCTestCase {
     }
 
     func testAuthenticateSocialLoginUser() {
-        stub(condition: isOauthTokenRequest(url:.socialLogin2FA)) { request in
+        stub(condition: isOauthTokenRequest(url: .socialLogin2FA)) { _ in
             let stubPath = OHPathForFile("WordPressComAuthenticateWithIDTokenBearerTokenSuccess.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
-        client.authenticateSocialLoginUser(1,authType: "authenticator", twoStepCode: "two_step_code", twoStepNonce: "two_step_nonce",
+        client.authenticateSocialLoginUser(1, authType: "authenticator", twoStepCode: "two_step_code", twoStepNonce: "two_step_nonce",
                                        success: { (token) in
                                         expect.fulfill()
                                         XCTAssert(!token!.isEmpty, "There should be a token available")
                                         XCTAssert(token == "bearer_token", "The newNonce should match")
-        },failure: { (error) in
+        }, failure: { (_) in
             expect.fulfill()
             XCTFail("This call should be successful")
 

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -131,7 +131,7 @@ extension WordPressComRestApiTests {
         // Given
         let inputPath = "/path/path"
         let expectedLocaleValue = "foo"
-        let params: [String : AnyObject] = [
+        let params: [String: AnyObject] = [
             WordPressComRestApi.LocaleKeyDefault: expectedLocaleValue as AnyObject
         ]
 

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -61,24 +61,24 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testSuccessfullCall() {
-        stub(condition: isRestAPIRequest()) { request in
+        stub(condition: isRestAPIRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiMedia.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTAssert(responseObject is [String: AnyObject], "The response should be a dictionary")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should be successfull")
             }
         )
         self.waitForExpectations(timeout: 2, handler: nil)
     }
-    
+
     func testBaseUrl() {
         let defaultApi = WordPressComRestApi()
         XCTAssertEqual(defaultApi.baseURLString, "https://public-api.wordpress.com/")
@@ -90,17 +90,17 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testInvalidTokenFailedCall() {
-        stub(condition: isRestAPIRequest()) { request in
+        stub(condition: isRestAPIRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiFailRequestInvalidToken.json", type(of: self))
             return fixture(filePath: stubPath!, status: 400, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (error, _) in
                 expect.fulfill()
                 XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error should a WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.invalidToken.rawValue), "The error code should be invalid token")
@@ -109,16 +109,16 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testInvalidJSONReceivedFailedCall() {
-        stub(condition: isRestAPIRequest()) { request in
+        stub(condition: isRestAPIRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiFailInvalidJSON.json", type(of: self))
             return fixture(filePath: stubPath!, status: 200, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.GET(wordPressMediaRoutePath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (error, _) in
                 expect.fulfill()
                 XCTAssert(error.domain == WordPressComRestApiErrorDomain, "The error domain should be WordPressComRestApiErrorDomain")
                 XCTAssert(error.code == Int(WordPressComRestApiError.responseSerializationFailed.rawValue), "The code should be invalid response serialization")
@@ -127,16 +127,16 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testInvalidJSONSentFailedCall() {
-        stub(condition: isRestAPIMediaNewRequest()) { request in
+        stub(condition: isRestAPIMediaNewRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiFailInvalidInput.json", type(of: self))
             return fixture(filePath: stubPath!, status: 400, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (error, _) in
                 expect.fulfill()
                 XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.invalidInput.rawValue), "The error code should be invalid input")
@@ -145,16 +145,16 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testUnauthorizedFailedCall() {
-        stub(condition: isRestAPIMediaNewRequest()) { request in
+        stub(condition: isRestAPIMediaNewRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiFailUnauthorized.json", type(of: self))
             return fixture(filePath: stubPath!, status: 403, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (error, _) in
                 expect.fulfill()
                 XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.authorizationRequired.rawValue), "The error code should be AuthorizationRequired")
@@ -163,16 +163,16 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testMultipleErrorsFailedCall() {
-        stub(condition: isRestAPIMediaNewRequest()) { request in
+        stub(condition: isRestAPIMediaNewRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiMultipleErrors.json", type(of: self))
             return fixture(filePath: stubPath!, status: 403, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (error, _) in
                 expect.fulfill()
                 XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.uploadFailed.rawValue), "The error code should be AuthorizationRequired")
@@ -181,16 +181,16 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testMultipleErrorsFailedMultiPartPostCall() {
-        stub(condition: isRestAPIMediaNewRequest()) { request in
+        stub(condition: isRestAPIMediaNewRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiMultipleErrors.json", type(of: self))
             return fixture(filePath: stubPath!, status: 403, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [], success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             expect.fulfill()
             XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
             XCTAssert(error.code == Int(WordPressComRestApiError.uploadFailed.rawValue), "The error code should be AuthorizationRequired")
@@ -199,7 +199,7 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testStreamMethodCallWithInvalidFile() {
-        stub(condition: isRestAPIMediaNewRequest()) { request in
+        stub(condition: isRestAPIMediaNewRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiMedia.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -207,10 +207,10 @@ class WordPressComRestApiTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
         let filePart = FilePart(parameterName: "file", url: URL(fileURLWithPath: "/a.txt") as URL, filename: "a.txt", mimeType: "image/jpeg")
-        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (_, _) in
                 expect.fulfill()
             }
         )
@@ -218,7 +218,7 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testStreamMethodParallelCalls() {
-        stub(condition: isRestAPIMediaNewRequest()) { request in
+        stub(condition: isRestAPIMediaNewRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiMedia.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -231,19 +231,19 @@ class WordPressComRestApiTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
         let filePart = FilePart(parameterName: "media[]", url: mediaURL as URL, filename: "test-image.jpg", mimeType: "image/jpeg")
-        let progress1 = api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        let progress1 = api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (_: AnyObject, _: HTTPURLResponse?) in
                 XCTFail("This call should fail")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (error, _) in
                 print(error)
                 XCTAssert(error.domain == NSURLErrorDomain, "The error domain should be NSURLErrorDomain")
                 XCTAssert(error.code == NSURLErrorCancelled, "The error code should be NSURLErrorCancelled")
             }
         )
         progress1?.cancel()
-        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.multipartPOST(wordPressMediaNewEndpointPath, parameters: nil, fileParts: [filePart], success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
 
-            }, failure: { (error, httpResponse) in
+            }, failure: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should succesful")
             }
@@ -252,15 +252,15 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     func testCancelationOfRequest() {
-        stub(condition: isRestAPIMediaNewRequest()) { request in
+        stub(condition: isRestAPIMediaNewRequest()) { _ in
             return HTTPStubsResponse.init(error: NSError(domain: NSURLErrorDomain, code: NSURLErrorCancelled, userInfo: nil))
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
-        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.POST(wordPressMediaNewEndpointPath, parameters: nil, success: { (_: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTFail("This call should fail")
-        }, failure: { (error, httpResponse) in
+        }, failure: { (error, _) in
             expect.fulfill()
             XCTAssert(error.domain == NSURLErrorDomain, "The error domain should be NSURLErrorDomain")
             XCTAssert(error.code == NSURLErrorCancelled, "The error code should be NSURLErrorCancelled")

--- a/WordPressKitTests/WordPressComServiceRemoteRestTests.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteRestTests.swift
@@ -44,7 +44,7 @@ class WordPressComServiceRemoteRestTests: XCTestCase {
     }
 
     func testThrottledFailureCall() {
-        stub(condition: isRestAPIUsersNewRequest()) { request in
+        stub(condition: isRestAPIUsersNewRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiFailThrottled.json", type(of: self))
             return fixture(filePath: stubPath!, status: 500, headers: ["Content-Type" as NSObject: "application/html" as AnyObject])
         }
@@ -55,7 +55,7 @@ class WordPressComServiceRemoteRestTests: XCTestCase {
                                             andPassword: "fakePassword",
                                             andClientID: "moo",
                                             andClientSecret: "cow",
-                                            success: { (responseObject) in
+                                            success: { (_) in
                                                 expect.fulfill()
                                                 XCTFail("This call should fail")
             }, failure: { (error) in

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
@@ -1,4 +1,3 @@
-
 import XCTest
 @testable import WordPressKit
 
@@ -43,7 +42,7 @@ final class SiteCreationServiceTests: RemoteTestCase, RESTTestable {
                 XCTAssertEqual(site.urlString, expectedUrlString)
                 XCTAssertEqual(site.xmlrpcString, "https://10711c.wordpress.com/xmlrpc.php")
 
-            case .failure(_):
+            case .failure:
                 XCTFail()
             }
         }

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteVerticals.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteVerticals.swift
@@ -27,7 +27,7 @@ final class SiteCreationVerticalsTests: RemoteTestCase, RESTTestable {
                 let actualLimit = verticals.count
                 XCTAssertEqual(actualLimit, expectedLimit)
 
-            case .failure(_):
+            case .failure:
                 XCTFail()
             }
         }

--- a/WordPressKitTests/WordPressOrgRestApiTests.swift
+++ b/WordPressKitTests/WordPressOrgRestApiTests.swift
@@ -23,7 +23,7 @@ class WordPressOrgRestApiTests: XCTestCase {
     }
 
     func testUnauthorizedCall() {
-        stub(condition: isAPIRequest()) { request in
+        stub(condition: isAPIRequest()) { _ in
             let stubPath = OHPathForFile("wp-forbidden.json", type(of: self))
             return fixture(filePath: stubPath!, status: 401, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
@@ -32,9 +32,9 @@ class WordPressOrgRestApiTests: XCTestCase {
         api.GET("wp/v2/settings", parameters: nil) { (result, response) in
             expect.fulfill()
             switch result {
-            case .success(_):
+            case .success:
                 XCTFail("This call should not suceed")
-            case .failure(_):
+            case .failure:
                 XCTAssertEqual(response?.statusCode, 401, "Response should be unauthorized")
             }
         }
@@ -42,13 +42,13 @@ class WordPressOrgRestApiTests: XCTestCase {
     }
 
     func testSuccessfulCall() {
-        stub(condition: isAPIRequest()) { request in
+        stub(condition: isAPIRequest()) { _ in
             let stubPath = OHPathForFile("wp-pages.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
         }
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressOrgRestApi(apiBase: apiBase)
-        api.GET("wp/v2/pages", parameters: nil) { (result, response) in
+        api.GET("wp/v2/pages", parameters: nil) { (result, _) in
             expect.fulfill()
             switch result {
             case .success(let object):
@@ -57,7 +57,7 @@ class WordPressOrgRestApiTests: XCTestCase {
                     return
                 }
                 XCTAssertEqual(pages.count, 10, "The API should return 10 pages")
-            case .failure(_):
+            case .failure:
                 XCTFail("This call should not fail")
             }
         }

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -23,17 +23,17 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     }
 
     func testSuccessfullCall() {
-        stub(condition: isXmlRpcAPIRequest()) { request in
+        stub(condition: isXmlRpcAPIRequest()) { _ in
             let stubPath = OHPathForFile("xmlrpc-response-getpost.xml", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
-        api.callMethod("wp.getPost", parameters: nil, success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+        api.callMethod("wp.getPost", parameters: nil, success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
             expect.fulfill()
             XCTAssert(responseObject is [String: AnyObject], "The response should be a dictionary")
-            }, failure: { (error, httpResponse) in
+            }, failure: { (_, _) in
                 expect.fulfill()
                 XCTFail("This call should be successfull")
             }


### PR DESCRIPTION
### Description

This is just to take care of all the issues fixed by the first run of `swiftlint autocorrect`. 

### Testing Details

Any hound violations? 

- [ ] Please check here if your pull request includes additional test coverage.
