### PR TITLE
Update podspec version to match latest release

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.31.0"
+  s.version       = "4.32.0-beta.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

This is a quick fix to a mistake I made when cutting [the `4.32.0-beta.1` release](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/4.32.0-beta.1) where I overlooked updating the podspec version.

After merging this I'll edit the release in question so that it points to the merge commit.

**Note**: This updated release will contain the changes in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/386 which was merged later, I think that's fine as long as no new changes come along.

### Testing Details

Check that the 

- [ ] Please check here if your pull request includes additional test coverage.
