### PR TITLE
Likes: update endpoint version and parse new data

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.32.0-beta.2"
+  s.version       = "4.32.0-beta.3"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -432,6 +432,7 @@
 		93F50A481F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml in Resources */ = {isa = PBXBuildFile; fileRef = 93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */; };
 		984E34EB22EF7209005C3F92 /* StatsFileDownloadsTimeIntervalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984E34EA22EF7209005C3F92 /* StatsFileDownloadsTimeIntervalData.swift */; };
 		984E34F422EF9465005C3F92 /* stats-file-downloads.json in Resources */ = {isa = PBXBuildFile; fileRef = 984E34F322EF9464005C3F92 /* stats-file-downloads.json */; };
+		9856BE962630B5C200C12FEB /* RemoteUser+Likes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9856BE952630B5C200C12FEB /* RemoteUser+Likes.swift */; };
 		98DC787522BAEBF200267279 /* StatsAllAnnualInsight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DC787422BAEBF100267279 /* StatsAllAnnualInsight.swift */; };
 		9A2D0B28225E0119009E585F /* JetpackServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D0B27225E0119009E585F /* JetpackServiceRemote.swift */; };
 		9A2D0B2B225E0E22009E585F /* JetpackServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D0B2A225E0E22009E585F /* JetpackServiceRemoteTests.swift */; };
@@ -1030,6 +1031,7 @@
 		93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-response-valid-but-unexpected-dictionary.xml"; sourceTree = "<group>"; };
 		984E34EA22EF7209005C3F92 /* StatsFileDownloadsTimeIntervalData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsFileDownloadsTimeIntervalData.swift; sourceTree = "<group>"; };
 		984E34F322EF9464005C3F92 /* stats-file-downloads.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-file-downloads.json"; sourceTree = "<group>"; };
+		9856BE952630B5C200C12FEB /* RemoteUser+Likes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RemoteUser+Likes.swift"; sourceTree = "<group>"; };
 		98DC787422BAEBF100267279 /* StatsAllAnnualInsight.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsAllAnnualInsight.swift; sourceTree = "<group>"; };
 		9A2D0B27225E0119009E585F /* JetpackServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackServiceRemote.swift; sourceTree = "<group>"; };
 		9A2D0B2A225E0E22009E585F /* JetpackServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackServiceRemoteTests.swift; sourceTree = "<group>"; };
@@ -1801,6 +1803,7 @@
 				9309995A1F16616A00F006A1 /* RemoteTheme.m */,
 				93BD27671EE736A8002BB00B /* RemoteUser.h */,
 				93BD27681EE736A8002BB00B /* RemoteUser.m */,
+				9856BE952630B5C200C12FEB /* RemoteUser+Likes.swift */,
 				436D563B2118E18D00CEAA33 /* State.swift */,
 				E1D6B555200E46F200325669 /* WPTimeZone.swift */,
 				E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */,
@@ -2755,6 +2758,7 @@
 				8BB66DB02523C181000B29DA /* ReaderPostServiceRemote+V2.swift in Sources */,
 				74E229501F1E741B0085F7F2 /* RemotePublicizeConnection.swift in Sources */,
 				40E7FEB722106A8D0032834E /* StatsCommentsInsight.swift in Sources */,
+				9856BE962630B5C200C12FEB /* RemoteUser+Likes.swift in Sources */,
 				57BCD3D426209D9500292CB3 /* AppTransportSecuritySettings.swift in Sources */,
 				9311A6891F22625A00704AC9 /* TaxonomyServiceRemoteREST.m in Sources */,
 				9AB6D647218705E90008F274 /* RemoteDiff.swift in Sources */,

--- a/WordPressKit/CommentServiceRemoteREST.h
+++ b/WordPressKit/CommentServiceRemoteREST.h
@@ -3,6 +3,7 @@
 #import <WordPressKit/SiteServiceRemoteWordPressComREST.h>
 
 @class RemoteUser;
+@class RemoteLikeUser;
 
 @interface CommentServiceRemoteREST : SiteServiceRemoteWordPressComREST <CommentServiceRemote>
 
@@ -87,7 +88,7 @@
  @param failure The block that will be executed on failure. Can be nil.
  */
 - (void)getLikesForCommentID:(NSNumber *)commentID
