### PR TITLE
[Tooling] Standardize podspec format

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -10,8 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressKit-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
-  s.author        = { "Automattic" => "mobile@automattic.com" }
-  s.social_media_url = "https://twitter.com/automattic"
+  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
 
   s.platform      = :ios, "11.0"
   s.swift_version = '5.0'

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,22 +1,24 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
   s.version       = "4.29.0-beta.6"
-  s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
 
+  s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC
                     This framework encapsulates all of the networking calls and entity parsers required to interact
                     with WordPress.com and WordPress.org endpoints.
                     DESC
 
-  s.homepage      = "https://github.com/wordpress-mobile/WordPressKit-iOS"
-  s.license       = "GPLv2"
-  s.author        = { "WordPress" => "mobile@automattic.com" }
+  s.homepage      = "http://apps.wordpress.com"
+  s.license       = { :type => "GPLv2", :file => "LICENSE" }
+  s.author        = { "Automattic" => "mobile@automattic.com" }
+  s.social_media_url = "http://twitter.com/WordPressiOS"
+
   s.platform      = :ios, "11.0"
   s.swift_version = '5.0'
+
   s.source        = { :git => "https://github.com/wordpress-mobile/WordPressKit-iOS.git", :tag => s.version.to_s }
   s.source_files  = 'WordPressKit/**/*.{h,m,swift}'
   s.private_header_files = "WordPressKit/Private/*.h"
-  s.requires_arc  = true
   s.header_dir    = 'WordPressKit'
 
   s.dependency 'Alamofire', '~> 4.8.0'
@@ -25,7 +27,7 @@ Pod::Spec.new do |s|
   s.dependency 'wpxmlrpc', '~> 0.9'
   s.dependency 'UIDeviceIdentifier', '~> 1.4'
 
-# Use a loose restriction that allows both production and beta versions, up to the next major version.
+  # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.
   s.dependency 'WordPressShared', '~> 1.15-beta' # Don't change this until we hit 2.0 in WPShared
 end

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -8,10 +8,10 @@ Pod::Spec.new do |s|
                     with WordPress.com and WordPress.org endpoints.
                     DESC
 
-  s.homepage      = "http://apps.wordpress.com"
+  s.homepage      = "https://github.com/wordpress-mobile/WordPressKit-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
   s.author        = { "Automattic" => "mobile@automattic.com" }
-  s.social_media_url = "http://twitter.com/WordPressiOS"
+  s.social_media_url = "https://twitter.com/automattic"
 
   s.platform      = :ios, "11.0"
   s.swift_version = '5.0'

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressKit-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }
-  s.author        = { "The WordPress Mobile Team" => "mobile@automattic.com" }
+  s.author        = { "The WordPress Mobile Team" => "mobile@wordpress.org" }
 
   s.platform      = :ios, "11.0"
   s.swift_version = '5.0'

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.description   = <<-DESC
                     This framework encapsulates all of the networking calls and entity parsers required to interact
                     with WordPress.com and WordPress.org endpoints.
-                    DESC
+                  DESC
 
   s.homepage      = "https://github.com/wordpress-mobile/WordPressKit-iOS"
   s.license       = { :type => "GPLv2", :file => "LICENSE" }


### PR DESCRIPTION
As part of paaHJt-Vl-p2, this simply standardize the podspec file so that all our pods use a similar format and structure, with similar keys and common values.

See https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/582 for the rules I decided to follow on the format and content standardization.