### PR TITLE
RemoteLikeUserPreferredBlog: make properties public

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.32.0-beta.5"
+  s.version       = "4.32.0-beta.6"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/RemoteUser+Likes.swift
+++ b/WordPressKit/RemoteUser+Likes.swift
@@ -27,10 +27,10 @@ import Foundation
 }
 
 @objc public class RemoteLikeUserPreferredBlog: NSObject {
-    @objc let blogUrl: String
-    @objc let blogName: String
-    @objc let iconUrl: String
-    @objc let blogID: NSNumber?
+    @objc public var blogUrl: String
+    @objc public var blogName: String
+    @objc public var iconUrl: String
+    @objc public var blogID: NSNumber?
 
     public init(dictionary: [String: Any]) {
         blogUrl = dictionary["url"] as? String ?? ""


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15662
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16383

This makes the properties of `RemoteLikeUserPreferredBlog` public so they can be accessed from WordPress > `CommentService`.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
