### PR TITLE
Parse a remote user's email response.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.31.0"
+  s.version       = "4.31.1-beta.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.31.1-beta.1"
+  s.version       = "4.32.0-beta.2"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/BlogServiceRemoteXMLRPC.m
+++ b/WordPressKit/BlogServiceRemoteXMLRPC.m
@@ -194,6 +194,7 @@ static NSString * const RemotePostTypePublicKey = @"public";
     user.userID = [xmlrpcUser numberForKey:@"user_id"];
     user.username = [xmlrpcUser stringForKey:@"username"];
     user.displayName = [xmlrpcUser stringForKey:@"display_name"];
+    user.email = [xmlrpcUser stringForKey:@"email"];
     return user;
 }
 


### PR DESCRIPTION
### Description

Refs https://github.com/wordpress-mobile/WordPress-iOS/pull/16215

This updates `BlogServiceRemoteXMLRPC.remoteUserFromXMLRPCDictionary` to include the remote user's email address as part of the response.

@ScoutHarris Game for a review?

### Testing Details

This can be tested via https://github.com/wordpress-mobile/WordPress-iOS/pull/16215. Set a break point and confirm that the email address is included in the response.

- [ ] Please check here if your pull request includes additional test coverage.
