### PR TITLE
Comment and Post likes: get relevant IDs

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.32.0-beta.6"
+  s.version       = "4.32.0-beta.7"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -398,23 +398,13 @@
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
-    NSDictionary *params = @{ @"meta": @"site,comment"};
 
     [self.wordPressComRestApi GET:requestUrl
-                       parameters:params
+                       parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
-            NSNumber *commentID = responseObject[@"meta"][@"data"][@"comment"][@"ID"];
-            NSNumber *siteID = responseObject[@"meta"][@"data"][@"site"][@"ID"];
-
-            if ([commentID wp_isValidObject] && [siteID wp_isValidObject]) {
-                NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
-                success([self remoteUsersFromJSONArray:jsonUsers commentID:commentID siteID:siteID]);
-            } else {
-                NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid commentID or siteID for comment likes: %@", responseObject] };
-                NSError *error = [NSError errorWithDomain:WordPressComRestApiErrorDomain code:0 userInfo:userInfo];
-                failure(error);
-            }
+            NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
+            success([self remoteUsersFromJSONArray:jsonUsers commentID:commentID siteID:self.siteID]);
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -398,13 +398,14 @@
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+    NSNumber *siteID = self.siteID;
 
     [self.wordPressComRestApi GET:requestUrl
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
             NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
-            success([self remoteUsersFromJSONArray:jsonUsers commentID:commentID siteID:self.siteID]);
+            success([self remoteUsersFromJSONArray:jsonUsers commentID:commentID siteID:siteID]);
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -398,13 +398,23 @@
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+    NSDictionary *params = @{ @"meta": @"site,comment"};
 
     [self.wordPressComRestApi GET:requestUrl
-                       parameters:nil
+                       parameters:params
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
-            NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
-            success([self remoteUsersFromJSONArray:jsonUsers]);
+            NSNumber *commentID = responseObject[@"meta"][@"data"][@"comment"][@"ID"];
+            NSNumber *siteID = responseObject[@"meta"][@"data"][@"site"][@"ID"];
+
+            if ([commentID wp_isValidObject] && [siteID wp_isValidObject]) {
+                NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
+                success([self remoteUsersFromJSONArray:jsonUsers commentID:commentID siteID:siteID]);
+            } else {
+                NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid commentID or siteID for comment likes: %@", responseObject] };
+                NSError *error = [NSError errorWithDomain:WordPressComRestApiErrorDomain code:0 userInfo:userInfo];
+                failure(error);
+            }
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {
@@ -469,14 +479,18 @@
 }
 
 /**
- Returns an array of RemoteUser based on provided JSON representation of users.
+ Returns an array of RemoteLikeUser based on provided JSON representation of users.
  
  @param jsonUsers An array containing JSON representations of users.
+ @param commentID ID of the Comment the users liked.
+ @param siteID    ID of the Comment's site.
  */
 - (NSArray<RemoteLikeUser *> *)remoteUsersFromJSONArray:(NSArray *)jsonUsers
+                                              commentID:(NSNumber *)commentID
+                                                 siteID:(NSNumber *)siteID
 {
     return [jsonUsers wp_map:^id(NSDictionary *jsonUser) {
-        return [[RemoteLikeUser alloc] initWithDictionary: jsonUser];
+        return [[RemoteLikeUser alloc] initWithDictionary:jsonUser commentID:commentID siteID:siteID];
     }];
 }
 

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -319,23 +319,13 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/likes", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
-    NSDictionary *params = @{ RemoteOptionKeyMeta: @"site,post"};
     
     [self.wordPressComRestApi GET:requestUrl
-                       parameters:params
+                       parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
-            NSNumber *postID = responseObject[@"meta"][@"data"][@"post"][@"ID"];
-            NSNumber *siteID = responseObject[@"meta"][@"data"][@"site"][@"ID"];
-
-            if ([postID wp_isValidObject] && [siteID wp_isValidObject]) {
                 NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
-                success([self remoteUsersFromJSONArray:jsonUsers postID:postID siteID:siteID]);
-            } else {
-                NSDictionary *userInfo = @{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Invalid postID or siteID for post likes: %@", responseObject] };
-                NSError *error = [NSError errorWithDomain:WordPressComRestApiErrorDomain code:0 userInfo:userInfo];
-                failure(error);
-            }
+                success([self remoteUsersFromJSONArray:jsonUsers postID:postID siteID:self.siteID]);
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -319,13 +319,14 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/likes", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
-    
+    NSNumber *siteID = self.siteID;
+
     [self.wordPressComRestApi GET:requestUrl
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
                 NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
-                success([self remoteUsersFromJSONArray:jsonUsers postID:postID siteID:self.siteID]);
+                success([self remoteUsersFromJSONArray:jsonUsers postID:postID siteID:siteID]);
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {

--- a/WordPressKit/RemoteUser+Likes.swift
+++ b/WordPressKit/RemoteUser+Likes.swift
@@ -3,11 +3,26 @@ import Foundation
 @objc public class RemoteLikeUser: RemoteUser {
     @objc public var bio: String?
     @objc public var dateLiked: String?
+    @objc public var likedSiteID: NSNumber?
+    @objc public var likedPostID: NSNumber?
+    @objc public var likedCommentID: NSNumber?
     @objc public var preferredBlog: RemoteLikeUserPreferredBlog?
 
-    @objc public init(dictionary: [String: Any]) {
+    @objc public init(dictionary: [String: Any], postID: NSNumber, siteID: NSNumber) {
         super.init()
+        setValuesFor(dictionary: dictionary)
+        likedPostID = postID
+        likedSiteID = siteID
+    }
 
+    @objc public init(dictionary: [String: Any], commentID: NSNumber, siteID: NSNumber) {
+        super.init()
+        setValuesFor(dictionary: dictionary)
+        likedCommentID = commentID
+        likedSiteID = siteID
+    }
+
+    private func setValuesFor(dictionary: [String: Any]) {
         userID = dictionary["ID"] as? NSNumber
         username = dictionary["login"] as? String
         displayName = dictionary["name"] as? String

--- a/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
@@ -41,6 +41,8 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.primaryBlogID, NSNumber(value: 124625450))
             XCTAssertEqual(user.avatarURL, "avatar URL")
             XCTAssertEqual(user.bio, "user bio")
+            XCTAssertEqual(user.likedCommentID, NSNumber(value: 9))
+            XCTAssertEqual(user.likedSiteID, NSNumber(value: 8))
             expect.fulfill()
 
         }, failure: { _ in

--- a/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
@@ -41,8 +41,8 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.primaryBlogID, NSNumber(value: 124625450))
             XCTAssertEqual(user.avatarURL, "avatar URL")
             XCTAssertEqual(user.bio, "user bio")
-            XCTAssertEqual(user.likedCommentID, NSNumber(value: 9))
-            XCTAssertEqual(user.likedSiteID, NSNumber(value: 8))
+            XCTAssertEqual(user.likedCommentID, NSNumber(value: 1))
+            XCTAssertEqual(user.likedSiteID, NSNumber(value: 0))
             expect.fulfill()
 
         }, failure: { _ in

--- a/WordPressKitTests/Mock Data/comment-likes-success.json
+++ b/WordPressKitTests/Mock Data/comment-likes-success.json
@@ -75,15 +75,5 @@
             "primary_blog": "primary blog URL",
             "preferred_blog": null
         }
-    ],
-    "meta": {
-        "data": {
-            "comment": {
-                "ID": 9
-            },
-            "site": {
-                "ID": 8
-            }
-        }
-    }
+    ]
 }

--- a/WordPressKitTests/Mock Data/comment-likes-success.json
+++ b/WordPressKitTests/Mock Data/comment-likes-success.json
@@ -75,5 +75,15 @@
             "primary_blog": "primary blog URL",
             "preferred_blog": null
         }
-    ]
+    ],
+    "meta": {
+        "data": {
+            "comment": {
+                "ID": 9
+            },
+            "site": {
+                "ID": 8
+            }
+        }
+    }
 }

