### PR TITLE
Fix dependency issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,7 @@
 GEM
+  specs:
+
+GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.2)
@@ -87,4 +90,4 @@ DEPENDENCIES
   cocoapods (~> 1.8)!
 
 BUNDLED WITH
-   2.1.4
+   2.2.10

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -21,8 +21,11 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.8.0'
   s.dependency 'CocoaLumberjack', '~> 3.4'
-  s.dependency 'WordPressShared', '~> 1.15.0'
   s.dependency 'NSObject-SafeExpectations', '0.0.4'
   s.dependency 'wpxmlrpc', '~> 0.9'
   s.dependency 'UIDeviceIdentifier', '~> 1.4'
+
+    # Use a loose restriction that allows both production and beta versions, up to the next major version.
+  # If you want to update which of these is used, specify it in the host app.
+  s.dependency 'WordPressShared', '~> 1.15-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |s|
   s.dependency 'wpxmlrpc', '~> 0.9'
   s.dependency 'UIDeviceIdentifier', '~> 1.4'
 
-    # Use a loose restriction that allows both production and beta versions, up to the next major version.
+# Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressShared', '~> 1.15-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.28.0"
+  s.version       = "4.29.0-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC


### PR DESCRIPTION
Fixes an issue that could come up with WordPressShared is a transitive dependency.

Instead of locking this library to a specific WP version, we'll just specify the _minimum_ version that is supported (along with any future betas)