### PR TITLE
Adds a wrapper around the dotCom and Dot Org Rest API 

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.31.0-beta.2"
-  
+  s.version       = "4.31.0-beta.3"
+
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC
                     This framework encapsulates all of the networking calls and entity parsers required to interact

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		4625BAEB253E118400C04AAD /* PageLayoutServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4625BAEA253E118400C04AAD /* PageLayoutServiceRemoteTests.swift */; };
 		4625BAF1253E12C000C04AAD /* page-layout-blog-layouts-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4625BAF0253E12C000C04AAD /* page-layout-blog-layouts-success.json */; };
 		4625BAF7253E130900C04AAD /* page-layout-blog-layouts-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = 4625BAF6253E130800C04AAD /* page-layout-blog-layouts-malformed.json */; };
+		467C20692626243D00DB5A38 /* WordPressRestApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467C20682626243D00DB5A38 /* WordPressRestApi.swift */; };
 		730E869F21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */; };
 		731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */; };
 		731BA83821DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83721DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift */; };
@@ -692,6 +693,7 @@
 		4625BAEA253E118400C04AAD /* PageLayoutServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageLayoutServiceRemoteTests.swift; sourceTree = "<group>"; };
 		4625BAF0253E12C000C04AAD /* page-layout-blog-layouts-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "page-layout-blog-layouts-success.json"; sourceTree = "<group>"; };
 		4625BAF6253E130800C04AAD /* page-layout-blog-layouts-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "page-layout-blog-layouts-malformed.json"; sourceTree = "<group>"; };
+		467C20682626243D00DB5A38 /* WordPressRestApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressRestApi.swift; sourceTree = "<group>"; };
 		6C2A33D76FD1052D6F30466D /* Pods-WordPressKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.debug.xcconfig"; sourceTree = "<group>"; };
 		6F2E0CC4FA01B5475A378DA2 /* Pods-WordPressKitTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComServiceRemote+SiteVerticals.swift"; sourceTree = "<group>"; };
@@ -2057,6 +2059,7 @@
 			isa = PBXGroup;
 			children = (
 				FF807250241FB90E00809AF5 /* Authenticator.swift */,
+				467C20682626243D00DB5A38 /* WordPressRestApi.swift */,
 				FF80724F241FB90E00809AF5 /* WordPressOrgRestApi.swift */,
 				93BD27741EE73944002BB00B /* HTTPAuthenticationAlertController.swift */,
 				93BD27751EE73944002BB00B /* NSDate+WordPressJSON.h */,
@@ -2798,6 +2801,7 @@
 				93C674F21EE8351E00BFAF05 /* NSMutableDictionary+Helpers.m in Sources */,
 				4624222D2548BA0F002B8A12 /* RemoteSiteDesign.swift in Sources */,
 				74D67F061F1528470010C5ED /* PeopleServiceRemote.swift in Sources */,
+				467C20692626243D00DB5A38 /* WordPressRestApi.swift in Sources */,
 				98DC787522BAEBF200267279 /* StatsAllAnnualInsight.swift in Sources */,
 				740B23C31F17EE8000067A2A /* RemotePostCategory.m in Sources */,
 				8B2F4BF124ACE3C30056C08A /* RemoteReaderInterest.swift in Sources */,

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -544,6 +544,22 @@ extension WordPressComRestApi {
     }
 }
 