--- a/WordPressKitTests/Mock Data/post-likes-success.json
+++ b/WordPressKitTests/Mock Data/post-likes-success.json
@@ -1,8 +1,6 @@
 {
     "found": 3,
     "i_like": true,
-    "site_ID": 0,
-    "post_ID": 1,
     "likes": [
         {
             "ID": 12345,
@@ -80,5 +78,15 @@
             "primary_blog": "primary blog URL",
             "preferred_blog": null
         }
-    ]
+    ],
+    "meta": {
+        "data": {
+            "post": {
+                "ID": 9
+            },
+            "site": {
+                "ID": 8
+            }
+        }
+    }
 }

--- a/WordPressKitTests/Mock Data/post-likes-success.json
+++ b/WordPressKitTests/Mock Data/post-likes-success.json
@@ -78,15 +78,5 @@
             "primary_blog": "primary blog URL",
             "preferred_blog": null
         }
-    ],
-    "meta": {
-        "data": {
-            "post": {
-                "ID": 9
-            },
-            "site": {
-                "ID": 8
-            }
-        }
-    }
+    ]
 }

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -41,6 +41,8 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.primaryBlogID, NSNumber(value: 54321))
             XCTAssertEqual(user.avatarURL, "avatar URL")
             XCTAssertEqual(user.bio, "user bio")
+            XCTAssertEqual(user.likedPostID, NSNumber(value: 9))
+            XCTAssertEqual(user.likedSiteID, NSNumber(value: 8))
             expect.fulfill()
 
         }, failure: { _ in

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -41,8 +41,8 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.primaryBlogID, NSNumber(value: 54321))
             XCTAssertEqual(user.avatarURL, "avatar URL")
             XCTAssertEqual(user.bio, "user bio")
-            XCTAssertEqual(user.likedPostID, NSNumber(value: 9))
-            XCTAssertEqual(user.likedSiteID, NSNumber(value: 8))
+            XCTAssertEqual(user.likedPostID, NSNumber(value: 1))
+            XCTAssertEqual(user.likedSiteID, NSNumber(value: 0))
             expect.fulfill()
 
         }, failure: { _ in


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15662
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16394

This updates the Post and Comment likes endpoints to fetch meta data:
- Posts: `site,post`
- Comments: `site,comment`

The `siteID` and `postID`/`commentID` are stored in each `RemoteLikeUser`.

### Testing Details

- Functionality can tested with the referenced WPiOS PR.
- Verify likes tests pass.
  - `CommentServiceRemoteRESTLikesTests`
  - `PostServiceRemoteRESTLikesTests`

- [x] Please check here if your pull request includes additional test coverage.
