### PR TITLE
Include Author ID in Post Service parameters.

### DIFF
--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -520,6 +520,10 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
         parameters[@"slug"] = post.slug;
     }
 
+    if (post.authorID) {
+        parameters[@"author"] = post.authorID;
+    }
+
     if (post.categories) {
         parameters[@"categories_by_id"] = [post.categories valueForKey:@"categoryID"];
     }

--- a/WordPressKit/PostServiceRemoteXMLRPC.m
+++ b/WordPressKit/PostServiceRemoteXMLRPC.m
@@ -383,6 +383,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     [postParams setValueIfNotNil:[post.URL absoluteString] forKey:@"permalink"];
     [postParams setValueIfNotNil:post.excerpt forKey:@"mt_excerpt"];
     [postParams setValueIfNotNil:post.slug forKey:@"wp_slug"];
+    [postParams setValueIfNotNil:post.authorID forKey:@"wp_author_id"];
     
     // To remove a featured image, you have to send an empty string to the API
     if (post.postThumbnailID == nil) {


### PR DESCRIPTION
### Description

Fixes #380 

### Testing Details

An authorID provided by a `RemotePost` should translate to a `POST` parameter for REST and XML-RPC calls.

- [ ] Please check here if your pull request includes additional test coverage.