-                     success:(void (^)(NSArray<RemoteUser *> *))success
+                     success:(void (^)(NSArray<RemoteLikeUser *> *))success
                      failure:(void (^)(NSError *))failure;
 
 @end

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -390,14 +390,14 @@
 }
 
 - (void)getLikesForCommentID:(NSNumber *)commentID
-                     success:(void (^)(NSArray<RemoteUser *> *))success
+                     success:(void (^)(NSArray<RemoteLikeUser *> *))success
                      failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(commentID);
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
 
     [self.wordPressComRestApi GET:requestUrl
                        parameters:nil
@@ -473,34 +473,11 @@
  
  @param jsonUsers An array containing JSON representations of users.
  */
-- (NSArray<RemoteUser *> *)remoteUsersFromJSONArray:(NSArray *)jsonUsers
+- (NSArray<RemoteLikeUser *> *)remoteUsersFromJSONArray:(NSArray *)jsonUsers
 {
     return [jsonUsers wp_map:^id(NSDictionary *jsonUser) {
-        return [self remoteUserFromJSONDictionary:jsonUser];
+        return [[RemoteLikeUser alloc] initWithDictionary: jsonUser];
     }];
-}
-
-/**
- Creates a RemoteUser instance based on provided JSON object. Expected dictionary
- contents (and its mapping to the RemoteUser object):
-    - ID -> userID
-    - login -> username
-    - name -> displayName
-    - site_ID -> primaryBlogID
-    - avatar_URL -> avatarURL
-
- @param jsonUser The dictionary that represents a RemoteUser.
- */
-- (RemoteUser *)remoteUserFromJSONDictionary:(NSDictionary *)jsonUser
-{
-    RemoteUser *user = [RemoteUser new];
-    user.userID = jsonUser[@"ID"];
-    user.username = jsonUser[@"login"];
-    user.displayName = jsonUser[@"name"];
-    user.primaryBlogID = jsonUser[@"site_ID"];
-    user.avatarURL = jsonUser[@"avatar_URL"];
-
-    return user;
 }
 
 @end

--- a/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/PostServiceRemoteREST.h
@@ -4,6 +4,7 @@
 #import <WordPressKit/RemoteMedia.h>
 
 @class RemoteUser;
+@class RemoteLikeUser;
 
 @interface PostServiceRemoteREST : SiteServiceRemoteWordPressComREST <PostServiceRemote>
 
@@ -66,7 +67,7 @@
  *  @param      failure     The block that will be executed on failure. Can be nil.
  */
 - (void)getLikesForPostID:(NSNumber *)postID
-                  success:(void (^)(NSArray<RemoteUser *> *))success
+                  success:(void (^)(NSArray<RemoteLikeUser *> *))success
                   failure:(void (^)(NSError *))failure;
 
 @end

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -308,14 +308,14 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 }
 
 - (void)getLikesForPostID:(NSNumber *)postID