+extension WordPressComRestApi: WordPressRestApi {
+    @discardableResult
+    public func GET(_ path: String, parameters: [String : AnyObject]?, completion: @escaping Completion) -> Progress? {
+        return GET(path, parameters: parameters) { (responseObject, httpResponse) in
+            completion(.success(responseObject), httpResponse)
+        } failure: { (error, httpResponse) in
+            completion(.failure(error), httpResponse)
+        }
+    }
+
+    public func requestPath(fromOrgPath path: String, with siteID: Int?) -> String {
+        guard let siteID = siteID else { return path }
+        return path.replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(siteID)/")
+    }
+}
+
 // MARK: - Constants
 
 private extension WordPressComRestApi {

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -546,12 +546,12 @@ extension WordPressComRestApi {
 
 extension WordPressComRestApi: WordPressRestApi {
     @discardableResult
-    public func GET(_ path: String, parameters: [String : AnyObject]?, completion: @escaping Completion) -> Progress? {
-        return GET(path, parameters: parameters) { (responseObject, httpResponse) in
+    public func GET(_ path: String, parameters: [String: AnyObject]?, completion: @escaping Completion) -> Progress? {
+        return GET(path, parameters: parameters, success: { (responseObject, httpResponse) in
             completion(.success(responseObject), httpResponse)
-        } failure: { (error, httpResponse) in
+        }, failure: { (error, httpResponse) in
             completion(.failure(error), httpResponse)
-        }
+        })
     }
 
     public func requestPath(fromOrgPath path: String, with siteID: Int?) -> String {

--- a/WordPressKit/WordPressOrgRestApi.swift
+++ b/WordPressKit/WordPressOrgRestApi.swift
@@ -11,7 +11,7 @@ import Foundation
 }
 
 @objc
-open class WordPressOrgRestApi: NSObject {
+open class WordPressOrgRestApi: NSObject, WordPressRestApi {
     public typealias Completion = (Swift.Result<Any, Error>, HTTPURLResponse?) -> Void
     private let apiBase: URL
     private let authenticator: Authenticator?

--- a/WordPressKit/WordPressRestApi.swift
+++ b/WordPressKit/WordPressRestApi.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// This class offers a wrapper to provide a common interface between `WordPressOrgRestApi` and `WordPressComRestApi` for classes that can use either
+/// one nearly interchangably.
+public protocol WordPressRestApi {
+    typealias Completion = (Swift.Result<Any, Error>, HTTPURLResponse?) -> Void
+
+    /**
+     Executes a GET request to the specified endpoint defined on URLString
+
+     - parameter path:  the url string to be added to the baseURL
+     - parameter parameters: the parameters to be encoded on the request
+     - parameter completion: callback to be called on successful or failed request.
+
+     - returns:  a NSProgress object that can be used to track the progress of the request and to cancel the request. If the method
+     returns nil it's because something happened on the request serialization and the network request was not started, but the failure callback
+     will be invoked with the error specificing the serialization issues.
+     */
+    @discardableResult func GET(_ path: String, parameters: [String: AnyObject]?, completion: @escaping Completion) -> Progress?
+
+    /**
+    Modifies the provided path from an Org endpoint as needed to support a generic path for either `WordPressOrgRestApi` and `WordPressComRestApi`. This is meant to be
+    used as a helper before calling the GET request.
+
+     - parameter path:  the url string to be added to the baseURL
+     - parameter siteID: the unique ID that represents a site.
+
+     - returns:  a modified path or the same path depending on the implementation. A default implementation is provided that returns the same path.
+     */
+    func requestPath(fromOrgPath path: String, with siteID: Int?) -> String
+}
+
+extension WordPressRestApi {
+    public func requestPath(fromOrgPath path: String, with siteID: Int?) -> String {
+        return path
+    }
+}

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -274,7 +274,7 @@ class WordPressComRestApiTests: XCTestCase {
         let expectedPath = "/wp/v2/sites/1001/themes?status=active"
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
         let result = api.requestPath(fromOrgPath: orgPath, with: 1001)
-        XCTAssertEqual(result,expectedPath)
+        XCTAssertEqual(result, expectedPath)
     }
 
     func testSuccessfullCallCommonGETStructure() {
@@ -291,7 +291,7 @@ class WordPressComRestApiTests: XCTestCase {
             switch result {
             case .success(let responseObject):
                 XCTAssert(responseObject is [String: AnyObject], "The response should be a dictionary")
-            case .failure(_):
+            case .failure:
                 XCTFail("This call should be successfull")
             }
         }
@@ -309,7 +309,7 @@ class WordPressComRestApiTests: XCTestCase {
         api.GET(wordPressMediaRoutePath, parameters: nil) { (result, response) in
             expect.fulfill()
             switch result {
-            case .success(_):
+            case .success:
                 XCTFail("This call should fail")
             case .failure(let err):
                 let error = err as NSError


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3163

📓 This can safely merge before the associated iOS PR
**Related PR:** 
- **iOS:** https://github.com/wordpress-mobile/WordPress-iOS/pull/16282

### Description
This adds a protocol to enable calling the `WordPressComRestApi` and `WordPressOrgRestApi` rest APIs more generically. This change enables us to reference the APIs like: 

https://github.com/wordpress-mobile/WordPress-iOS/pull/16282/files#diff-7c6d162cb574648684c05a0dc616461c371e301910b6b446c0610c292f8f2b2bR16-R26

And would allow a simplification of areas of code like:
https://github.com/wordpress-mobile/WordPress-iOS/blob/7226927d598be4a3b529347bb7e80e74414bb8c3/WordPress/Classes/ViewRelated/Gutenberg/GutenbergNetworking.swift#L15-L58

### Testing Details
I've added unit tests to this build but it can also be tested alongside the notes and with the build-in https://github.com/wordpress-mobile/WordPress-iOS/pull/16282.

- [x] Please check here if your pull request includes additional test coverage.
