### PR TITLE
Add property to Account Settings: user enabled block emails

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.28.0"
+  s.version       = "4.28.1-beta.1"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.28.1-beta.1"
+  s.version       = "4.29.0-beta.2"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountSettings.swift
+++ b/WordPressKit/AccountSettings.swift
@@ -17,6 +17,7 @@ public struct AccountSettings {
     public let webAddress: String  // user_URL
     public let language: String    // language
     public let tracksOptOut: Bool
+    public let blockEmailNotifications: Bool
 
     public init(firstName: String,
                 lastName: String,
@@ -30,7 +31,8 @@ public struct AccountSettings {
                 primarySiteID: Int,
                 webAddress: String,
                 language: String,
-                tracksOptOut: Bool) {
+                tracksOptOut: Bool,
+                blockEmailNotifications: Bool) {
         self.firstName = firstName
         self.lastName = lastName
         self.displayName = displayName
@@ -44,6 +46,7 @@ public struct AccountSettings {
         self.webAddress = webAddress
         self.language = language
         self.tracksOptOut = tracksOptOut
+        self.blockEmailNotifications = blockEmailNotifications
     }
 }
 

--- a/WordPressKit/AccountSettingsRemote.swift
+++ b/WordPressKit/AccountSettingsRemote.swift
@@ -161,7 +161,8 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
             let primarySiteID = response["primary_site_ID"] as? Int,
             let webAddress = response["user_URL"] as? String,
             let language = response["language"] as? String,
-            let tracksOptOut = response["tracks_opt_out"] as? Bool else {
+            let tracksOptOut = response["tracks_opt_out"] as? Bool,
+            let blockEmailNotifications = response["subscription_delivery_email_blocked"] as? Bool else {
                 DDLogError("Error decoding me/settings response: \(responseObject)")
                 throw ResponseError.decodingFailure
             }
@@ -180,7 +181,8 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
                                primarySiteID: primarySiteID,
                                webAddress: webAddress,
                                language: language,
-                               tracksOptOut: tracksOptOut)
+                               tracksOptOut: tracksOptOut,
+                               blockEmailNotifications: blockEmailNotifications)
     }
 
     private func fieldNameForChange(_ change: AccountSettingsChange) -> String {

--- a/WordPressKitTests/AccountSettingsRemoteTests.swift
+++ b/WordPressKitTests/AccountSettingsRemoteTests.swift
@@ -66,6 +66,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(settings.email, self.email, "The email addresses should be equal.")
             XCTAssertEqual(settings.webAddress, self.userURL, "The web addresses should be equal.")
             XCTAssertEqual(settings.primarySiteID, self.siteID, "The primary site ID's should be equal.")
+            XCTAssertTrue(settings.blockEmailNotifications, "The 'block emails' in Reader Subscriptions should be enabled.")
             expect.fulfill()
         }) { _ in
             XCTFail("This callback shouldn't get called")

--- a/WordPressKitTests/me-settings-success.json
+++ b/WordPressKitTests/me-settings-success.json
@@ -43,5 +43,6 @@
     "jetpack_connect": [],
     "is_desktop_app_user": true,
     "locale_variant": false,
-    "tracks_opt_out": false
+    "tracks_opt_out": false,
+    "subscription_delivery_email_blocked": true
 }

--- a/WordPressKitTests/me-settings-success.json
+++ b/WordPressKitTests/me-settings-success.json
@@ -23,7 +23,7 @@
     "subscription_delivery_mail_option": "html",
     "subscription_delivery_day": 1,
     "subscription_delivery_hour": 6,
-    "subscription_delivery_email_blocked": false,
+    "subscription_delivery_email_blocked": true,
     "two_step_enabled": true,
     "two_step_sms_enabled": false,
     "two_step_backup_codes_printed": true,
@@ -43,6 +43,5 @@
     "jetpack_connect": [],
     "is_desktop_app_user": true,
     "locale_variant": false,
-    "tracks_opt_out": false,
-    "subscription_delivery_email_blocked": true
+    "tracks_opt_out": false
 }


### PR DESCRIPTION
### Description

WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16067

In WordPress > Me > Notification Settings > [Reader Subscriptions](https://wordpress.com/me/notifications/subscriptions), you can enable "Block Emails", which prevents any further email notifications from sending to the user for that site. 

Check whether or not that setting has been enabled from the `me/settings` [endpoint](https://developer.wordpress.com/docs/api/1.1/get/me/settings/) response, using the `subscription_delivery_email_blocked` field value.

Fixes #n/a

### Testing Details

This property and its value aren't used yet. WPiOS change tk.

- [x] Please check here if your pull request includes additional test coverage.
