### PR TITLE
Add the edit context to the delete post call

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.32.0-beta.4"
+  s.version       = "4.32.0-beta.5"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -265,7 +265,8 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 {
     NSParameterAssert([post isKindOfClass:[RemotePost class]]);
 
-    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", self.siteID, post.postID];
+    // The parameters are passed as part of the string here because AlamoFire doesn't encode parameters on POST requests.
+    NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete?context=edit", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -347,7 +347,7 @@
 
     XCTAssertNoThrow(service = [[PostServiceRemoteREST alloc] initWithWordPressComRestApi:api siteID:dotComID]);
 
-    NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", dotComID, post.postID];
+    NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/delete?context=edit", dotComID, post.postID];
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 


### PR DESCRIPTION
**Discovered with** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3342
**Related PR** https://github.com/wordpress-mobile/WordPress-iOS/pull/16367

### Description

When deleting a post the server will treat that as a Classic Post if you don't include the `context=edit` query parameter. 

You can validate this by deleting a post then making a `POST` request to:
`https://public-api.wordpress.com/rest/v1.1/sites/$site/posts/$post_ID/delete`
`https://public-api.wordpress.com/rest/v1.1/sites/$site/posts/$post_ID/delete?context=edit`

### Testing Details

Using the build from PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16367

1. Navigate to a Post and ensure it's a Gutenberg Post.
2. Delete it. 
3. Navigate to the trash, select the Edit button on the post.
4. Expect the post to be opened as Gutenberg content.

- [x] Please check here if your pull request includes additional test coverage.
