### PR TITLE
Filter Jetpack sites for an account

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.29.0-beta.6"
+  s.version       = "4.29.0-beta.7"
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemote.h
+++ b/WordPressKit/AccountServiceRemote.h
@@ -14,13 +14,15 @@ typedef NS_ERROR_ENUM(AccountServiceRemoteErrorDomain, AccountServiceRemoteError
 @protocol AccountServiceRemote <NSObject>
 
 /**
- *  @brief      Gets all blogs for an account.
+ *  @brief      Gets blogs for an account.
  *
- *  @param      success     The block that will be executed on success.  Can be nil.
- *  @param      failure     The block that will be executed on failure.  Can be nil.
+ *  @param      filterJetpackSites    Whether we're fetching only Jetpack blogs.
+ *  @param      success      The block that will be executed on success.  Can be nil.
+ *  @param      failure      The block that will be executed on failure.  Can be nil.
  */
-- (void)getBlogsWithSuccess:(void (^)(NSArray *blogs))success
-                    failure:(void (^)(NSError *error))failure;
+- (void)getBlogs:(BOOL)filterJetpackSites
+         success:(void (^)(NSArray *blogs))success
+         failure:(void (^)(NSError *error))failure;
 
 /**
  *  @brief      Gets only visible blogs for an account.

--- a/WordPressKit/AccountServiceRemote.h
+++ b/WordPressKit/AccountServiceRemote.h
@@ -25,6 +25,16 @@ typedef NS_ERROR_ENUM(AccountServiceRemoteErrorDomain, AccountServiceRemoteError
          failure:(void (^)(NSError *error))failure;
 
 /**
+ *  @brief      Gets all blogs for an account.
+ *
+ *  @param      success      The block that will be executed on success.  Can be nil.
+ *  @param      failure      The block that will be executed on failure.  Can be nil.
+ */
+- (void)getBlogsWithSuccess:(void (^)(NSArray *blogs))success
+                    failure:(void (^)(NSError *error))failure;
+
+
+/**
  *  @brief      Gets only visible blogs for an account.
  *
  *  @discussion This method is designed for use in extensions in order to provide a simple

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -34,8 +34,17 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
          success:(void (^)(NSArray *))success
          failure:(void (^)(NSError *))failure
 {
-    NSDictionary *parameters = filterJetpackSites ? @{@"filters": @"jetpack"} : nil;
-    [self getBlogsWithParameters:parameters success:success failure:failure];
+    if (filterJetpackSites) {
+        [self getBlogsWithParameters:@{@"filters": @"jetpack"} success:success failure:failure];
+    } else {
+        [self getBlogsWithSuccess:success failure:failure];
+    }
+}
+
+- (void)getBlogsWithSuccess:(void (^)(NSArray *))success
+                    failure:(void (^)(NSError *))failure
+{
+    [self getBlogsWithParameters:nil success:success failure:failure];
 }
 
 - (void)getVisibleBlogsWithSuccess:(void (^)(NSArray *))success

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -30,10 +30,12 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
 
 @implementation AccountServiceRemoteREST
 
-- (void)getBlogsWithSuccess:(void (^)(NSArray *))success
-                    failure:(void (^)(NSError *))failure
+- (void)getBlogs:(BOOL)filterJetpackSites
+         success:(void (^)(NSArray *))success
+         failure:(void (^)(NSError *))failure
 {
-    [self getBlogsWithParameters:nil success:success failure:failure];
+    NSDictionary *parameters = filterJetpackSites ? @{@"filters": @"jetpack"} : nil;
+    [self getBlogsWithParameters:parameters success:success failure:failure];
 }
 
 - (void)getVisibleBlogsWithSuccess:(void (^)(NSArray *))success

--- a/WordPressKitTests/AccountServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/AccountServiceRemoteRESTTests.swift
@@ -139,7 +139,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs success")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsSuccessMockFilename, contentType: .ApplicationJSON)
-        remote.getBlogs(false, success: { blogs in
+        remote.getBlogsWithSuccess({ blogs in
             XCTAssertEqual(blogs?.count, 3, "There should be 3 blogs here")
             expect.fulfill()
         }, failure: { _ in
@@ -169,7 +169,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs with empty response array success")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsEmptySuccessMockFilename, contentType: .ApplicationJSON)
-        remote.getBlogs(false, success: { blogs in
+        remote.getBlogsWithSuccess({ blogs in
             XCTAssertEqual(blogs?.count, 0, "There should be 0 blogs here")
             expect.fulfill()
         }, failure: { _ in
@@ -199,7 +199,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs server error failure")
 
         stubRemoteResponse(meSitesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getBlogs(false, success: { blogs in
+        remote.getBlogsWithSuccess({ blogs in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -241,7 +241,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs auth failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getBlogs(false, success: { blogs in
+        remote.getBlogsWithSuccess({ blogs in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -283,7 +283,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs with invalid json response failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getBlogs(false, success: { blogs in
+        remote.getBlogsWithSuccess({ blogs in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { _ in

--- a/WordPressKitTests/AccountServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/AccountServiceRemoteRESTTests.swift
@@ -13,6 +13,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
     let authOptionsEndpoint     = "users/jimthetester/auth-options"
     let meEndpoint              = "me"
     let meSitesEndpoint         = "me/sites"
+    let jetpackSitesEndpoint    = "filters=jetpack"
     let emailEndpoint           = "/is-available/email"
     let usernameEndpoint        = "/is-available/username"
     let linkEndpoint            = "auth/send-login-email"
@@ -138,7 +139,22 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs success")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsSuccessMockFilename, contentType: .ApplicationJSON)
-        remote.getBlogsWithSuccess({ blogs in
+        remote.getBlogs(false, success: { blogs in
+            XCTAssertEqual(blogs?.count, 3, "There should be 3 blogs here")
+            expect.fulfill()
+        }, failure: { _ in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetJetpackBlogsSucceeds() {
+        let expect = expectation(description: "Get blogs success")
+
+        stubRemoteResponse(jetpackSitesEndpoint, filename: getBlogsSuccessMockFilename, contentType: .ApplicationJSON)
+        remote.getBlogs(true, success: { blogs in
             XCTAssertEqual(blogs?.count, 3, "There should be 3 blogs here")
             expect.fulfill()
         }, failure: { _ in
@@ -153,7 +169,22 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs with empty response array success")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsEmptySuccessMockFilename, contentType: .ApplicationJSON)
-        remote.getBlogsWithSuccess({ blogs in
+        remote.getBlogs(false, success: { blogs in
+            XCTAssertEqual(blogs?.count, 0, "There should be 0 blogs here")
+            expect.fulfill()
+        }, failure: { _ in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetJetpackBlogsWithEmptyResponseArraySucceeds() {
+        let expect = expectation(description: "Get blogs with empty response array success")
+
+        stubRemoteResponse(jetpackSitesEndpoint, filename: getBlogsEmptySuccessMockFilename, contentType: .ApplicationJSON)
+        remote.getBlogs(true, success: { blogs in
             XCTAssertEqual(blogs?.count, 0, "There should be 0 blogs here")
             expect.fulfill()
         }, failure: { _ in
@@ -168,7 +199,28 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs server error failure")
 
         stubRemoteResponse(meSitesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getBlogsWithSuccess({ _ in
+        remote.getBlogs(false, success: { blogs in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        }, failure: { error in
+            guard let error = error as NSError? else {
+                XCTFail("The returned error could not be cast as NSError")
+                expect.fulfill()
+                return
+            }
+            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetJetpackBlogsWithServerErrorFails() {
+        let expect = expectation(description: "Get blogs server error failure")
+
+        stubRemoteResponse(jetpackSitesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
+        remote.getBlogs(true, success: { blogs in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -189,7 +241,28 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs auth failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getBlogsWithSuccess({ _ in
+        remote.getBlogs(false, success: { blogs in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        }, failure: { error in
+            guard let error = error as NSError? else {
+                XCTFail("The returned error could not be cast as NSError")
+                expect.fulfill()
+                return
+            }
+            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetJetpackBlogsWithBadAuthFails() {
+        let expect = expectation(description: "Get blogs auth failure")
+
+        stubRemoteResponse(jetpackSitesEndpoint, filename: getBlogsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
+        remote.getBlogs(true, success: { blogs in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -210,7 +283,21 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs with invalid json response failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getBlogsWithSuccess({ _ in
+        remote.getBlogs(false, success: { blogs in
+            XCTFail("This callback shouldn't get called")
+            expect.fulfill()
+        }, failure: { _ in
+            expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testGetJetpackBlogsWithBadJsonFails() {
+        let expect = expectation(description: "Get blogs with invalid json response failure")
+
+        stubRemoteResponse(jetpackSitesEndpoint, filename: getBlogsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
+        remote.getBlogs(true, success: { blogs in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { _ in


### PR DESCRIPTION
## Description

- Added a new getBlogs method that includes a `filterJetpackSites` flag 

## How to test

- WP PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16140