### PR TITLE
Likes: remove parsing user's URL

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.30.0"
+  s.version       = "4.31.0-beta.1"
   
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -487,7 +487,6 @@
     - login -> username
     - name -> displayName
     - site_ID -> primaryBlogID
-    - URL -> homeURL
     - avatar_URL -> avatarURL
 
  @param jsonUser The dictionary that represents a RemoteUser.
@@ -500,13 +499,6 @@
     user.displayName = jsonUser[@"name"];
     user.primaryBlogID = jsonUser[@"site_ID"];
     user.avatarURL = jsonUser[@"avatar_URL"];
-
-    // ensure that the URL is present and the site is visible.
-    NSString *homeURL = jsonUser[@"URL"];
-    NSNumber *siteVisible = jsonUser[@"site_visible"];
-    if (![homeURL isEmpty] && siteVisible.boolValue) {
-        user.homeURL = homeURL;
-    }
 
     return user;
 }

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -611,7 +611,6 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
  *              - login -> username
  *              - name -> displayName
  *              - site_ID -> primaryBlogID
- *              - URL -> homeURL
  *              - avatar_URL -> avatarURL
  *
  *  @param  jsonUser    The dictionary that represents a RemoteUser.
@@ -625,13 +624,6 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     user.primaryBlogID = jsonUser[@"site_ID"];
     user.avatarURL = jsonUser[@"avatar_URL"];
 
-    // ensure that the URL is present and the site is visible.
-    NSString *homeURL = jsonUser[@"URL"];
-    NSNumber *siteVisible = jsonUser[@"site_visible"];
-    if (![homeURL isEmpty] && siteVisible.boolValue) {
-        user.homeURL = homeURL;
-    }
-    
     return user;
 }
 

--- a/WordPressKit/RemoteUser.h
+++ b/WordPressKit/RemoteUser.h
@@ -7,7 +7,6 @@
 @property (nonatomic, strong) NSString *email;
 @property (nonatomic, strong) NSString *displayName;
 @property (nonatomic, strong) NSNumber *primaryBlogID;
-@property (nonatomic, strong) NSString *homeURL;
 @property (nonatomic, strong) NSString *avatarURL;
 @property (nonatomic, strong) NSDate *dateCreated;
 @property (nonatomic, assign) BOOL emailVerified;

--- a/WordPressKitTests/AccountServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/AccountServiceRemoteRESTTests.swift
@@ -199,7 +199,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs server error failure")
 
         stubRemoteResponse(meSitesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getBlogsWithSuccess({ blogs in
+        remote.getBlogsWithSuccess({ _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -220,7 +220,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs server error failure")
 
         stubRemoteResponse(jetpackSitesEndpoint, data: Data(), contentType: .NoContentType, status: 500)
-        remote.getBlogs(true, success: { blogs in
+        remote.getBlogs(true, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -241,7 +241,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs auth failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getBlogsWithSuccess({ blogs in
+        remote.getBlogsWithSuccess({ _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -262,7 +262,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs auth failure")
 
         stubRemoteResponse(jetpackSitesEndpoint, filename: getBlogsAuthFailureMockFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getBlogs(true, success: { blogs in
+        remote.getBlogs(true, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { error in
@@ -283,7 +283,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs with invalid json response failure")
 
         stubRemoteResponse(meSitesEndpoint, filename: getBlogsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getBlogsWithSuccess({ blogs in
+        remote.getBlogsWithSuccess({ _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { _ in
@@ -297,7 +297,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get blogs with invalid json response failure")
 
         stubRemoteResponse(jetpackSitesEndpoint, filename: getBlogsBadJsonFailureMockFilename, contentType: .ApplicationJSON, status: 200)
-        remote.getBlogs(true, success: { blogs in
+        remote.getBlogs(true, success: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         }, failure: { _ in

--- a/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
@@ -39,38 +39,7 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.username, "johnwick")
             XCTAssertEqual(user.displayName, "John Wick")
             XCTAssertEqual(user.primaryBlogID, NSNumber(value: 124625450))
-            XCTAssertEqual(user.homeURL, "home URL")
             XCTAssertEqual(user.avatarURL, "avatar URL")
-            expect.fulfill()
-
-        }, failure: { _ in
-            XCTFail("This callback shouldn't get called")
-        })
-
-        waitForExpectations(timeout: timeout, handler: nil)
-    }
-
-    func testThatHomeURLIsCorrectlyParsed() {
-        let expect = expectation(description: "Fetching comment likes should succeed")
-
-        stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForCommentID(NSNumber(value: commentId), success: { users in
-            // site_visible: false
-            guard let secondUser = users?[1] else {
-                XCTFail("Failed to retrieve mock post likes")
-                return
-            }
-
-            XCTAssertNil(secondUser.homeURL)
-
-            // site_visible: true, URL: empty string
-            guard let thirdUser = users?.last else {
-                XCTFail("Failed to retrieve mock post likes")
-                return
-            }
-
-            XCTAssertNil(thirdUser.homeURL)
-
             expect.fulfill()
 
         }, failure: { _ in

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -39,38 +39,7 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.username, "johndoe")
             XCTAssertEqual(user.displayName, "John Doe")
             XCTAssertEqual(user.primaryBlogID, NSNumber(value: 54321))
-            XCTAssertEqual(user.homeURL, "home URL")
             XCTAssertEqual(user.avatarURL, "avatar URL")
-            expect.fulfill()
-
-        }, failure: { _ in
-            XCTFail("This callback shouldn't get called")
-        })
-
-        waitForExpectations(timeout: timeout, handler: nil)
-    }
-
-    func testThatHomeURLCorrectlyParsed() {
-        let expect = expectation(description: "Fetch likes should succeed")
-
-        stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForPostID(NSNumber(value: postId), success: { users in
-            // site_visible: false
-            guard let secondUser = users?[1] else {
-                XCTFail("Failed to retrieve mock post likes")
-                return
-            }
-
-            XCTAssertNil(secondUser.homeURL)
-
-            // site_visible: true, URL: empty string
-            guard let thirdUser = users?.last else {
-                XCTFail("Failed to retrieve mock post likes")
-                return
-            }
-
-            XCTAssertNil(thirdUser.homeURL)
-
             expect.fulfill()
 
         }, failure: { _ in


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15662, https://github.com/wordpress-mobile/WordPressKit-iOS/pull/361

This removes parsing the user's primary URL. It was intended to be used in Like notifications, but we've changed direction and the URL is no longer needed.

### Testing Details

Verify the tests pass.

- [x] Please check here if your pull request includes additional test coverage. (Specifically, _less_ test coverage as I've removed relevant tests.)
