### PR TITLE
Last Post Insight: don't fail if there are no posts

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.29.0-beta.2"
+  s.version       = "4.29.0-beta.3"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.29.0-beta.3"
+  s.version       = "4.29.0-beta.4"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKitTests/ReaderPostServiceRemote+RelatedPostsTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+RelatedPostsTests.swift
@@ -46,7 +46,7 @@ class ReaderPostServiceRelatedPostsTests: RemoteTestCase, RESTTestable {
                            contentType: .ApplicationJSON,
                            status: 503)
 
-        readerPostServiceRemote.fetchRelatedPosts(for: postID, from: siteID, success: { relatedPosts in
+        readerPostServiceRemote.fetchRelatedPosts(for: postID, from: siteID, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15401
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16074

This fixes an issue where fetching post stats would return a failure if there are no posts. Now, success is returned with no data.


### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