-                  success:(void (^)(NSArray<RemoteUser *> * _Nonnull))success
+                  success:(void (^)(NSArray<RemoteLikeUser *> * _Nonnull))success
                   failure:(void (^)(NSError * _Nullable))failure
 {
     NSParameterAssert(postID);
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/likes", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
     
     [self.wordPressComRestApi GET:requestUrl
                        parameters:nil
@@ -599,36 +599,11 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
  *
  *  @param  jsonUsers   An array containing JSON representations of users.
  */
-- (NSArray<RemoteUser *> *)remoteUsersFromJSONArray:(NSArray *)jsonUsers
+- (NSArray<RemoteLikeUser *> *)remoteUsersFromJSONArray:(NSArray *)jsonUsers
 {
     return [jsonUsers wp_map:^id(NSDictionary *jsonUser) {
-        return [self remoteUserFromJSONDictionary:jsonUser];
+        return [[RemoteLikeUser alloc] initWithDictionary: jsonUser];
     }];
-}
-
-/**
- *  @brief      Creates a RemoteUser instance based on provided JSON object.
- *
- *  @discussion Expected dictionary contents (and its mapping to the
- *              RemoteUser object):
- *              - ID -> userID
- *              - login -> username
- *              - name -> displayName
- *              - site_ID -> primaryBlogID
- *              - avatar_URL -> avatarURL
- *
- *  @param  jsonUser    The dictionary that represents a RemoteUser.
- */
-- (RemoteUser *)remoteUserFromJSONDictionary:(NSDictionary *)jsonUser
-{
-    RemoteUser *user = [RemoteUser new];
-    user.userID = jsonUser[@"ID"];
-    user.username = jsonUser[@"login"];
-    user.displayName = jsonUser[@"name"];
-    user.primaryBlogID = jsonUser[@"site_ID"];
-    user.avatarURL = jsonUser[@"avatar_URL"];
-
-    return user;
 }
 
 @end

--- a/WordPressKit/RemoteUser+Likes.swift
+++ b/WordPressKit/RemoteUser+Likes.swift
@@ -26,16 +26,16 @@ import Foundation
 
 }
 
-public class RemoteLikeUserPreferredBlog: NSObject {
-    let blogUrl: String
-    let blogName: String
-    let iconUrl: String
-    let blogID: Int?
+@objc public class RemoteLikeUserPreferredBlog: NSObject {
+    @objc let blogUrl: String
+    @objc let blogName: String
+    @objc let iconUrl: String
+    @objc let blogID: NSNumber?
 
     public init(dictionary: [String: Any]) {
         blogUrl = dictionary["url"] as? String ?? ""
         blogName = dictionary["name"] as? String ?? ""
-        blogID = dictionary["id"] as? Int ?? nil
+        blogID = dictionary["id"] as? NSNumber ?? nil
 
         iconUrl = {
             if let iconInfo = dictionary["icon"] as? [String: Any],

--- a/WordPressKit/RemoteUser+Likes.swift
+++ b/WordPressKit/RemoteUser+Likes.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+@objc public class RemoteLikeUser: RemoteUser {
+    @objc public var bio: String?
+    @objc public var dateLiked: String?
+    @objc public var preferredBlog: RemoteLikeUserPreferredBlog?
+
+    @objc public init(dictionary: [String: Any]) {
+        super.init()
+
+        userID = dictionary["ID"] as? NSNumber
+        username = dictionary["login"] as? String
+        displayName = dictionary["name"] as? String
+        primaryBlogID = dictionary["site_ID"] as? NSNumber
+        avatarURL = dictionary["avatar_URL"] as? String
+        bio = dictionary["bio"] as? String
+        dateLiked = dictionary["date_liked"] as? String
+
+        preferredBlog = {
+            if let preferredBlogDict = dictionary["preferred_blog"] as? [String: Any] {
+                return RemoteLikeUserPreferredBlog.init(dictionary: preferredBlogDict)
+            }
+            return nil
+        }()
+    }
+
+}
+
+public class RemoteLikeUserPreferredBlog: NSObject {
+    let blogUrl: String
+    let blogName: String
+    let iconUrl: String
+    let blogID: Int?
+
+    public init(dictionary: [String: Any]) {
+        blogUrl = dictionary["url"] as? String ?? ""
+        blogName = dictionary["name"] as? String ?? ""
+        blogID = dictionary["id"] as? Int ?? nil
+
+        iconUrl = {
+            if let iconInfo = dictionary["icon"] as? [String: Any],
+               let iconImg = iconInfo["img"] as? String {
+                return iconImg
+            }
+            return ""
+        }()
+    }
+}

--- a/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
@@ -40,6 +40,7 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.displayName, "John Wick")
             XCTAssertEqual(user.primaryBlogID, NSNumber(value: 124625450))
             XCTAssertEqual(user.avatarURL, "avatar URL")
+            XCTAssertEqual(user.bio, "user bio")
             expect.fulfill()
 
         }, failure: { _ in
@@ -58,6 +59,28 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         }, failure: { error in
             XCTAssertNotNil(error)
             expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testThatParsingPreferredBlogWorks() {
+        let expect = expectation(description: "Fetching comment likes should succeed")
+
+        stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesSuccessFilename, contentType: .ApplicationJSON)
+        remote.getLikesForCommentID(NSNumber(value: commentId), success: { users in
+            guard let userWithPreferredBlog = users?.first,
+                  let userWithoutPreferredBlog = users?.last else {
+                XCTFail("Failed to retrieve mock comment likes")
+                return
+            }
+
+            XCTAssertEqual(userWithPreferredBlog.preferredBlog?.blogUrl, "blog URL")
+            XCTAssert((userWithoutPreferredBlog.preferredBlog == nil), "preferredBlog should be nil.")
+            expect.fulfill()
+
+        }, failure: { _ in
+            XCTFail("This callback shouldn't get called")
         })
 
         waitForExpectations(timeout: timeout, handler: nil)

--- a/WordPressKitTests/Mock Data/comment-likes-success.json
+++ b/WordPressKitTests/Mock Data/comment-likes-success.json
@@ -16,7 +16,19 @@
             "ip_address": false,
             "site_ID": 124625450,
             "site_visible": true,
-            "default_avatar": false
+            "default_avatar": false,
+            "date_liked": "2021-04-08 15:11:37",
+            "bio": "user bio",
+            "primary_blog": "primary blog URL",
+            "preferred_blog": {
+                "id": 12345,
+                "name": "Blog",
+                "url": "blog URL",
+                "icon": {
+                    "img": "img URL",
+                    "ico": "ico URL"
+                }
+            }
         },
         {
             "ID": 12346,
@@ -32,7 +44,16 @@
             "ip_address": false,
             "site_ID": 54321,
             "site_visible": false,
-            "default_avatar": false
+            "default_avatar": false,
+            "date_liked": "2021-04-08 15:11:37",
+            "bio": "user bio",
+            "primary_blog": "primary blog URL",
+            "preferred_blog": {
+                "id": 12345,
+                "name": "Blog",
+                "url": "blog URL",
+                "icon": null
+            }
         },
         {
             "ID": 12347,
@@ -48,7 +69,11 @@
             "ip_address": false,
             "site_ID": 54321,
             "site_visible": true,
-            "default_avatar": false
+            "default_avatar": false,
+            "date_liked": "2021-04-08 15:11:37",
+            "bio": "",
+            "primary_blog": "primary blog URL",
+            "preferred_blog": null
         }
     ]
 }

--- a/WordPressKitTests/Mock Data/post-likes-success.json
+++ b/WordPressKitTests/Mock Data/post-likes-success.json
@@ -18,7 +18,19 @@
             "ip_address": false,
             "site_ID": 54321,
             "site_visible": true,
-            "default_avatar": false
+            "default_avatar": false,
+            "date_liked": "2021-04-16 17:12:08",
+            "bio": "user bio",
+            "primary_blog": "primary blog URL",
+            "preferred_blog": {
+                "id": 12345,
+                "name": "Blog",
+                "url": "blog URL",
+                "icon": {
+                    "img": "img URL",
+                    "ico": "ico URL"
+                }
+            }
         },
         {
             "ID": 12346,
@@ -34,7 +46,19 @@
             "ip_address": false,
             "site_ID": 54321,
             "site_visible": false,
-            "default_avatar": false
+            "default_avatar": false,
+            "date_liked": "2021-04-16 17:12:08",
+            "bio": "",
+            "primary_blog": "primary blog URL",
+            "preferred_blog": {
+                "id": 12345,
+                "name": "Blog",
+                "url": "blog URL",
+                "icon": {
+                    "img": "img URL",
+                    "ico": "ico URL"
+                }
+            }
         },
         {
             "ID": 12347,
@@ -50,7 +74,11 @@
             "ip_address": false,
             "site_ID": 54321,
             "site_visible": true,
-            "default_avatar": false
+            "default_avatar": false,
+            "date_liked": "2021-04-16 17:12:08",
+            "bio": "user bio",
+            "primary_blog": "primary blog URL",
+            "preferred_blog": null
         }
     ]
 }

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -40,6 +40,7 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.displayName, "John Doe")
             XCTAssertEqual(user.primaryBlogID, NSNumber(value: 54321))
             XCTAssertEqual(user.avatarURL, "avatar URL")
