### PR TITLE
Add edit context to restore post call

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.31.0"
+  s.version       = "4.32.0-beta.2"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.32.0-beta.2"
+  s.version       = "4.32.0-beta.3"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -290,6 +290,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
 
     // The parameters are passed as part of the string here because AlamoFire doesn't encode parameters on POST requests.
+    // https://github.com/wordpress-mobile/WordPressKit-iOS/pull/385
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/restore?context=edit", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -289,7 +289,8 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
 
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/restore", self.siteID, post.postID];
+    // The parameters are passed as part of the string here because AlamoFire doesn't encode parameters on POST requests.
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/restore?context=edit", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -384,7 +384,7 @@
 
     XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:dotComID]);
 
-    NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/restore", dotComID, post.postID];
+    NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/restore?context=edit", dotComID, post.postID];
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 


### PR DESCRIPTION
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3342
**Related PR** https://github.com/wordpress-mobile/WordPress-iOS/pull/16342

### Description

When restoring a post with basic content such as a single paragraph block the server will sometimes treat that as a Classic Post if you don't include the `context=edit` query parameter. 

You can validate this by deleting a post then making a `POST` request to:
`https://public-api.wordpress.com/rest/v1.1/sites/{{site_id}}/posts/{{post_id}}/restore`
`https://public-api.wordpress.com/rest/v1.1/sites/{{site_id}}/posts/{{post_id}}/restore?context=edit`

This is 100% repeatable for posts that have been created as part of Headstart content.

### Testing Details

Using the build from PR https://github.com/wordpress-mobile/WordPress-iOS/pull/16342

1. Create a site that generates posts such as Cassel under the Blog category. 
    * This is an important step because for some reason that I wasn't able to track down logging in on a different device restores the content as a Gutenberg Post without then added parameter.
2. Navigate to a Post and ensure it's a Gutenberg Post.
3. Delete it. 
4. Restore it. 
5. Validate that the restored post (now in drafts) uses the Gutenberg Editor. 

- [x] Please check here if your pull request includes additional test coverage.
