### PR TITLE
Push podspec to internal spec repo too

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,22 @@ orbs:
   # Using 1.0 of our Orbs means it will use the latest 1.0.x version from https://github.com/wordpress-mobile/circleci-orbs
   ios: wordpress-mobile/ios@1.0
 
+# YAML anchors for some common/repeated values
+x-common-params:
+  - &xcode-version "11.2.1"
+  - &podspec "WordPressKit.podspec"
+  - &on-tags-only
+      tags:
+        only: /.*/
+      branches:
+        ignore: /.*/
+
 workflows:
   test_and_validate:
     jobs:
       - ios/test:
           name: Test
-          xcode-version: "11.2.1"
+          xcode-version: *xcode-version
           workspace: WordPressKit.xcworkspace
           scheme: WordPressKitTests
           device: iPhone Xs
@@ -18,17 +28,21 @@ workflows:
           pod-install: true
       - ios/validate-podspec:
           name: Validate Podspec
-          xcode-version: "11.2.1"
-          podspec-path: WordPressKit.podspec
+          xcode-version: *xcode-version
+          podspec-path: *podspec
           bundle-install: true
       - ios/publish-podspec:
+          name: Publish to a8c Spec Repo
+          xcode-version: *xcode-version
+          podspec-path: *podspec
+          spec-repo: https://github.com/wordpress-mobile/cocoapods-specs.git
+          bundle-install: true
+          post-to-slack: false
+          filters: *on-tags-only
+      - ios/publish-podspec:
           name: Publish to Trunk
-          xcode-version: "11.2.1"
-          podspec-path: WordPressKit.podspec
+          xcode-version: *xcode-version
+          podspec-path: *podspec
           bundle-install: true
           post-to-slack: true
-          filters:
-            tags:
-              only: /.*/
-            branches:
-              ignore: /.*/
+          filters: *on-tags-only


### PR DESCRIPTION
This will make CI push this podspec to our new internal spec repo on tag (in addition to still pushing it to trunk as usual).

Similar to:
 - https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/580
 - https://github.com/wordpress-mobile/WordPressUI-iOS/pull/83
 - https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/289