+            XCTAssertEqual(user.bio, "user bio")
             expect.fulfill()
 
         }, failure: { _ in
@@ -58,6 +59,28 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         }, failure: { error in
             XCTAssertNotNil(error)
             expect.fulfill()
+        })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testThatParsingPreferredBlogWorks() {
+        let expect = expectation(description: "Fetch likes should succeed")
+
+        stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
+        remote.getLikesForPostID(NSNumber(value: postId), success: { users in
+            guard let userWithPreferredBlog = users?.first,
+                  let userWithoutPreferredBlog = users?.last else {
+                XCTFail("Failed to retrieve mock post likes")
+                return
+            }
+
+            XCTAssertEqual(userWithPreferredBlog.preferredBlog?.blogUrl, "blog URL")
+            XCTAssert((userWithoutPreferredBlog.preferredBlog == nil), "preferredBlog should be nil.")
+            expect.fulfill()
+
+        }, failure: { _ in
+            XCTFail("This callback shouldn't get called")
         })
 
         waitForExpectations(timeout: timeout, handler: nil)

--- a/WordPressKitTests/WordPressAPI/WordPressOrgXMLRPCValidatorTests.swift
+++ b/WordPressKitTests/WordPressAPI/WordPressOrgXMLRPCValidatorTests.swift
@@ -21,7 +21,7 @@ final class WordPressOrgXMLRPCValidatorTests: XCTestCase {
                 schemes.insert(scheme)
             }
             return true
-        }, response: { request in
+        }, response: { _ in
             let error = NSError(domain: "", code: NSURLErrorNotConnectedToInternet, userInfo: nil)
             return HTTPStubsResponse(error: error)
         })
