### PR TITLE
Remove language from SiteDesignServiceRemote because it duplicates locale

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.32.0-beta.7"
+  s.version       = "4.32.0-beta.8"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/SiteDesignServiceRemote.swift
+++ b/WordPressKit/SiteDesignServiceRemote.swift
@@ -30,8 +30,7 @@ public class SiteDesignServiceRemote {
 
     static let endpoint = "/wpcom/v2/common-starter-site-designs"
     static let parameters: [String: AnyObject] = [
-        "type": ("mobile" as AnyObject),
-        "language": (WordPressComLanguageDatabase().deviceLanguage.slug as AnyObject)
+        "type": ("mobile" as AnyObject)
     ]
 
     private static func joinParameters(_ parameters: [String: AnyObject], additionalParameters: [String: AnyObject]?) -> [String: AnyObject] {


### PR DESCRIPTION
### Description

In #299 we added `language` as a parameter to duplicate `locale` those server-side needs have changed now so we can remove this parameter.

This can be tested with: https://github.com/wordpress-mobile/WordPress-iOS/pull/16404

### Testing Details

- [ ] Please check here if your pull request includes additional test coverage.