@@ -30,9 +30,9 @@ final class WordPressOrgXMLRPCValidatorTests: XCTestCase {
 
         // When
         let expectation = self.expectation(description: "Wait for success or failure")
-        validator.guessXMLRPCURLForSite(exampleURLString, userAgent: "", success: { result in
+        validator.guessXMLRPCURLForSite(exampleURLString, userAgent: "", success: { _ in
             expectation.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expectation.fulfill()
         })
 
@@ -51,7 +51,7 @@ final class WordPressOrgXMLRPCValidatorTests: XCTestCase {
                 schemes.insert(scheme)
             }
             return true
-        }, response: { request in
+        }, response: { _ in
             let error = NSError(domain: "", code: NSURLErrorNotConnectedToInternet, userInfo: nil)
             return HTTPStubsResponse(error: error)
         })
@@ -60,9 +60,9 @@ final class WordPressOrgXMLRPCValidatorTests: XCTestCase {
 
         // When
         let expectation = self.expectation(description: "Wait for success or failure")
-        validator.guessXMLRPCURLForSite(exampleURLString, userAgent: "", success: { result in
+        validator.guessXMLRPCURLForSite(exampleURLString, userAgent: "", success: { _ in
             expectation.fulfill()
-        }, failure: { error in
+        }, failure: { _ in
             expectation.fulfill()
         })
 

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -286,7 +286,7 @@ class WordPressComRestApiTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
 
-        api.GET(wordPressMediaRoutePath, parameters: nil) { (result, response) in
+        api.GET(wordPressMediaRoutePath, parameters: nil) { (result, _) in
             expect.fulfill()
             switch result {
             case .success(let responseObject):
@@ -306,7 +306,7 @@ class WordPressComRestApiTests: XCTestCase {
         let expect = self.expectation(description: "One callback should be invoked")
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
 
-        api.GET(wordPressMediaRoutePath, parameters: nil) { (result, response) in
+        api.GET(wordPressMediaRoutePath, parameters: nil) { (result, _) in
             expect.fulfill()
             switch result {
             case .success:


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15662
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16353

This uses the new v1.2 versions of the Post and Comment likes endpoints to obtain:
- `preferred_blog`
- `bio`
- `date_liked`

New classes:
- `RemoteLikeUser` that inherits from `RemoteUser` and adds specific Like info.
- `RemoteLikeUserPreferredBlog` used by `RemoteLikeUser` to store `preferred_blog` info.

Note:
Something to consider when reviewing the structure I implemented. It is my intent to create `LikeUser` and `LikeUserPreferredBlog` entities in WPiOS core data (names TBD if you have a preference). The `LikeUser` will have a relationship to `LikeUserPreferredBlog`. 

### Testing Details

Can be smoke tested with the referenced WPiOS PR. These changes aren't used in WPiOS yet, but since `RemoteLikeUser` inherits from `RemoteUser`, likers should still display as before.

- [x] Please check here if your pull request includes additional test coverage.
