### PR TITLE
[Global Styles] Implement Global Styles endpoint

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.37.0-beta.3"
+  s.version       = "4.37.0-beta.4"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -105,6 +105,11 @@
 		4625BAEB253E118400C04AAD /* PageLayoutServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4625BAEA253E118400C04AAD /* PageLayoutServiceRemoteTests.swift */; };
 		4625BAF1253E12C000C04AAD /* page-layout-blog-layouts-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4625BAF0253E12C000C04AAD /* page-layout-blog-layouts-success.json */; };
 		4625BAF7253E130900C04AAD /* page-layout-blog-layouts-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = 4625BAF6253E130800C04AAD /* page-layout-blog-layouts-malformed.json */; };
+		464BAB0B262F6736006AEED5 /* RemoteBlockEditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464BAB0A262F6736006AEED5 /* RemoteBlockEditorSettings.swift */; };
+		465F8894263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json in Resources */ = {isa = PBXBuildFile; fileRef = 465F8893263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json */; };
+		465F889A263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json in Resources */ = {isa = PBXBuildFile; fileRef = 465F8899263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json */; };
+		465F88A2263B325C00F4C950 /* ChecksumUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465F88A1263B325C00F4C950 /* ChecksumUtil.swift */; };
+		465F88BF263B54EE00F4C950 /* ChecksumUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465F88BE263B54EE00F4C950 /* ChecksumUtilTests.swift */; };
 		467C20692626243D00DB5A38 /* WordPressRestApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467C20682626243D00DB5A38 /* WordPressRestApi.swift */; };
 		46ABD0E0262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46ABD0DF262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift */; };
 		46ABD0E6262EEDAB00C7FF24 /* FakeInfoDictionaryObjectProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46ABD0E5262EEDAB00C7FF24 /* FakeInfoDictionaryObjectProvider.swift */; };
@@ -698,6 +703,11 @@
 		4625BAEA253E118400C04AAD /* PageLayoutServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageLayoutServiceRemoteTests.swift; sourceTree = "<group>"; };
 		4625BAF0253E12C000C04AAD /* page-layout-blog-layouts-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "page-layout-blog-layouts-success.json"; sourceTree = "<group>"; };
 		4625BAF6253E130800C04AAD /* page-layout-blog-layouts-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "page-layout-blog-layouts-malformed.json"; sourceTree = "<group>"; };
+		464BAB0A262F6736006AEED5 /* RemoteBlockEditorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBlockEditorSettings.swift; sourceTree = "<group>"; };
+		465F8893263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wp-block-editor-v1-settings-success-NotThemeJSON.json"; sourceTree = "<group>"; };
+		465F8899263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wp-block-editor-v1-settings-success-ThemeJSON.json"; sourceTree = "<group>"; };
+		465F88A1263B325C00F4C950 /* ChecksumUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecksumUtil.swift; sourceTree = "<group>"; };
+		465F88BE263B54EE00F4C950 /* ChecksumUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecksumUtilTests.swift; sourceTree = "<group>"; };
 		467C20682626243D00DB5A38 /* WordPressRestApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressRestApi.swift; sourceTree = "<group>"; };
 		46ABD0DF262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgXMLRPCValidatorTests.swift; sourceTree = "<group>"; };
 		46ABD0E5262EEDAB00C7FF24 /* FakeInfoDictionaryObjectProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeInfoDictionaryObjectProvider.swift; sourceTree = "<group>"; };
@@ -1318,6 +1328,15 @@
 			name = StarterPageLayouts;
 			sourceTree = "<group>";
 		};
+		465F8892263B094900F4C950 /* BlockEditorSettings */ = {
+			isa = PBXGroup;
+			children = (
+				465F8893263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json */,
+				465F8899263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json */,
+			);
+			path = BlockEditorSettings;
+			sourceTree = "<group>";
+		};
 		57A38E502624F7D000472480 /* WordPressAPI */ = {
 			isa = PBXGroup;
 			children = (
@@ -1812,6 +1831,7 @@
 				F9E56DF524EB11EF00916770 /* FeatureFlag.swift */,
 				4625B964253A343900C04AAD /* RemotePageLayouts.swift */,
 				4624222C2548BA0F002B8A12 /* RemoteSiteDesign.swift */,
+				464BAB0A262F6736006AEED5 /* RemoteBlockEditorSettings.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -2111,6 +2131,7 @@
 				93C674F01EE8351E00BFAF05 /* NSMutableDictionary+Helpers.m */,
 				9F4E51FF2088E38200424676 /* ObjectValidation.swift */,
 				57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */,
+				465F88A1263B325C00F4C950 /* ChecksumUtil.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -2215,6 +2236,7 @@
 				46ABD0E9262EEE0400C7FF24 /* AppTransportSecuritySettingsTests.swift */,
 				F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */,
 				24ADA24D24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift */,
+				465F88BE263B54EE00F4C950 /* ChecksumUtilTests.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -2425,6 +2447,7 @@
 				93BD27591EE73442002BB00B /* is-available-email-failure.json in Resources */,
 				74D67F171F15C2D70010C5ED /* site-users-update-role-success.json in Resources */,
 				74C473B11EF31A19009918F2 /* site-delete-success.json in Resources */,
+				465F8894263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json in Resources */,
 				E14694031F344F71004052C8 /* site-plugins-error.json in Resources */,
 				829BA4311FACF187003ADEEA /* activity-rewind-status-success.json in Resources */,
 				93BD27571EE73442002BB00B /* auth-send-login-email-no-user-failure.json in Resources */,
@@ -2458,6 +2481,7 @@
 				BA5AEF6B24923DAC007D8E49 /* plugin-state-jetpack.json in Resources */,
 				436D564C211CCCB900CEAA33 /* domain-contact-information-response-success.json in Resources */,
 				FFA4D4AD2423B1FE00BF5180 /* wp-admin-post-new.html in Resources */,
+				465F889A263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json in Resources */,
 				BA9A7F7F24C6895600925E81 /* plugin-directory-jetpack-beta.json in Resources */,
 				E6B0461425E5B6F500DF6F4F /* sites-invites-links-generate.json in Resources */,
 				93BD275A1EE73442002BB00B /* is-available-email-success.json in Resources */,
@@ -2720,6 +2744,7 @@
 			files = (
 				32E1DD23236AA09A008914B0 /* RemotePostAutosave.swift in Sources */,
 				FF807252241FB90E00809AF5 /* Authenticator.swift in Sources */,
+				464BAB0B262F6736006AEED5 /* RemoteBlockEditorSettings.swift in Sources */,
 				7430C9B41F1927C50051B8E6 /* RemoteReaderSite.m in Sources */,
 				74585B8E1F0D51A100E7E667 /* DomainsServiceRemote.swift in Sources */,
 				4625B965253A343900C04AAD /* RemotePageLayouts.swift in Sources */,
@@ -2842,6 +2867,7 @@
 				93188D1F1F2262BF0028ED4D /* RemotePostTag.m in Sources */,
 				74D67F081F15BEB70010C5ED /* RemotePerson.swift in Sources */,
 				984E34EB22EF7209005C3F92 /* StatsFileDownloadsTimeIntervalData.swift in Sources */,
+				465F88A2263B325C00F4C950 /* ChecksumUtil.swift in Sources */,
 				40AB1ADA200FED25009B533D /* PluginDirectoryFeedPage.swift in Sources */,
 				436D56352118D85800CEAA33 /* Country.swift in Sources */,
 				74A44DCB1F13C533006CD8F4 /* NotificationSettingsServiceRemote.swift in Sources */,
@@ -2936,6 +2962,7 @@
 				8B2F4BE924ABC9DC0056C08A /* ReaderPostServiceRemote+CardsTests.swift in Sources */,
 				40F9880C221ACEEE00B7B369 /* StatsRemoteV2Tests.swift in Sources */,
 				4625BAEB253E118400C04AAD /* PageLayoutServiceRemoteTests.swift in Sources */,
+				465F88BF263B54EE00F4C950 /* ChecksumUtilTests.swift in Sources */,
 				826017001F9FD60A00533B6C /* ActivityServiceRemoteTests.swift in Sources */,
 				93F50A3A1F226BB600B5BEBA /* WordPressComServiceRemoteRestTests.swift in Sources */,
 				E13EE14C1F332C4400C15787 /* PluginServiceRemoteTests.swift in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -108,7 +108,11 @@
 		464BAB0B262F6736006AEED5 /* RemoteBlockEditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 464BAB0A262F6736006AEED5 /* RemoteBlockEditorSettings.swift */; };
 		465F8894263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json in Resources */ = {isa = PBXBuildFile; fileRef = 465F8893263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json */; };
 		465F889A263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json in Resources */ = {isa = PBXBuildFile; fileRef = 465F8899263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json */; };
+		465F889E263B0C5500F4C950 /* BlockEditorSettingsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465F889D263B0C5500F4C950 /* BlockEditorSettingsServiceRemote.swift */; };
 		465F88A2263B325C00F4C950 /* ChecksumUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465F88A1263B325C00F4C950 /* ChecksumUtil.swift */; };
+		465F88A7263B371D00F4C950 /* BlockEditorSettingsServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465F88A6263B371D00F4C950 /* BlockEditorSettingsServiceRemoteTests.swift */; };
+		465F88B1263B3E8A00F4C950 /* get_wp_v2_themes_twentytwentyone.json in Resources */ = {isa = PBXBuildFile; fileRef = 465F88B0263B3E8A00F4C950 /* get_wp_v2_themes_twentytwentyone.json */; };
+		465F88B7263B455300F4C950 /* get_wp_v2_themes_twentytwentyone-no-colors.json in Resources */ = {isa = PBXBuildFile; fileRef = 465F88B6263B455300F4C950 /* get_wp_v2_themes_twentytwentyone-no-colors.json */; };
 		465F88BF263B54EE00F4C950 /* ChecksumUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 465F88BE263B54EE00F4C950 /* ChecksumUtilTests.swift */; };
 		467C20692626243D00DB5A38 /* WordPressRestApi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467C20682626243D00DB5A38 /* WordPressRestApi.swift */; };
 		46ABD0E0262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46ABD0DF262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift */; };
@@ -706,7 +710,11 @@
 		464BAB0A262F6736006AEED5 /* RemoteBlockEditorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBlockEditorSettings.swift; sourceTree = "<group>"; };
 		465F8893263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wp-block-editor-v1-settings-success-NotThemeJSON.json"; sourceTree = "<group>"; };
 		465F8899263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "wp-block-editor-v1-settings-success-ThemeJSON.json"; sourceTree = "<group>"; };
+		465F889D263B0C5500F4C950 /* BlockEditorSettingsServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEditorSettingsServiceRemote.swift; sourceTree = "<group>"; };
 		465F88A1263B325C00F4C950 /* ChecksumUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecksumUtil.swift; sourceTree = "<group>"; };
+		465F88A6263B371D00F4C950 /* BlockEditorSettingsServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEditorSettingsServiceRemoteTests.swift; sourceTree = "<group>"; };
+		465F88B0263B3E8A00F4C950 /* get_wp_v2_themes_twentytwentyone.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = get_wp_v2_themes_twentytwentyone.json; sourceTree = "<group>"; };
+		465F88B6263B455300F4C950 /* get_wp_v2_themes_twentytwentyone-no-colors.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "get_wp_v2_themes_twentytwentyone-no-colors.json"; sourceTree = "<group>"; };
 		465F88BE263B54EE00F4C950 /* ChecksumUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChecksumUtilTests.swift; sourceTree = "<group>"; };
 		467C20682626243D00DB5A38 /* WordPressRestApi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressRestApi.swift; sourceTree = "<group>"; };
 		46ABD0DF262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgXMLRPCValidatorTests.swift; sourceTree = "<group>"; };
@@ -1333,8 +1341,18 @@
 			children = (
 				465F8893263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json */,
 				465F8899263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json */,
+				465F88B0263B3E8A00F4C950 /* get_wp_v2_themes_twentytwentyone.json */,
+				465F88B6263B455300F4C950 /* get_wp_v2_themes_twentytwentyone-no-colors.json */,
 			);
 			path = BlockEditorSettings;
+			sourceTree = "<group>";
+		};
+		465F88A5263B370300F4C950 /* BlockEditorSettings */ = {
+			isa = PBXGroup;
+			children = (
+				465F88A6263B371D00F4C950 /* BlockEditorSettingsServiceRemoteTests.swift */,
+			);
+			name = BlockEditorSettings;
 			sourceTree = "<group>";
 		};
 		57A38E502624F7D000472480 /* WordPressAPI */ = {
@@ -1546,6 +1564,7 @@
 				826016FE1F9FD59400533B6C /* Activity */,
 				FAD1345425909DF500A8FEB1 /* Backup */,
 				74B5F0DF1EF82AAB00B411E7 /* Blog */,
+				465F88A5263B370300F4C950 /* BlockEditorSettings */,
 				ABD95B7D25DD6C2400735BEE /* Comment */,
 				74585B911F0D520700E7E667 /* Domains */,
 				7EC60EBC22DC4F5A00FB0336 /* Editor */,
@@ -1739,6 +1758,7 @@
 				F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */,
 				4625B96B253A357500C04AAD /* PageLayoutServiceRemote.swift */,
 				462422282548B98A002B8A12 /* SiteDesignServiceRemote.swift */,
+				465F889D263B0C5500F4C950 /* BlockEditorSettingsServiceRemote.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -1851,6 +1871,7 @@
 		93BD27421EE73384002BB00B /* Mock Data */ = {
 			isa = PBXGroup;
 			children = (
+				465F8892263B094900F4C950 /* BlockEditorSettings */,
 				C92EFF7225E7444400E0308D /* common-starter-site-designs-empty-designs.json */,
 				C92EFF6C25E741E900E0308D /* common-starter-site-designs-malformed.json */,
 				C92EFF6825E7403F00E0308D /* common-starter-site-designs-success.json */,
@@ -2484,6 +2505,7 @@
 				465F889A263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json in Resources */,
 				BA9A7F7F24C6895600925E81 /* plugin-directory-jetpack-beta.json in Resources */,
 				E6B0461425E5B6F500DF6F4F /* sites-invites-links-generate.json in Resources */,
+				465F88B1263B3E8A00F4C950 /* get_wp_v2_themes_twentytwentyone.json in Resources */,
 				93BD275A1EE73442002BB00B /* is-available-email-success.json in Resources */,
 				17BF9A6C20C7DC3300BF57D2 /* reader-site-search-success.json in Resources */,
 				FACBDD4C25ECB76C0026705B /* reader-post-related-posts-success.json in Resources */,
@@ -2548,6 +2570,7 @@
 				FFE247AF20C891E6002DF3A2 /* WordPressComOAuthWrongPasswordFail.json in Resources */,
 				F194E1252417EE7E00874408 /* atomic-get-auth-cookie-success.json in Resources */,
 				731BA83A21DED358000FDFCD /* site-creation-success.json in Resources */,
+				465F88B7263B455300F4C950 /* get_wp_v2_themes_twentytwentyone-no-colors.json in Resources */,
 				9A2D0B2F225E1245009E585F /* jetpack-service-check-site-success.json in Resources */,
 				829BA4301FACF187003ADEEA /* activity-rewind-status-restore-failure.json in Resources */,
 				8B16CE962525045F007BE5A9 /* reader-posts-success.json in Resources */,
@@ -2829,6 +2852,7 @@
 				74BA04FA1F06DC3900ED5CD8 /* RemoteComment.m in Sources */,
 				7E3E7A4C20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift in Sources */,
 				40F98809221AC88700B7B369 /* StatsPostingStreakInsight.swift in Sources */,
+				465F889E263B0C5500F4C950 /* BlockEditorSettingsServiceRemote.swift in Sources */,
 				93C674EC1EE8348F00BFAF05 /* RemoteBlogOptionsHelper.m in Sources */,
 				E632D7781F6E047400297F6D /* SocialLogin2FANonceInfo.swift in Sources */,
 				32FC1D29255C91ED00CD0A7B /* JetpackScanServiceRemote.swift in Sources */,
@@ -2993,6 +3017,7 @@
 				FFE247A720C891D1002DF3A2 /* WordPressComOAuthTests.swift in Sources */,
 				93AB06041EE8838400EF8764 /* RemoteTestCase.swift in Sources */,
 				BA2A78FA24A486D300BB6F53 /* SitePluginTests.swift in Sources */,
+				465F88A7263B371D00F4C950 /* BlockEditorSettingsServiceRemoteTests.swift in Sources */,
 				93BD27411EE73311002BB00B /* AccountServiceRemoteRESTTests.swift in Sources */,
 				93F50A441F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift in Sources */,
 				7430C9BC1F192C0F0051B8E6 /* ReaderSiteServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/BlockEditorSettingsServiceRemote.swift
+++ b/WordPressKit/BlockEditorSettingsServiceRemote.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public class BlockEditorSettingsServiceRemote {
+    let remoteAPI: WordPressRestApi
+    init(remoteAPI: WordPressRestApi) {
+        self.remoteAPI = remoteAPI
+    }
+}
+
+// MARK: Editor `theme_supports` support
+public extension BlockEditorSettingsServiceRemote {
+    typealias EditorThemeCompletionHandler = (Swift.Result<RemoteEditorTheme?, Error>) -> Void
+
+    func fetchTheme(forSiteID siteID: Int?, _ completion: @escaping EditorThemeCompletionHandler) {
+        let requestPath = "/wp/v2/themes"
+        let parameters: [String: AnyObject] = ["status": "active" as AnyObject]
+        let modifiedPath = remoteAPI.requestPath(fromOrgPath: requestPath, with: siteID)
+        remoteAPI.GET(modifiedPath, parameters: parameters) { [weak self] (result, _) in
+            guard let `self` = self else { return }
+            switch result {
+            case .success(let response):
+                self.processEditorThemeResponse(response) { editorTheme in
+                    completion(.success(editorTheme))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func processEditorThemeResponse(_ response: Any, completion: (_ editorTheme: RemoteEditorTheme?) -> Void) {
+        guard let responseData = try? JSONSerialization.data(withJSONObject: response, options: []),
+              let editorThemes = try? JSONDecoder().decode([RemoteEditorTheme].self, from: responseData) else {
+            completion(nil)
+            return
+        }
+        completion(editorThemes.first)
+    }
+
+}
+
+// MARK: Editor Global Styles support
+public extension BlockEditorSettingsServiceRemote {
+    typealias BlockEditorSettingsCompletionHandler = (Swift.Result<RemoteBlockEditorSettings?, Error>) -> Void
+
+    func fetchBlockEditorSettings(_ completion: @escaping BlockEditorSettingsCompletionHandler) {
+        let requestPath = "/__experimental/wp-block-editor/v1/settings"
+        let parameters: [String: AnyObject] = ["context": "site-editor" as AnyObject]
+        remoteAPI.GET(requestPath, parameters: parameters) { [weak self] (result, _) in
+            guard let `self` = self else { return }
+            switch result {
+            case .success(let response):
+                self.processBlockEditorSettingsResponse(response) { blockEditorSettings in
+                    completion(.success(blockEditorSettings))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    private func processBlockEditorSettingsResponse(_ response: Any, completion: (_ editorTheme: RemoteBlockEditorSettings?) -> Void) {
+        guard let responseData = try? JSONSerialization.data(withJSONObject: response, options: []),
+              let blockEditorSettings = try? JSONDecoder().decode(RemoteBlockEditorSettings.self, from: responseData) else {
+            completion(nil)
+            return
+        }
+        completion(blockEditorSettings)
+    }
+}

--- a/WordPressKit/BlockEditorSettingsServiceRemote.swift
+++ b/WordPressKit/BlockEditorSettingsServiceRemote.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public class BlockEditorSettingsServiceRemote {
     let remoteAPI: WordPressRestApi
-    init(remoteAPI: WordPressRestApi) {
+    public init(remoteAPI: WordPressRestApi) {
         self.remoteAPI = remoteAPI
     }
 }

--- a/WordPressKit/BlockEditorSettingsServiceRemote.swift
+++ b/WordPressKit/BlockEditorSettingsServiceRemote.swift
@@ -45,7 +45,7 @@ public extension BlockEditorSettingsServiceRemote {
 
     func fetchBlockEditorSettings(_ completion: @escaping BlockEditorSettingsCompletionHandler) {
         let requestPath = "/__experimental/wp-block-editor/v1/settings"
-        let parameters: [String: AnyObject] = ["context": "site-editor" as AnyObject]
+        let parameters: [String: AnyObject] = ["context": "mobile" as AnyObject]
         remoteAPI.GET(requestPath, parameters: parameters) { [weak self] (result, _) in
             guard let `self` = self else { return }
             switch result {

--- a/WordPressKit/ChecksumUtil.swift
+++ b/WordPressKit/ChecksumUtil.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public class ChecksumUtil {
+
+    /// Generates a checksum based on the encoded keys. 
+    static func checksum<T>(from codable: T) -> String where T: Encodable {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+        let result: String
+        do {
+            let data = try encoder.encode(codable)
+            result = String(data: data, encoding: .utf8) ?? ""
+        } catch {
+            result = ""
+        }
+        return result.md5()
+    }
+}

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+public class RemoteBlockEditorSettings: Codable {
+    enum CodingKeys: String, CodingKey {
+        case isFSETheme = "__unstableEnableFullSiteEditingBlocks"
+        case globalStylesBaseStyles = "__experimentalGlobalStylesBaseStyles"
+        case colors
+        case gradients
+    }
+
+    let isFSETheme: Bool
+    let globalStylesBaseStyles: GlobalStylesBaseStyles?
+    let colors: [RemoteColor]?
+    let gradients: [RemoteGradient]?
+
+    lazy var checksum: String = {
+        return ChecksumUtil.checksum(from: self)
+    }()
+
+    required public init(from decoder: Decoder) throws {
+        let map = try decoder.container(keyedBy: CodingKeys.self)
+        self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
+        self.globalStylesBaseStyles = try? map.decode(GlobalStylesBaseStyles.self, forKey: .globalStylesBaseStyles)
+        self.colors = try? map.decode([RemoteColor].self, forKey: .colors)
+        self.gradients = try? map.decode([RemoteGradient].self, forKey: .gradients)
+    }
+}
+
+public struct GlobalStylesBaseStyles: Codable {
+    enum CodingKeys: String, CodingKey {
+        case colorSettings = "color"
+    }
+
+    let colorSettings: GlobalStylesColorSettings
+}
+
+public struct GlobalStylesColorSettings: Codable {
+    enum CodingKeys: String, CodingKey {
+        case colors = "palette"
+        case gradients
+    }
+
+    let colors: [RemoteColor]?
+    let gradients: [RemoteGradient]?
+
+    public init(from decoder: Decoder) throws {
+        let map = try decoder.container(keyedBy: CodingKeys.self)
+        self.colors = try? map.decode([RemoteColor].self, forKey: .colors)
+        self.gradients = try? map.decode([RemoteGradient].self, forKey: .gradients)
+    }
+}
+
+// MARK: EditorTheme
+public class RemoteEditorTheme: Codable {
+    enum CodingKeys: String, CodingKey {
+        case themeSupport = "theme_supports"
+    }
+
+    let themeSupport: RemoteEditorThemeSupport?
+    lazy var checksum: String = {
+        return ChecksumUtil.checksum(from: themeSupport)
+    }()
+}
+
+public struct RemoteEditorThemeSupport: Codable {
+    enum CodingKeys: String, CodingKey {
+        case colors = "editor-color-palette"
+        case gradients = "editor-gradient-presets"
+    }
+
+    let colors: [RemoteColor]?
+    let gradients: [RemoteGradient]?
+
+    public init(from decoder: Decoder) throws {
+        let map = try decoder.container(keyedBy: CodingKeys.self)
+        self.colors = try? map.decode([RemoteColor].self, forKey: .colors)
+        self.gradients = try? map.decode([RemoteGradient].self, forKey: .gradients)
+    }
+}
+
+// MARK: Common Objects
+
+public struct RemoteColor: Codable {
+    let slug: String
+    let color: String
+    let name: String
+}
+
+public struct RemoteGradient: Codable {
+    let slug: String
+    let gradient: String
+    let name: String
+}

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -25,7 +25,7 @@ public class RemoteBlockEditorSettings: Codable {
             // parse the reponse then convert it to a string.
             guard
                 let jsonGlobalStylesBaseStyles = try? map.decode([String: Any].self, forKey: .rawGlobalStylesBaseStyles),
-                let data = try? JSONSerialization.data(withJSONObject: jsonGlobalStylesBaseStyles, options: [])
+                let data = try? JSONSerialization.data(withJSONObject: jsonGlobalStylesBaseStyles, options: [.sortedKeys])
             else {
                 return nil
             }

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -8,12 +8,12 @@ public class RemoteBlockEditorSettings: Codable {
         case gradients
     }
 
-    let isFSETheme: Bool
-    let globalStylesBaseStyles: GlobalStylesBaseStyles?
-    let colors: [RemoteColor]?
-    let gradients: [RemoteGradient]?
+    public let isFSETheme: Bool
+    public let globalStylesBaseStyles: GlobalStylesBaseStyles?
+    public let colors: [[String: String]]?
+    public let gradients: [[String: String]]?
 
-    lazy var checksum: String = {
+    public lazy var checksum: String = {
         return ChecksumUtil.checksum(from: self)
     }()
 
@@ -21,8 +21,8 @@ public class RemoteBlockEditorSettings: Codable {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
         self.globalStylesBaseStyles = try? map.decode(GlobalStylesBaseStyles.self, forKey: .globalStylesBaseStyles)
-        self.colors = try? map.decode([RemoteColor].self, forKey: .colors)
-        self.gradients = try? map.decode([RemoteGradient].self, forKey: .gradients)
+        self.colors = try? map.decode([[String: String]].self, forKey: .colors)
+        self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
     }
 }
 
@@ -31,7 +31,7 @@ public struct GlobalStylesBaseStyles: Codable {
         case colorSettings = "color"
     }
 
-    let colorSettings: GlobalStylesColorSettings
+    public let colorSettings: GlobalStylesColorSettings
 }
 
 public struct GlobalStylesColorSettings: Codable {
@@ -40,13 +40,13 @@ public struct GlobalStylesColorSettings: Codable {
         case gradients
     }
 
-    let colors: [RemoteColor]?
-    let gradients: [RemoteGradient]?
+    public let colors: [[String: String]]?
+    public let gradients: [[String: String]]?
 
     public init(from decoder: Decoder) throws {
         let map = try decoder.container(keyedBy: CodingKeys.self)
-        self.colors = try? map.decode([RemoteColor].self, forKey: .colors)
-        self.gradients = try? map.decode([RemoteGradient].self, forKey: .gradients)
+        self.colors = try? map.decode([[String: String]].self, forKey: .colors)
+        self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
     }
 }
 
@@ -56,8 +56,8 @@ public class RemoteEditorTheme: Codable {
         case themeSupport = "theme_supports"
     }
 
-    let themeSupport: RemoteEditorThemeSupport?
-    lazy var checksum: String = {
+    public let themeSupport: RemoteEditorThemeSupport?
+    public lazy var checksum: String = {
         return ChecksumUtil.checksum(from: themeSupport)
     }()
 }
@@ -68,26 +68,12 @@ public struct RemoteEditorThemeSupport: Codable {
         case gradients = "editor-gradient-presets"
     }
 
-    let colors: [RemoteColor]?
-    let gradients: [RemoteGradient]?
+    public let colors: [[String: String]]?
+    public let gradients: [[String: String]]?
 
     public init(from decoder: Decoder) throws {
         let map = try decoder.container(keyedBy: CodingKeys.self)
-        self.colors = try? map.decode([RemoteColor].self, forKey: .colors)
-        self.gradients = try? map.decode([RemoteGradient].self, forKey: .gradients)
+        self.colors = try? map.decode([[String: String]].self, forKey: .colors)
+        self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
     }
-}
-
-// MARK: Common Objects
-
-public struct RemoteColor: Codable {
-    let slug: String
-    let color: String
-    let name: String
-}
-
-public struct RemoteGradient: Codable {
-    let slug: String
-    let gradient: String
-    let name: String
 }

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -3,13 +3,13 @@ import Foundation
 public class RemoteBlockEditorSettings: Codable {
     enum CodingKeys: String, CodingKey {
         case isFSETheme = "__unstableEnableFullSiteEditingBlocks"
-        case globalStylesBaseStyles = "__experimentalGlobalStylesBaseStyles"
+        case rawGlobalStylesBaseStyles = "__experimentalGlobalStylesBaseStyles"
         case colors
         case gradients
     }
 
     public let isFSETheme: Bool
-    public let globalStylesBaseStyles: GlobalStylesBaseStyles?
+    public let rawGlobalStylesBaseStyles: String?
     public let colors: [[String: String]]?
     public let gradients: [[String: String]]?
 
@@ -20,31 +20,17 @@ public class RemoteBlockEditorSettings: Codable {
     required public init(from decoder: Decoder) throws {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
-        self.globalStylesBaseStyles = try? map.decode(GlobalStylesBaseStyles.self, forKey: .globalStylesBaseStyles)
-        self.colors = try? map.decode([[String: String]].self, forKey: .colors)
-        self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
-    }
-}
-
-public struct GlobalStylesBaseStyles: Codable {
-    enum CodingKeys: String, CodingKey {
-        case colorSettings = "color"
-    }
-
-    public let colorSettings: GlobalStylesColorSettings
-}
-
-public struct GlobalStylesColorSettings: Codable {
-    enum CodingKeys: String, CodingKey {
-        case colors = "palette"
-        case gradients
-    }
-
-    public let colors: [[String: String]]?
-    public let gradients: [[String: String]]?
-
-    public init(from decoder: Decoder) throws {
-        let map = try decoder.container(keyedBy: CodingKeys.self)
+        self.rawGlobalStylesBaseStyles = {
+            // Swift cuurently doesn't support type conversions from Dictionaries to strings while decoding. So we need to
+            // parse the reponse then convert it to a string.
+            guard
+                let jsonGlobalStylesBaseStyles = try? map.decode([String: Any].self, forKey: .rawGlobalStylesBaseStyles),
+                let data = try? JSONSerialization.data(withJSONObject: jsonGlobalStylesBaseStyles, options: [])
+            else {
+                return nil
+            }
+            return String(data: data, encoding: .utf8)
+        }()
         self.colors = try? map.decode([[String: String]].self, forKey: .colors)
         self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
     }

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -4,12 +4,14 @@ public class RemoteBlockEditorSettings: Codable {
     enum CodingKeys: String, CodingKey {
         case isFSETheme = "__unstableEnableFullSiteEditingBlocks"
         case rawStyles = "__experimentalStyles"
-        case rawFeatures = "__experimentalFeatures"
+        case colors
+        case gradients
     }
 
     public let isFSETheme: Bool
     public let rawStyles: String?
-    public let rawFeatures: String?
+    public let colors: [[String: String]]?
+    public let gradients: [[String: String]]?
 
     public lazy var checksum: String = {
         return ChecksumUtil.checksum(from: self)
@@ -31,7 +33,8 @@ public class RemoteBlockEditorSettings: Codable {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
         self.rawStyles = RemoteBlockEditorSettings.parseToString(map, .rawStyles)
-        self.rawFeatures = RemoteBlockEditorSettings.parseToString(map, .rawFeatures)
+        self.colors = try? map.decode([[String: String]].self, forKey: .colors)
+        self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
     }
 }
 

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -4,12 +4,14 @@ public class RemoteBlockEditorSettings: Codable {
     enum CodingKeys: String, CodingKey {
         case isFSETheme = "__unstableEnableFullSiteEditingBlocks"
         case rawStyles = "__experimentalStyles"
+        case rawFeatures = "__experimentalFeatures"
         case colors
         case gradients
     }
 
     public let isFSETheme: Bool
     public let rawStyles: String?
+    public let rawFeatures: String?
     public let colors: [[String: String]]?
     public let gradients: [[String: String]]?
 
@@ -33,6 +35,7 @@ public class RemoteBlockEditorSettings: Codable {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
         self.rawStyles = RemoteBlockEditorSettings.parseToString(map, .rawStyles)
+        self.rawFeatures = RemoteBlockEditorSettings.parseToString(map, .rawFeatures)
         self.colors = try? map.decode([[String: String]].self, forKey: .colors)
         self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
     }

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -141,6 +141,7 @@ extension BlockEditorSettingsServiceRemoteTests {
                 XCTAssertFalse(result!.checksum.isEmpty)
                 XCTAssertGreaterThan(result!.colors!.count, 0)
                 XCTAssertGreaterThan(result!.gradients!.count, 0)
+                XCTAssertNil(result!.rawGlobalStylesBaseStyles)
             case .failure:
                 XCTFail("This payload should parse successfully")
             }
@@ -165,6 +166,7 @@ extension BlockEditorSettingsServiceRemoteTests {
                 XCTAssertFalse(result!.checksum.isEmpty)
                 XCTAssertNil(result!.colors)
                 XCTAssertGreaterThan(result!.gradients!.count, 0)
+                XCTAssertNil(result!.rawGlobalStylesBaseStyles)
             case .failure:
                 XCTFail("This payload should parse successfully")
             }
@@ -189,6 +191,7 @@ extension BlockEditorSettingsServiceRemoteTests {
                 XCTAssertFalse(result!.checksum.isEmpty)
                 XCTAssertGreaterThan(result!.colors!.count, 0)
                 XCTAssertNil(result!.gradients)
+                XCTAssertNil(result!.rawGlobalStylesBaseStyles)
             case .failure:
                 XCTFail("This payload should parse successfully")
             }
@@ -209,9 +212,10 @@ extension BlockEditorSettingsServiceRemoteTests {
             case .success(let result):
                 XCTAssertNotNil(result)
                 XCTAssertFalse(result!.checksum.isEmpty)
-                // ToDo: Enable when data is updated with GSS Samples
-//                XCTAssertGreaterThan(result!.globalStylesBaseStyles!.colorSettings.colors!.count, 0)
-//                XCTAssertGreaterThan(result!.globalStylesBaseStyles!.colorSettings.gradients!.count, 0)
+                XCTAssertNotNil(result!.rawGlobalStylesBaseStyles)
+                let gssRawJson = result!.rawGlobalStylesBaseStyles!.data(using: .utf8)!
+                let vaildJson = try? JSONSerialization.jsonObject(with: gssRawJson, options: [])
+                XCTAssertNotNil(vaildJson)
             case .failure:
                 XCTFail("This payload should parse successfully")
             }

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -211,5 +211,10 @@ extension BlockEditorSettingsServiceRemoteTests {
 
         XCTAssertGreaterThan(result!.colors!.count, 0)
         XCTAssertGreaterThan(result!.gradients!.count, 0)
+
+        XCTAssertNotNil(result!.rawFeatures)
+        let themeRawJson = result!.rawFeatures!.data(using: .utf8)!
+        let vaildJson = try? JSONSerialization.jsonObject(with: themeRawJson, options: [])
+        XCTAssertNotNil(vaildJson)
     }
 }

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -1,0 +1,248 @@
+import XCTest
+@testable import WordPressKit
+
+class BlockEditorSettingsServiceRemoteTests: XCTestCase {
+    private let blockSettingsNOTThemeJSONResponseFilename = "wp-block-editor-v1-settings-success-NotThemeJSON"
+    private let blockSettingsThemeJSONResponseFilename = "wp-block-editor-v1-settings-success-ThemeJSON"
+    private let twentytwentyoneResponseFilename = "get_wp_v2_themes_twentytwentyone"
+    private let testError = NSError(domain: "tests", code: 0, userInfo: nil)
+    private let siteID = 1
+
+    private var service: BlockEditorSettingsServiceRemote!
+    var mockRemoteApi: MockWordPressComRestApi!
+
+    override func setUp() {
+        mockRemoteApi = MockWordPressComRestApi()
+        service = BlockEditorSettingsServiceRemote(remoteAPI: mockRemoteApi)
+    }
+
+    func mockedData(withFilename filename: String) -> AnyObject {
+        let json = Bundle(for: BlockEditorSettingsServiceRemoteTests.self).url(forResource: filename, withExtension: "json")!
+        let data = try! Data(contentsOf: json)
+        return try! JSONSerialization.jsonObject(with: data, options: .allowFragments) as AnyObject
+    }
+}
+
+// MARK: Editor `theme_supports` support
+extension BlockEditorSettingsServiceRemoteTests {
+
+    func testFetchThemeSuccess() {
+        let waitExpectation = expectation(description: "Theme should be successfully fetched")
+        let mockedResponse = mockedData(withFilename: twentytwentyoneResponseFilename)
+        service.fetchTheme(forSiteID: siteID) { (response) in
+            switch response {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                XCTAssertFalse(result!.checksum.isEmpty)
+                XCTAssertGreaterThan(result!.themeSupport!.colors!.count, 0)
+                XCTAssertGreaterThan(result!.themeSupport!.gradients!.count, 0)
+            case .failure:
+                XCTFail("This payload should parse successfully")
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn!(mockedResponse, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        validateEditorThemeRequest()
+    }
+
+    func testFetchThemeNoGradients() {
+        let waitExpectation = expectation(description: "Theme should be successfully fetched")
+        var mockedResponse = mockedData(withFilename: twentytwentyoneResponseFilename) as! [[String: Any]]
+
+        // Clear out Gradients
+        var theme = mockedResponse[0]
+        var themeSupport = theme[RemoteEditorTheme.CodingKeys.themeSupport.stringValue] as! [String: Any]
+        themeSupport[RemoteEditorThemeSupport.CodingKeys.gradients.stringValue] = "false"
+        theme[RemoteEditorTheme.CodingKeys.themeSupport.stringValue] = themeSupport
+        mockedResponse[0] = theme
+
+        service.fetchTheme(forSiteID: siteID) { (response) in
+            switch response {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                XCTAssertFalse(result!.checksum.isEmpty)
+                XCTAssertGreaterThan(result!.themeSupport!.colors!.count, 0)
+                XCTAssertNil(result!.themeSupport!.gradients)
+            case .failure:
+                XCTFail("This payload should parse successfully")
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        validateEditorThemeRequest()
+    }
+
+    func testFetchThemeNoColors() {
+        let waitExpectation = expectation(description: "Theme should be successfully fetched")
+        var mockedResponse = mockedData(withFilename: twentytwentyoneResponseFilename) as! [[String: Any]]
+
+        // Clear out Colors
+        var theme = mockedResponse[0]
+        var themeSupport = theme[RemoteEditorTheme.CodingKeys.themeSupport.stringValue] as! [String: Any]
+        themeSupport[RemoteEditorThemeSupport.CodingKeys.colors.stringValue] = "false"
+        theme[RemoteEditorTheme.CodingKeys.themeSupport.stringValue] = themeSupport
+        mockedResponse[0] = theme
+
+        service.fetchTheme(forSiteID: siteID) { (response) in
+            switch response {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                XCTAssertFalse(result!.checksum.isEmpty)
+                XCTAssertNil(result!.themeSupport!.colors)
+                XCTAssertGreaterThan(result!.themeSupport!.gradients!.count, 0)
+            case .failure:
+                XCTFail("This payload should parse successfully")
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        validateEditorThemeRequest()
+    }
+
+    func testFetchThemeFailure() {
+        let waitExpectation = expectation(description: "Theme should be successfully fetched")
+        service.fetchTheme(forSiteID: siteID) { (response) in
+            switch response {
+            case .success:
+                XCTFail("This Request should have failed")
+            case .failure(let error):
+                XCTAssertNotNil(error)
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.failureBlockPassedIn!(testError, nil)
+        waitForExpectations(timeout: 0.1)
+        validateEditorThemeRequest()
+    }
+
+    private func validateEditorThemeRequest() {
+        XCTAssertTrue(self.mockRemoteApi.getMethodCalled)
+        XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/wp/v2/sites/1/themes")
+        XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["status"], "active")
+    }
+}
+
+// MARK: Editor Global Styles support
+extension BlockEditorSettingsServiceRemoteTests {
+
+    func testFetchBlockEditorSettingsNotThemeJSON() {
+        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
+        let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
+        service.fetchBlockEditorSettings { (response) in
+            switch response {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                XCTAssertFalse(result!.checksum.isEmpty)
+                XCTAssertGreaterThan(result!.colors!.count, 0)
+                XCTAssertGreaterThan(result!.gradients!.count, 0)
+            case .failure:
+                XCTFail("This payload should parse successfully")
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn!(mockedResponse, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        validateFetchBlockEditorSettingsRequest()
+    }
+
+    func testFetchBlockEditorSettingsNotThemeJSON_NoColors() {
+        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
+        var mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename) as! [String : Any]
+        // Clear out Colors
+        mockedResponse[RemoteBlockEditorSettings.CodingKeys.colors.stringValue] = "false"
+
+        service.fetchBlockEditorSettings { (response) in
+            switch response {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                XCTAssertFalse(result!.checksum.isEmpty)
+                XCTAssertNil(result!.colors)
+                XCTAssertGreaterThan(result!.gradients!.count, 0)
+            case .failure:
+                XCTFail("This payload should parse successfully")
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        validateFetchBlockEditorSettingsRequest()
+    }
+
+    func testFetchBlockEditorSettingsNotThemeJSON_NoGradients() {
+        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
+        var mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename) as! [String : Any]
+        // Clear out Gradients
+        mockedResponse[RemoteBlockEditorSettings.CodingKeys.gradients.stringValue] = "false"
+
+        service.fetchBlockEditorSettings { (response) in
+            switch response {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                XCTAssertFalse(result!.checksum.isEmpty)
+                XCTAssertGreaterThan(result!.colors!.count, 0)
+                XCTAssertNil(result!.gradients)
+            case .failure:
+                XCTFail("This payload should parse successfully")
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        validateFetchBlockEditorSettingsRequest()
+    }
+
+    func testFetchBlockEditorSettingsThemeJSON() {
+        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
+        let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
+
+        service.fetchBlockEditorSettings { (response) in
+            switch response {
+            case .success(let result):
+                XCTAssertNotNil(result)
+                XCTAssertFalse(result!.checksum.isEmpty)
+                // ToDo: Enable when data is updated with GSS Samples
+//                XCTAssertGreaterThan(result!.globalStylesBaseStyles!.colorSettings.colors!.count, 0)
+//                XCTAssertGreaterThan(result!.globalStylesBaseStyles!.colorSettings.gradients!.count, 0)
+            case .failure:
+                XCTFail("This payload should parse successfully")
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        validateFetchBlockEditorSettingsRequest()
+    }
+
+    func testFetchBlockEditorSettingsFailure() {
+        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
+        service.fetchBlockEditorSettings { (response) in
+            switch response {
+            case .success:
+                XCTFail("This Request should have failed")
+            case .failure(let error):
+                XCTAssertNotNil(error)
+            }
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.failureBlockPassedIn!(testError, nil)
+        waitForExpectations(timeout: 0.1)
+        validateFetchBlockEditorSettingsRequest()
+    }
+
+    private func validateFetchBlockEditorSettingsRequest() {
+        XCTAssertTrue(self.mockRemoteApi.getMethodCalled)
+        XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/__experimental/wp-block-editor/v1/settings")
+        XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["context"], "site-editor")
+    }
+}
+

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -227,6 +227,15 @@ extension BlockEditorSettingsServiceRemoteTests {
         validateFetchBlockEditorSettingsRequest()
     }
 
+    func testFetchBlockEditorSettingsThemeJSON_ConsistentChecksum() {
+        let json = Bundle(for: BlockEditorSettingsServiceRemoteTests.self).url(forResource: blockSettingsThemeJSONResponseFilename, withExtension: "json")!
+        let data = try! Data(contentsOf: json)
+
+        let blockEditorSettings1 = try? JSONDecoder().decode(RemoteBlockEditorSettings.self, from: data)
+        let blockEditorSettings2 = try? JSONDecoder().decode(RemoteBlockEditorSettings.self, from: data)
+        XCTAssertEqual(blockEditorSettings1!.checksum, blockEditorSettings2!.checksum)
+    }
+
     func testFetchBlockEditorSettingsFailure() {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
         service.fetchBlockEditorSettings { (response) in

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -155,7 +155,7 @@ extension BlockEditorSettingsServiceRemoteTests {
 
     func testFetchBlockEditorSettingsNotThemeJSON_NoColors() {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
-        var mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename) as! [String : Any]
+        var mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename) as! [String: Any]
         // Clear out Colors
         mockedResponse[RemoteBlockEditorSettings.CodingKeys.colors.stringValue] = "false"
 
@@ -180,7 +180,7 @@ extension BlockEditorSettingsServiceRemoteTests {
 
     func testFetchBlockEditorSettingsNotThemeJSON_NoGradients() {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
-        var mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename) as! [String : Any]
+        var mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename) as! [String: Any]
         // Clear out Gradients
         mockedResponse[RemoteBlockEditorSettings.CodingKeys.gradients.stringValue] = "false"
 
@@ -249,4 +249,3 @@ extension BlockEditorSettingsServiceRemoteTests {
         XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["context"], "site-editor")
     }
 }
-

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -137,67 +137,14 @@ extension BlockEditorSettingsServiceRemoteTests {
         service.fetchBlockEditorSettings { (response) in
             switch response {
             case .success(let result):
-                XCTAssertNotNil(result)
-                XCTAssertFalse(result!.checksum.isEmpty)
-                XCTAssertGreaterThan(result!.colors!.count, 0)
-                XCTAssertGreaterThan(result!.gradients!.count, 0)
-                XCTAssertNil(result!.rawGlobalStylesBaseStyles)
+                self.validateFetchBlockEditorSettingsResults(result)
+                XCTAssertNil(result!.rawStyles)
             case .failure:
                 XCTFail("This payload should parse successfully")
             }
             waitExpectation.fulfill()
         }
         mockRemoteApi.successBlockPassedIn!(mockedResponse, HTTPURLResponse())
-
-        waitForExpectations(timeout: 0.1)
-        validateFetchBlockEditorSettingsRequest()
-    }
-
-    func testFetchBlockEditorSettingsNotThemeJSON_NoColors() {
-        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
-        var mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename) as! [String: Any]
-        // Clear out Colors
-        mockedResponse[RemoteBlockEditorSettings.CodingKeys.colors.stringValue] = "false"
-
-        service.fetchBlockEditorSettings { (response) in
-            switch response {
-            case .success(let result):
-                XCTAssertNotNil(result)
-                XCTAssertFalse(result!.checksum.isEmpty)
-                XCTAssertNil(result!.colors)
-                XCTAssertGreaterThan(result!.gradients!.count, 0)
-                XCTAssertNil(result!.rawGlobalStylesBaseStyles)
-            case .failure:
-                XCTFail("This payload should parse successfully")
-            }
-            waitExpectation.fulfill()
-        }
-        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
-
-        waitForExpectations(timeout: 0.1)
-        validateFetchBlockEditorSettingsRequest()
-    }
-
-    func testFetchBlockEditorSettingsNotThemeJSON_NoGradients() {
-        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
-        var mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename) as! [String: Any]
-        // Clear out Gradients
-        mockedResponse[RemoteBlockEditorSettings.CodingKeys.gradients.stringValue] = "false"
-
-        service.fetchBlockEditorSettings { (response) in
-            switch response {
-            case .success(let result):
-                XCTAssertNotNil(result)
-                XCTAssertFalse(result!.checksum.isEmpty)
-                XCTAssertGreaterThan(result!.colors!.count, 0)
-                XCTAssertNil(result!.gradients)
-                XCTAssertNil(result!.rawGlobalStylesBaseStyles)
-            case .failure:
-                XCTFail("This payload should parse successfully")
-            }
-            waitExpectation.fulfill()
-        }
-        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
 
         waitForExpectations(timeout: 0.1)
         validateFetchBlockEditorSettingsRequest()
@@ -210,10 +157,10 @@ extension BlockEditorSettingsServiceRemoteTests {
         service.fetchBlockEditorSettings { (response) in
             switch response {
             case .success(let result):
-                XCTAssertNotNil(result)
-                XCTAssertFalse(result!.checksum.isEmpty)
-                XCTAssertNotNil(result!.rawGlobalStylesBaseStyles)
-                let gssRawJson = result!.rawGlobalStylesBaseStyles!.data(using: .utf8)!
+                self.validateFetchBlockEditorSettingsResults(result)
+
+                XCTAssertNotNil(result!.rawStyles)
+                let gssRawJson = result!.rawStyles!.data(using: .utf8)!
                 let vaildJson = try? JSONSerialization.jsonObject(with: gssRawJson, options: [])
                 XCTAssertNotNil(vaildJson)
             case .failure:
@@ -255,6 +202,16 @@ extension BlockEditorSettingsServiceRemoteTests {
     private func validateFetchBlockEditorSettingsRequest() {
         XCTAssertTrue(self.mockRemoteApi.getMethodCalled)
         XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/__experimental/wp-block-editor/v1/settings")
-        XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["context"], "site-editor")
+        XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["context"], "mobile")
+    }
+
+    private func validateFetchBlockEditorSettingsResults(_ result: RemoteBlockEditorSettings?) {
+        XCTAssertNotNil(result)
+        XCTAssertFalse(result!.checksum.isEmpty)
+
+        XCTAssertNotNil(result!.rawFeatures)
+        let themeRawJson = result!.rawFeatures!.data(using: .utf8)!
+        let vaildJson = try? JSONSerialization.jsonObject(with: themeRawJson, options: [])
+        XCTAssertNotNil(vaildJson)
     }
 }

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -209,9 +209,7 @@ extension BlockEditorSettingsServiceRemoteTests {
         XCTAssertNotNil(result)
         XCTAssertFalse(result!.checksum.isEmpty)
 
-        XCTAssertNotNil(result!.rawFeatures)
-        let themeRawJson = result!.rawFeatures!.data(using: .utf8)!
-        let vaildJson = try? JSONSerialization.jsonObject(with: themeRawJson, options: [])
-        XCTAssertNotNil(vaildJson)
+        XCTAssertGreaterThan(result!.colors!.count, 0)
+        XCTAssertGreaterThan(result!.gradients!.count, 0)
     }
 }

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/get_wp_v2_themes_twentytwentyone-no-colors.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/get_wp_v2_themes_twentytwentyone-no-colors.json
@@ -1,0 +1,196 @@
+[
+    {
+        "stylesheet": "twentytwentyone",
+        "template": "twentytwentyone",
+        "requires_php": "5.6",
+        "requires_wp": "5.3",
+        "textdomain": "twentytwentyone",
+        "version": "1.2",
+        "screenshot": "https://unique-peccary.jurassic.ninja/wp-content/themes/twentytwentyone/screenshot.png",
+        "author": {
+            "raw": "the WordPress team",
+            "rendered": "<a href=\"https://wordpress.org/\">the WordPress team</a>"
+        },
+        "author_uri": {
+            "raw": "https://wordpress.org/",
+            "rendered": "https://wordpress.org/"
+        },
+        "description": {
+            "raw": "Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.",
+            "rendered": "Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog."
+        },
+        "name": {
+            "raw": "Twenty Twenty-One",
+            "rendered": "Twenty Twenty-One"
+        },
+        "tags": {
+            "raw": [
+                "one-column",
+                "accessibility-ready",
+                "custom-colors",
+                "custom-menu",
+                "custom-logo",
+                "editor-style",
+                "featured-images",
+                "footer-widgets",
+                "block-patterns",
+                "rtl-language-support",
+                "sticky-post",
+                "threaded-comments",
+                "translation-ready"
+            ],
+            "rendered": "one-column, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready"
+        },
+        "theme_uri": {
+            "raw": "https://wordpress.org/themes/twentytwentyone/",
+            "rendered": "https://wordpress.org/themes/twentytwentyone/"
+        },
+        "status": "active",
+        "theme_supports": {
+            "align-wide": true,
+            "automatic-feed-links": true,
+            "custom-background": {
+                "default-image": "",
+                "default-preset": "default",
+                "default-position-x": "left",
+                "default-position-y": "top",
+                "default-size": "auto",
+                "default-repeat": "repeat",
+                "default-attachment": "scroll",
+                "default-color": "d1e4dd"
+            },
+            "custom-header": false,
+            "custom-logo": {
+                "width": 300,
+                "height": 100,
+                "flex-width": true,
+                "flex-height": true,
+                "header-text": [],
+                "unlink-homepage-logo": true
+            },
+            "customize-selective-refresh-widgets": true,
+            "dark-editor-style": false,
+            "disable-custom-colors": false,
+            "disable-custom-font-sizes": false,
+            "disable-custom-gradients": false,
+            "editor-color-palette": false,
+            "editor-font-sizes": [
+                {
+                    "name": "Extra small",
+                    "size": 16,
+                    "slug": "extra-small"
+                },
+                {
+                    "name": "Small",
+                    "size": 18,
+                    "slug": "small"
+                },
+                {
+                    "name": "Normal",
+                    "size": 20,
+                    "slug": "normal"
+                },
+                {
+                    "name": "Large",
+                    "size": 24,
+                    "slug": "large"
+                },
+                {
+                    "name": "Extra large",
+                    "size": 40,
+                    "slug": "extra-large"
+                },
+                {
+                    "name": "Huge",
+                    "size": 96,
+                    "slug": "huge"
+                },
+                {
+                    "name": "Gigantic",
+                    "size": 144,
+                    "slug": "gigantic"
+                }
+            ],
+            "editor-gradient-presets": [
+                {
+                    "name": "Purple to yellow",
+                    "gradient": "linear-gradient(160deg, #D1D1E4 0%, #EEEADD 100%)",
+                    "slug": "purple-to-yellow"
+                },
+                {
+                    "name": "Yellow to purple",
+                    "gradient": "linear-gradient(160deg, #EEEADD 0%, #D1D1E4 100%)",
+                    "slug": "yellow-to-purple"
+                },
+                {
+                    "name": "Green to yellow",
+                    "gradient": "linear-gradient(160deg, #D1E4DD 0%, #EEEADD 100%)",
+                    "slug": "green-to-yellow"
+                },
+                {
+                    "name": "Yellow to green",
+                    "gradient": "linear-gradient(160deg, #EEEADD 0%, #D1E4DD 100%)",
+                    "slug": "yellow-to-green"
+                },
+                {
+                    "name": "Red to yellow",
+                    "gradient": "linear-gradient(160deg, #E4D1D1 0%, #EEEADD 100%)",
+                    "slug": "red-to-yellow"
+                },
+                {
+                    "name": "Yellow to red",
+                    "gradient": "linear-gradient(160deg, #EEEADD 0%, #E4D1D1 100%)",
+                    "slug": "yellow-to-red"
+                },
+                {
+                    "name": "Purple to red",
+                    "gradient": "linear-gradient(160deg, #D1D1E4 0%, #E4D1D1 100%)",
+                    "slug": "purple-to-red"
+                },
+                {
+                    "name": "Red to purple",
+                    "gradient": "linear-gradient(160deg, #E4D1D1 0%, #D1D1E4 100%)",
+                    "slug": "red-to-purple"
+                }
+            ],
+            "editor-styles": true,
+            "html5": [
+                "comment-form",
+                "comment-list",
+                "gallery",
+                "caption",
+                "style",
+                "script",
+                "navigation-widgets"
+            ],
+            "formats": [
+                "standard",
+                "link",
+                "aside",
+                "gallery",
+                "image",
+                "quote",
+                "status",
+                "video",
+                "audio",
+                "chat"
+            ],
+            "post-thumbnails": true,
+            "responsive-embeds": true,
+            "title-tag": true,
+            "wp-block-styles": true
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "https://unique-peccary.jurassic.ninja/wp-json/wp/v2/themes/twentytwentyone"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://unique-peccary.jurassic.ninja/wp-json/wp/v2/themes"
+                }
+            ]
+        }
+    }
+]

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/get_wp_v2_themes_twentytwentyone.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/get_wp_v2_themes_twentytwentyone.json
@@ -1,0 +1,247 @@
+[
+    {
+        "stylesheet": "twentytwentyone",
+        "template": "twentytwentyone",
+        "requires_php": "5.6",
+        "requires_wp": "5.3",
+        "textdomain": "twentytwentyone",
+        "version": "1.2",
+        "screenshot": "https://unique-peccary.jurassic.ninja/wp-content/themes/twentytwentyone/screenshot.png",
+        "author": {
+            "raw": "the WordPress team",
+            "rendered": "<a href=\"https://wordpress.org/\">the WordPress team</a>"
+        },
+        "author_uri": {
+            "raw": "https://wordpress.org/",
+            "rendered": "https://wordpress.org/"
+        },
+        "description": {
+            "raw": "Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog.",
+            "rendered": "Twenty Twenty-One is a blank canvas for your ideas and it makes the block editor your best brush. With new block patterns, which allow you to create a beautiful layout in a matter of seconds, this theme’s soft colors and eye-catching — yet timeless — design will let your work shine. Take it for a spin! See how Twenty Twenty-One elevates your portfolio, business website, or personal blog."
+        },
+        "name": {
+            "raw": "Twenty Twenty-One",
+            "rendered": "Twenty Twenty-One"
+        },
+        "tags": {
+            "raw": [
+                "one-column",
+                "accessibility-ready",
+                "custom-colors",
+                "custom-menu",
+                "custom-logo",
+                "editor-style",
+                "featured-images",
+                "footer-widgets",
+                "block-patterns",
+                "rtl-language-support",
+                "sticky-post",
+                "threaded-comments",
+                "translation-ready"
+            ],
+            "rendered": "one-column, accessibility-ready, custom-colors, custom-menu, custom-logo, editor-style, featured-images, footer-widgets, block-patterns, rtl-language-support, sticky-post, threaded-comments, translation-ready"
+        },
+        "theme_uri": {
+            "raw": "https://wordpress.org/themes/twentytwentyone/",
+            "rendered": "https://wordpress.org/themes/twentytwentyone/"
+        },
+        "status": "active",
+        "theme_supports": {
+            "align-wide": true,
+            "automatic-feed-links": true,
+            "custom-background": {
+                "default-image": "",
+                "default-preset": "default",
+                "default-position-x": "left",
+                "default-position-y": "top",
+                "default-size": "auto",
+                "default-repeat": "repeat",
+                "default-attachment": "scroll",
+                "default-color": "d1e4dd"
+            },
+            "custom-header": false,
+            "custom-logo": {
+                "width": 300,
+                "height": 100,
+                "flex-width": true,
+                "flex-height": true,
+                "header-text": [],
+                "unlink-homepage-logo": true
+            },
+            "customize-selective-refresh-widgets": true,
+            "dark-editor-style": false,
+            "disable-custom-colors": false,
+            "disable-custom-font-sizes": false,
+            "disable-custom-gradients": false,
+            "editor-color-palette": [
+                {
+                    "name": "Black",
+                    "slug": "black",
+                    "color": "#000000"
+                },
+                {
+                    "name": "Dark gray",
+                    "slug": "dark-gray",
+                    "color": "#28303D"
+                },
+                {
+                    "name": "Gray",
+                    "slug": "gray",
+                    "color": "#39414D"
+                },
+                {
+                    "name": "Green",
+                    "slug": "green",
+                    "color": "#D1E4DD"
+                },
+                {
+                    "name": "Blue",
+                    "slug": "blue",
+                    "color": "#D1DFE4"
+                },
+                {
+                    "name": "Purple",
+                    "slug": "purple",
+                    "color": "#D1D1E4"
+                },
+                {
+                    "name": "Red",
+                    "slug": "red",
+                    "color": "#E4D1D1"
+                },
+                {
+                    "name": "Orange",
+                    "slug": "orange",
+                    "color": "#E4DAD1"
+                },
+                {
+                    "name": "Yellow",
+                    "slug": "yellow",
+                    "color": "#EEEADD"
+                },
+                {
+                    "name": "White",
+                    "slug": "white",
+                    "color": "#FFFFFF"
+                }
+            ],
+            "editor-font-sizes": [
+                {
+                    "name": "Extra small",
+                    "size": 16,
+                    "slug": "extra-small"
+                },
+                {
+                    "name": "Small",
+                    "size": 18,
+                    "slug": "small"
+                },
+                {
+                    "name": "Normal",
+                    "size": 20,
+                    "slug": "normal"
+                },
+                {
+                    "name": "Large",
+                    "size": 24,
+                    "slug": "large"
+                },
+                {
+                    "name": "Extra large",
+                    "size": 40,
+                    "slug": "extra-large"
+                },
+                {
+                    "name": "Huge",
+                    "size": 96,
+                    "slug": "huge"
+                },
+                {
+                    "name": "Gigantic",
+                    "size": 144,
+                    "slug": "gigantic"
+                }
+            ],
+            "editor-gradient-presets": [
+                {
+                    "name": "Purple to yellow",
+                    "gradient": "linear-gradient(160deg, #D1D1E4 0%, #EEEADD 100%)",
+                    "slug": "purple-to-yellow"
+                },
+                {
+                    "name": "Yellow to purple",
+                    "gradient": "linear-gradient(160deg, #EEEADD 0%, #D1D1E4 100%)",
+                    "slug": "yellow-to-purple"
+                },
+                {
+                    "name": "Green to yellow",
+                    "gradient": "linear-gradient(160deg, #D1E4DD 0%, #EEEADD 100%)",
+                    "slug": "green-to-yellow"
+                },
+                {
+                    "name": "Yellow to green",
+                    "gradient": "linear-gradient(160deg, #EEEADD 0%, #D1E4DD 100%)",
+                    "slug": "yellow-to-green"
+                },
+                {
+                    "name": "Red to yellow",
+                    "gradient": "linear-gradient(160deg, #E4D1D1 0%, #EEEADD 100%)",
+                    "slug": "red-to-yellow"
+                },
+                {
+                    "name": "Yellow to red",
+                    "gradient": "linear-gradient(160deg, #EEEADD 0%, #E4D1D1 100%)",
+                    "slug": "yellow-to-red"
+                },
+                {
+                    "name": "Purple to red",
+                    "gradient": "linear-gradient(160deg, #D1D1E4 0%, #E4D1D1 100%)",
+                    "slug": "purple-to-red"
+                },
+                {
+                    "name": "Red to purple",
+                    "gradient": "linear-gradient(160deg, #E4D1D1 0%, #D1D1E4 100%)",
+                    "slug": "red-to-purple"
+                }
+            ],
+            "editor-styles": true,
+            "html5": [
+                "comment-form",
+                "comment-list",
+                "gallery",
+                "caption",
+                "style",
+                "script",
+                "navigation-widgets"
+            ],
+            "formats": [
+                "standard",
+                "link",
+                "aside",
+                "gallery",
+                "image",
+                "quote",
+                "status",
+                "video",
+                "audio",
+                "chat"
+            ],
+            "post-thumbnails": true,
+            "responsive-embeds": true,
+            "title-tag": true,
+            "wp-block-styles": true
+        },
+        "_links": {
+            "self": [
+                {
+                    "href": "https://unique-peccary.jurassic.ninja/wp-json/wp/v2/themes/twentytwentyone"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://unique-peccary.jurassic.ninja/wp-json/wp/v2/themes"
+                }
+            ]
+        }
+    }
+]

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
@@ -1,0 +1,318 @@
+{
+    "__unstableEnableFullSiteEditingBlocks": true,
+    "alignWide": true,
+    "allowedBlockTypes": true,
+    "allowedMimeTypes": {
+        "jpg|jpeg|jpe": "image/jpeg",
+        "gif": "image/gif",
+        "png": "image/png",
+        "bmp": "image/bmp",
+        "tiff|tif": "image/tiff",
+        "ico": "image/x-icon",
+        "heic": "image/heic",
+        "asf|asx": "video/x-ms-asf",
+        "wmv": "video/x-ms-wmv",
+        "wmx": "video/x-ms-wmx",
+        "wm": "video/x-ms-wm",
+        "avi": "video/avi",
+        "divx": "video/divx",
+        "flv": "video/x-flv",
+        "mov|qt": "video/quicktime",
+        "mpeg|mpg|mpe": "video/mpeg",
+        "mp4|m4v": "video/mp4",
+        "ogv": "video/ogg",
+        "webm": "video/webm",
+        "mkv": "video/x-matroska",
+        "3gp|3gpp": "video/3gpp",
+        "3g2|3gp2": "video/3gpp2",
+        "txt|asc|c|cc|h|srt": "text/plain",
+        "csv": "text/csv",
+        "tsv": "text/tab-separated-values",
+        "ics": "text/calendar",
+        "rtx": "text/richtext",
+        "css": "text/css",
+        "htm|html": "text/html",
+        "vtt": "text/vtt",
+        "dfxp": "application/ttaf+xml",
+        "mp3|m4a|m4b": "audio/mpeg",
+        "aac": "audio/aac",
+        "ra|ram": "audio/x-realaudio",
+        "wav": "audio/wav",
+        "ogg|oga": "audio/ogg",
+        "flac": "audio/flac",
+        "mid|midi": "audio/midi",
+        "wma": "audio/x-ms-wma",
+        "wax": "audio/x-ms-wax",
+        "mka": "audio/x-matroska",
+        "rtf": "application/rtf",
+        "js": "application/javascript",
+        "pdf": "application/pdf",
+        "class": "application/java",
+        "tar": "application/x-tar",
+        "zip": "application/zip",
+        "gz|gzip": "application/x-gzip",
+        "rar": "application/rar",
+        "7z": "application/x-7z-compressed",
+        "psd": "application/octet-stream",
+        "xcf": "application/octet-stream",
+        "doc": "application/msword",
+        "pot|pps|ppt": "application/vnd.ms-powerpoint",
+        "wri": "application/vnd.ms-write",
+        "xla|xls|xlt|xlw": "application/vnd.ms-excel",
+        "mdb": "application/vnd.ms-access",
+        "mpp": "application/vnd.ms-project",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "docm": "application/vnd.ms-word.document.macroEnabled.12",
+        "dotx": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+        "dotm": "application/vnd.ms-word.template.macroEnabled.12",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
+        "xlsb": "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+        "xltx": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+        "xltm": "application/vnd.ms-excel.template.macroEnabled.12",
+        "xlam": "application/vnd.ms-excel.addin.macroEnabled.12",
+        "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "pptm": "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+        "ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+        "ppsm": "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
+        "potx": "application/vnd.openxmlformats-officedocument.presentationml.template",
+        "potm": "application/vnd.ms-powerpoint.template.macroEnabled.12",
+        "ppam": "application/vnd.ms-powerpoint.addin.macroEnabled.12",
+        "sldx": "application/vnd.openxmlformats-officedocument.presentationml.slide",
+        "sldm": "application/vnd.ms-powerpoint.slide.macroEnabled.12",
+        "onetoc|onetoc2|onetmp|onepkg": "application/onenote",
+        "oxps": "application/oxps",
+        "xps": "application/vnd.ms-xpsdocument",
+        "odt": "application/vnd.oasis.opendocument.text",
+        "odp": "application/vnd.oasis.opendocument.presentation",
+        "ods": "application/vnd.oasis.opendocument.spreadsheet",
+        "odg": "application/vnd.oasis.opendocument.graphics",
+        "odc": "application/vnd.oasis.opendocument.chart",
+        "odb": "application/vnd.oasis.opendocument.database",
+        "odf": "application/vnd.oasis.opendocument.formula",
+        "wp|wpd": "application/wordperfect",
+        "key": "application/vnd.apple.keynote",
+        "numbers": "application/vnd.apple.numbers",
+        "pages": "application/vnd.apple.pages"
+    },
+    "blockCategories": [
+        {
+            "slug": "text",
+            "title": "Text",
+            "icon": null
+        },
+        {
+            "slug": "media",
+            "title": "Media",
+            "icon": null
+        },
+        {
+            "slug": "design",
+            "title": "Design",
+            "icon": null
+        },
+        {
+            "slug": "widgets",
+            "title": "Widgets",
+            "icon": null
+        },
+        {
+            "slug": "theme",
+            "title": "Theme",
+            "icon": null
+        },
+        {
+            "slug": "embed",
+            "title": "Embeds",
+            "icon": null
+        },
+        {
+            "slug": "reusable",
+            "title": "Reusable Blocks",
+            "icon": null
+        }
+    ],
+    "disableCustomColors": false,
+    "disableCustomFontSizes": false,
+    "disableCustomGradients": false,
+    "enableCustomLineHeight": true,
+    "enableCustomSpacing": true,
+    "enableCustomUnits": true,
+    "isRTL": false,
+    "imageDefaultSize": "large",
+    "imageDimensions": {
+        "thumbnail": {
+            "width": 150,
+            "height": 150,
+            "crop": true
+        },
+        "medium": {
+            "width": 300,
+            "height": 300,
+            "crop": false
+        },
+        "large": {
+            "width": 1024,
+            "height": 1024,
+            "crop": false
+        }
+    },
+    "imageEditing": true,
+    "imageSizes": [
+        {
+            "slug": "thumbnail",
+            "name": "Thumbnail"
+        },
+        {
+            "slug": "medium",
+            "name": "Medium"
+        },
+        {
+            "slug": "large",
+            "name": "Large"
+        },
+        {
+            "slug": "full",
+            "name": "Full Size"
+        }
+    ],
+    "maxUploadFileSize": 2097152,
+    "colors": [
+        {
+            "name": "Black",
+            "slug": "black",
+            "color": "#000000"
+        },
+        {
+            "name": "Dark gray",
+            "slug": "dark-gray",
+            "color": "#28303D"
+        },
+        {
+            "name": "Gray",
+            "slug": "gray",
+            "color": "#39414D"
+        },
+        {
+            "name": "Green",
+            "slug": "green",
+            "color": "#D1E4DD"
+        },
+        {
+            "name": "Blue",
+            "slug": "blue",
+            "color": "#D1DFE4"
+        },
+        {
+            "name": "Purple",
+            "slug": "purple",
+            "color": "#D1D1E4"
+        },
+        {
+            "name": "Red",
+            "slug": "red",
+            "color": "#E4D1D1"
+        },
+        {
+            "name": "Orange",
+            "slug": "orange",
+            "color": "#E4DAD1"
+        },
+        {
+            "name": "Yellow",
+            "slug": "yellow",
+            "color": "#EEEADD"
+        },
+        {
+            "name": "White",
+            "slug": "white",
+            "color": "#FFFFFF"
+        }
+    ],
+    "fontSizes": [
+        {
+            "name": "Extra small",
+            "shortName": "XS",
+            "size": 16,
+            "slug": "extra-small"
+        },
+        {
+            "name": "Small",
+            "shortName": "S",
+            "size": 18,
+            "slug": "small"
+        },
+        {
+            "name": "Normal",
+            "shortName": "M",
+            "size": 20,
+            "slug": "normal"
+        },
+        {
+            "name": "Large",
+            "shortName": "L",
+            "size": 24,
+            "slug": "large"
+        },
+        {
+            "name": "Extra large",
+            "shortName": "XL",
+            "size": 40,
+            "slug": "extra-large"
+        },
+        {
+            "name": "Huge",
+            "shortName": "XXL",
+            "size": 96,
+            "slug": "huge"
+        },
+        {
+            "name": "Gigantic",
+            "shortName": "XXXL",
+            "size": 144,
+            "slug": "gigantic"
+        }
+    ],
+    "gradients": [
+        {
+            "name": "Purple to yellow",
+            "gradient": "linear-gradient(160deg, #D1D1E4 0%, #EEEADD 100%)",
+            "slug": "purple-to-yellow"
+        },
+        {
+            "name": "Yellow to purple",
+            "gradient": "linear-gradient(160deg, #EEEADD 0%, #D1D1E4 100%)",
+            "slug": "yellow-to-purple"
+        },
+        {
+            "name": "Green to yellow",
+            "gradient": "linear-gradient(160deg, #D1E4DD 0%, #EEEADD 100%)",
+            "slug": "green-to-yellow"
+        },
+        {
+            "name": "Yellow to green",
+            "gradient": "linear-gradient(160deg, #EEEADD 0%, #D1E4DD 100%)",
+            "slug": "yellow-to-green"
+        },
+        {
+            "name": "Red to yellow",
+            "gradient": "linear-gradient(160deg, #E4D1D1 0%, #EEEADD 100%)",
+            "slug": "red-to-yellow"
+        },
+        {
+            "name": "Yellow to red",
+            "gradient": "linear-gradient(160deg, #EEEADD 0%, #E4D1D1 100%)",
+            "slug": "yellow-to-red"
+        },
+        {
+            "name": "Purple to red",
+            "gradient": "linear-gradient(160deg, #D1D1E4 0%, #E4D1D1 100%)",
+            "slug": "purple-to-red"
+        },
+        {
+            "name": "Red to purple",
+            "gradient": "linear-gradient(160deg, #E4D1D1 0%, #D1D1E4 100%)",
+            "slug": "red-to-purple"
+        }
+    ]
+}

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
@@ -8,6 +8,7 @@
         "png": "image/png",
         "bmp": "image/bmp",
         "tiff|tif": "image/tiff",
+        "webp": "image/webp",
         "ico": "image/x-icon",
         "heic": "image/heic",
         "asf|asx": "video/x-ms-asf",
@@ -132,12 +133,6 @@
             "icon": null
         }
     ],
-    "disableCustomColors": false,
-    "disableCustomFontSizes": false,
-    "disableCustomGradients": false,
-    "enableCustomLineHeight": true,
-    "enableCustomSpacing": true,
-    "enableCustomUnits": true,
     "isRTL": false,
     "imageDefaultSize": "large",
     "imageDimensions": {
@@ -177,142 +172,242 @@
         }
     ],
     "maxUploadFileSize": 2097152,
-    "colors": [
-        {
-            "name": "Black",
-            "slug": "black",
-            "color": "#000000"
-        },
-        {
-            "name": "Dark gray",
-            "slug": "dark-gray",
-            "color": "#28303D"
-        },
-        {
-            "name": "Gray",
-            "slug": "gray",
-            "color": "#39414D"
-        },
-        {
-            "name": "Green",
-            "slug": "green",
-            "color": "#D1E4DD"
-        },
-        {
-            "name": "Blue",
-            "slug": "blue",
-            "color": "#D1DFE4"
-        },
-        {
-            "name": "Purple",
-            "slug": "purple",
-            "color": "#D1D1E4"
-        },
-        {
-            "name": "Red",
-            "slug": "red",
-            "color": "#E4D1D1"
-        },
-        {
-            "name": "Orange",
-            "slug": "orange",
-            "color": "#E4DAD1"
-        },
-        {
-            "name": "Yellow",
-            "slug": "yellow",
-            "color": "#EEEADD"
-        },
-        {
-            "name": "White",
-            "slug": "white",
-            "color": "#FFFFFF"
-        }
+    "styles": [],
+    "supportsTemplateMode": true,
+    "supportsLayout": false,
+    "widgetTypesToHideFromLegacyWidgetBlock": [
+        "pages",
+        "calendar",
+        "archives",
+        "media_audio",
+        "media_image",
+        "media_gallery",
+        "media_video",
+        "meta",
+        "search",
+        "text",
+        "categories",
+        "recent-posts",
+        "recent-comments",
+        "rss",
+        "tag_cloud",
+        "nav_menu",
+        "custom_html",
+        "block"
     ],
-    "fontSizes": [
-        {
-            "name": "Extra small",
-            "shortName": "XS",
-            "size": 16,
-            "slug": "extra-small"
+    "__experimentalFeatures": {
+        "color": {
+            "palette": [
+                {
+                    "name": "Accent Color",
+                    "slug": "accent",
+                    "color": "#cd2653"
+                },
+                {
+                    "name": "Primary",
+                    "slug": "primary",
+                    "color": "#000000"
+                },
+                {
+                    "name": "Secondary",
+                    "slug": "secondary",
+                    "color": "#6d6d6d"
+                },
+                {
+                    "name": "Subtle Background",
+                    "slug": "subtle-background",
+                    "color": "#dcd7ca"
+                },
+                {
+                    "name": "Background Color",
+                    "slug": "background",
+                    "color": "#f5efe0"
+                }
+            ],
+            "gradients": [
+                {
+                    "name": "Vivid cyan blue to vivid purple",
+                    "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
+                    "slug": "vivid-cyan-blue-to-vivid-purple"
+                },
+                {
+                    "name": "Light green cyan to vivid green cyan",
+                    "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
+                    "slug": "light-green-cyan-to-vivid-green-cyan"
+                },
+                {
+                    "name": "Luminous vivid amber to luminous vivid orange",
+                    "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
+                    "slug": "luminous-vivid-amber-to-luminous-vivid-orange"
+                },
+                {
+                    "name": "Luminous vivid orange to vivid red",
+                    "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
+                    "slug": "luminous-vivid-orange-to-vivid-red"
+                },
+                {
+                    "name": "Very light gray to cyan bluish gray",
+                    "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
+                    "slug": "very-light-gray-to-cyan-bluish-gray"
+                },
+                {
+                    "name": "Cool to warm spectrum",
+                    "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
+                    "slug": "cool-to-warm-spectrum"
+                },
+                {
+                    "name": "Blush light purple",
+                    "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
+                    "slug": "blush-light-purple"
+                },
+                {
+                    "name": "Blush bordeaux",
+                    "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
+                    "slug": "blush-bordeaux"
+                },
+                {
+                    "name": "Luminous dusk",
+                    "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
+                    "slug": "luminous-dusk"
+                },
+                {
+                    "name": "Pale ocean",
+                    "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
+                    "slug": "pale-ocean"
+                },
+                {
+                    "name": "Electric grass",
+                    "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
+                    "slug": "electric-grass"
+                },
+                {
+                    "name": "Midnight",
+                    "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
+                    "slug": "midnight"
+                }
+            ],
+            "duotone": [
+                {
+                    "name": "Dark grayscale",
+                    "colors": [
+                        "#000000",
+                        "#7f7f7f"
+                    ],
+                    "slug": "dark-grayscale"
+                },
+                {
+                    "name": "Grayscale",
+                    "colors": [
+                        "#000000",
+                        "#ffffff"
+                    ],
+                    "slug": "grayscale"
+                },
+                {
+                    "name": "Purple and yellow",
+                    "colors": [
+                        "#8c00b7",
+                        "#fcff41"
+                    ],
+                    "slug": "purple-yellow"
+                },
+                {
+                    "name": "Blue and red",
+                    "colors": [
+                        "#000097",
+                        "#ff4747"
+                    ],
+                    "slug": "blue-red"
+                },
+                {
+                    "name": "Midnight",
+                    "colors": [
+                        "#000000",
+                        "#00a5ff"
+                    ],
+                    "slug": "midnight"
+                },
+                {
+                    "name": "Magenta and yellow",
+                    "colors": [
+                        "#c7005a",
+                        "#fff278"
+                    ],
+                    "slug": "magenta-yellow"
+                },
+                {
+                    "name": "Purple and green",
+                    "colors": [
+                        "#a60072",
+                        "#67ff66"
+                    ],
+                    "slug": "purple-green"
+                },
+                {
+                    "name": "Blue and orange",
+                    "colors": [
+                        "#1900d8",
+                        "#ffa96b"
+                    ],
+                    "slug": "blue-orange"
+                }
+            ],
+            "custom": true,
+            "link": false,
+            "customGradient": true
         },
-        {
-            "name": "Small",
-            "shortName": "S",
-            "size": 18,
-            "slug": "small"
+        "typography": {
+            "dropCap": true,
+            "customFontSize": true,
+            "customLineHeight": false,
+            "customFontStyle": true,
+            "customFontWeight": true,
+            "customTextTransforms": true,
+            "customTextDecorations": true,
+            "fontSizes": [
+                {
+                    "name": "Small",
+                    "shortName": "S",
+                    "size": "18px",
+                    "slug": "small"
+                },
+                {
+                    "name": "Regular",
+                    "shortName": "M",
+                    "size": "21px",
+                    "slug": "normal"
+                },
+                {
+                    "name": "Large",
+                    "shortName": "L",
+                    "size": "26.25px",
+                    "slug": "large"
+                },
+                {
+                    "name": "Larger",
+                    "shortName": "XL",
+                    "size": "32px",
+                    "slug": "larger"
+                }
+            ]
         },
-        {
-            "name": "Normal",
-            "shortName": "M",
-            "size": 20,
-            "slug": "normal"
+        "spacing": {
+            "customMargin": false,
+            "customPadding": false,
+            "units": false
         },
-        {
-            "name": "Large",
-            "shortName": "L",
-            "size": 24,
-            "slug": "large"
+        "border": {
+            "customColor": false,
+            "customRadius": false,
+            "customStyle": false,
+            "customWidth": false
         },
-        {
-            "name": "Extra large",
-            "shortName": "XL",
-            "size": 40,
-            "slug": "extra-large"
-        },
-        {
-            "name": "Huge",
-            "shortName": "XXL",
-            "size": 96,
-            "slug": "huge"
-        },
-        {
-            "name": "Gigantic",
-            "shortName": "XXXL",
-            "size": 144,
-            "slug": "gigantic"
+        "blocks": {
+            "core/button": {
+                "border": {
+                    "customRadius": true
+                }
+            }
         }
-    ],
-    "gradients": [
-        {
-            "name": "Purple to yellow",
-            "gradient": "linear-gradient(160deg, #D1D1E4 0%, #EEEADD 100%)",
-            "slug": "purple-to-yellow"
-        },
-        {
-            "name": "Yellow to purple",
-            "gradient": "linear-gradient(160deg, #EEEADD 0%, #D1D1E4 100%)",
-            "slug": "yellow-to-purple"
-        },
-        {
-            "name": "Green to yellow",
-            "gradient": "linear-gradient(160deg, #D1E4DD 0%, #EEEADD 100%)",
-            "slug": "green-to-yellow"
-        },
-        {
-            "name": "Yellow to green",
-            "gradient": "linear-gradient(160deg, #EEEADD 0%, #D1E4DD 100%)",
-            "slug": "yellow-to-green"
-        },
-        {
-            "name": "Red to yellow",
-            "gradient": "linear-gradient(160deg, #E4D1D1 0%, #EEEADD 100%)",
-            "slug": "red-to-yellow"
-        },
-        {
-            "name": "Yellow to red",
-            "gradient": "linear-gradient(160deg, #EEEADD 0%, #E4D1D1 100%)",
-            "slug": "yellow-to-red"
-        },
-        {
-            "name": "Purple to red",
-            "gradient": "linear-gradient(160deg, #D1D1E4 0%, #E4D1D1 100%)",
-            "slug": "purple-to-red"
-        },
-        {
-            "name": "Red to purple",
-            "gradient": "linear-gradient(160deg, #E4D1D1 0%, #D1D1E4 100%)",
-            "slug": "red-to-purple"
-        }
-    ]
+    }
 }

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
@@ -8,6 +8,7 @@
         "png": "image/png",
         "bmp": "image/bmp",
         "tiff|tif": "image/tiff",
+        "webp": "image/webp",
         "ico": "image/x-icon",
         "heic": "image/heic",
         "asf|asx": "video/x-ms-asf",
@@ -132,9 +133,9 @@
             "icon": null
         }
     ],
-    "disableCustomColors": true,
-    "disableCustomFontSizes": true,
-    "disableCustomGradients": true,
+    "disableCustomColors": false,
+    "disableCustomFontSizes": false,
+    "disableCustomGradients": false,
     "enableCustomLineHeight": false,
     "enableCustomSpacing": false,
     "enableCustomUnits": false,
@@ -178,78 +179,6 @@
     ],
     "maxUploadFileSize": 536870912,
     "colors": [
-        {
-            "name": "Black",
-            "slug": "black",
-            "color": "#000000",
-            "origin": "core"
-        },
-        {
-            "name": "Cyan bluish gray",
-            "slug": "cyan-bluish-gray",
-            "color": "#abb8c3",
-            "origin": "core"
-        },
-        {
-            "name": "White",
-            "slug": "white",
-            "color": "#ffffff",
-            "origin": "core"
-        },
-        {
-            "name": "Pale pink",
-            "slug": "pale-pink",
-            "color": "#f78da7",
-            "origin": "core"
-        },
-        {
-            "name": "Vivid red",
-            "slug": "vivid-red",
-            "color": "#cf2e2e",
-            "origin": "core"
-        },
-        {
-            "name": "Luminous vivid orange",
-            "slug": "luminous-vivid-orange",
-            "color": "#ff6900",
-            "origin": "core"
-        },
-        {
-            "name": "Luminous vivid amber",
-            "slug": "luminous-vivid-amber",
-            "color": "#fcb900",
-            "origin": "core"
-        },
-        {
-            "name": "Light green cyan",
-            "slug": "light-green-cyan",
-            "color": "#7bdcb5",
-            "origin": "core"
-        },
-        {
-            "name": "Vivid green cyan",
-            "slug": "vivid-green-cyan",
-            "color": "#00d084",
-            "origin": "core"
-        },
-        {
-            "name": "Pale cyan blue",
-            "slug": "pale-cyan-blue",
-            "color": "#8ed1fc",
-            "origin": "core"
-        },
-        {
-            "name": "Vivid cyan blue",
-            "slug": "vivid-cyan-blue",
-            "color": "#0693e3",
-            "origin": "core"
-        },
-        {
-            "name": "Vivid purple",
-            "slug": "vivid-purple",
-            "color": "#9b51e0",
-            "origin": "core"
-        },
         {
             "name": "Accent Color",
             "slug": "accent",
@@ -302,8 +231,166 @@
             "slug": "larger"
         }
     ],
+    "styles": [],
+    "supportsTemplateMode": true,
+    "supportsLayout": false,
     "__experimentalFeatures": {
         "color": {
+            "palette": {
+                "core": [
+                    {
+                        "name": "Black",
+                        "slug": "black",
+                        "color": "#000000"
+                    },
+                    {
+                        "name": "Cyan bluish gray",
+                        "slug": "cyan-bluish-gray",
+                        "color": "#abb8c3"
+                    },
+                    {
+                        "name": "White",
+                        "slug": "white",
+                        "color": "#ffffff"
+                    },
+                    {
+                        "name": "Pale pink",
+                        "slug": "pale-pink",
+                        "color": "#f78da7"
+                    },
+                    {
+                        "name": "Vivid red",
+                        "slug": "vivid-red",
+                        "color": "#cf2e2e"
+                    },
+                    {
+                        "name": "Luminous vivid orange",
+                        "slug": "luminous-vivid-orange",
+                        "color": "#ff6900"
+                    },
+                    {
+                        "name": "Luminous vivid amber",
+                        "slug": "luminous-vivid-amber",
+                        "color": "#fcb900"
+                    },
+                    {
+                        "name": "Light green cyan",
+                        "slug": "light-green-cyan",
+                        "color": "#7bdcb5"
+                    },
+                    {
+                        "name": "Vivid green cyan",
+                        "slug": "vivid-green-cyan",
+                        "color": "#00d084"
+                    },
+                    {
+                        "name": "Pale cyan blue",
+                        "slug": "pale-cyan-blue",
+                        "color": "#8ed1fc"
+                    },
+                    {
+                        "name": "Vivid cyan blue",
+                        "slug": "vivid-cyan-blue",
+                        "color": "#0693e3"
+                    },
+                    {
+                        "name": "Vivid purple",
+                        "slug": "vivid-purple",
+                        "color": "#9b51e0"
+                    }
+                ],
+                "theme": [
+                    {
+                        "name": "Accent Color",
+                        "slug": "accent",
+                        "color": "#cd2653"
+                    },
+                    {
+                        "name": "Primary",
+                        "slug": "primary",
+                        "color": "#000000"
+                    },
+                    {
+                        "name": "Secondary",
+                        "slug": "secondary",
+                        "color": "#6d6d6d"
+                    },
+                    {
+                        "name": "Subtle Background",
+                        "slug": "subtle-background",
+                        "color": "#dcd7ca"
+                    },
+                    {
+                        "name": "Background Color",
+                        "slug": "background",
+                        "color": "#f5efe0"
+                    }
+                ]
+            },
+            "gradients": {
+                "core": [
+                    {
+                        "name": "Vivid cyan blue to vivid purple",
+                        "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
+                        "slug": "vivid-cyan-blue-to-vivid-purple"
+                    },
+                    {
+                        "name": "Light green cyan to vivid green cyan",
+                        "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
+                        "slug": "light-green-cyan-to-vivid-green-cyan"
+                    },
+                    {
+                        "name": "Luminous vivid amber to luminous vivid orange",
+                        "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
+                        "slug": "luminous-vivid-amber-to-luminous-vivid-orange"
+                    },
+                    {
+                        "name": "Luminous vivid orange to vivid red",
+                        "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
+                        "slug": "luminous-vivid-orange-to-vivid-red"
+                    },
+                    {
+                        "name": "Very light gray to cyan bluish gray",
+                        "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
+                        "slug": "very-light-gray-to-cyan-bluish-gray"
+                    },
+                    {
+                        "name": "Cool to warm spectrum",
+                        "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
+                        "slug": "cool-to-warm-spectrum"
+                    },
+                    {
+                        "name": "Blush light purple",
+                        "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
+                        "slug": "blush-light-purple"
+                    },
+                    {
+                        "name": "Blush bordeaux",
+                        "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
+                        "slug": "blush-bordeaux"
+                    },
+                    {
+                        "name": "Luminous dusk",
+                        "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
+                        "slug": "luminous-dusk"
+                    },
+                    {
+                        "name": "Pale ocean",
+                        "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
+                        "slug": "pale-ocean"
+                    },
+                    {
+                        "name": "Electric grass",
+                        "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
+                        "slug": "electric-grass"
+                    },
+                    {
+                        "name": "Midnight",
+                        "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
+                        "slug": "midnight"
+                    }
+                ]
+            },
             "duotone": [
                 {
                     "name": "Dark grayscale",
@@ -377,7 +464,63 @@
             "customFontStyle": true,
             "customFontWeight": true,
             "customTextTransforms": true,
-            "customTextDecorations": true
+            "customTextDecorations": true,
+            "customLetterSpacing": true,
+            "fontSizes": {
+                "core": [
+                    {
+                        "name": "Small",
+                        "slug": "small",
+                        "size": "13px"
+                    },
+                    {
+                        "name": "Normal",
+                        "slug": "normal",
+                        "size": "16px"
+                    },
+                    {
+                        "name": "Medium",
+                        "slug": "medium",
+                        "size": "20px"
+                    },
+                    {
+                        "name": "Large",
+                        "slug": "large",
+                        "size": "36px"
+                    },
+                    {
+                        "name": "Huge",
+                        "slug": "huge",
+                        "size": "42px"
+                    }
+                ],
+                "theme": [
+                    {
+                        "name": "Small",
+                        "shortName": "S",
+                        "size": "18px",
+                        "slug": "small"
+                    },
+                    {
+                        "name": "Regular",
+                        "shortName": "M",
+                        "size": "21px",
+                        "slug": "normal"
+                    },
+                    {
+                        "name": "Large",
+                        "shortName": "L",
+                        "size": "26.25px",
+                        "slug": "large"
+                    },
+                    {
+                        "name": "Larger",
+                        "shortName": "XL",
+                        "size": "32px",
+                        "slug": "larger"
+                    }
+                ]
+            }
         },
         "spacing": {
             "customMargin": false
@@ -400,74 +543,62 @@
         {
             "name": "Vivid cyan blue to vivid purple",
             "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
-            "slug": "vivid-cyan-blue-to-vivid-purple",
-            "origin": "core"
+            "slug": "vivid-cyan-blue-to-vivid-purple"
         },
         {
             "name": "Light green cyan to vivid green cyan",
             "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
-            "slug": "light-green-cyan-to-vivid-green-cyan",
-            "origin": "core"
+            "slug": "light-green-cyan-to-vivid-green-cyan"
         },
         {
             "name": "Luminous vivid amber to luminous vivid orange",
             "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
-            "slug": "luminous-vivid-amber-to-luminous-vivid-orange",
-            "origin": "core"
+            "slug": "luminous-vivid-amber-to-luminous-vivid-orange"
         },
         {
             "name": "Luminous vivid orange to vivid red",
             "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
-            "slug": "luminous-vivid-orange-to-vivid-red",
-            "origin": "core"
+            "slug": "luminous-vivid-orange-to-vivid-red"
         },
         {
             "name": "Very light gray to cyan bluish gray",
             "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
-            "slug": "very-light-gray-to-cyan-bluish-gray",
-            "origin": "core"
+            "slug": "very-light-gray-to-cyan-bluish-gray"
         },
         {
             "name": "Cool to warm spectrum",
             "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
-            "slug": "cool-to-warm-spectrum",
-            "origin": "core"
+            "slug": "cool-to-warm-spectrum"
         },
         {
             "name": "Blush light purple",
             "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
-            "slug": "blush-light-purple",
-            "origin": "core"
+            "slug": "blush-light-purple"
         },
         {
             "name": "Blush bordeaux",
             "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
-            "slug": "blush-bordeaux",
-            "origin": "core"
+            "slug": "blush-bordeaux"
         },
         {
             "name": "Luminous dusk",
             "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
-            "slug": "luminous-dusk",
-            "origin": "core"
+            "slug": "luminous-dusk"
         },
         {
             "name": "Pale ocean",
             "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
-            "slug": "pale-ocean",
-            "origin": "core"
+            "slug": "pale-ocean"
         },
         {
             "name": "Electric grass",
             "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
-            "slug": "electric-grass",
-            "origin": "core"
+            "slug": "electric-grass"
         },
         {
             "name": "Midnight",
             "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
-            "slug": "midnight",
-            "origin": "core"
+            "slug": "midnight"
         }
     ]
 }

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
@@ -8,7 +8,6 @@
         "png": "image/png",
         "bmp": "image/bmp",
         "tiff|tif": "image/tiff",
-        "webp": "image/webp",
         "ico": "image/x-icon",
         "heic": "image/heic",
         "asf|asx": "video/x-ms-asf",
@@ -133,6 +132,12 @@
             "icon": null
         }
     ],
+    "disableCustomColors": true,
+    "disableCustomFontSizes": true,
+    "disableCustomGradients": true,
+    "enableCustomLineHeight": false,
+    "enableCustomSpacing": false,
+    "enableCustomUnits": false,
     "isRTL": false,
     "imageDefaultSize": "large",
     "imageDimensions": {
@@ -171,121 +176,134 @@
             "name": "Full Size"
         }
     ],
-    "maxUploadFileSize": 2097152,
-    "styles": [],
-    "supportsTemplateMode": true,
-    "supportsLayout": false,
-    "widgetTypesToHideFromLegacyWidgetBlock": [
-        "pages",
-        "calendar",
-        "archives",
-        "media_audio",
-        "media_image",
-        "media_gallery",
-        "media_video",
-        "meta",
-        "search",
-        "text",
-        "categories",
-        "recent-posts",
-        "recent-comments",
-        "rss",
-        "tag_cloud",
-        "nav_menu",
-        "custom_html",
-        "block"
+    "maxUploadFileSize": 536870912,
+    "colors": [
+        {
+            "name": "Black",
+            "slug": "black",
+            "color": "#000000",
+            "origin": "core"
+        },
+        {
+            "name": "Cyan bluish gray",
+            "slug": "cyan-bluish-gray",
+            "color": "#abb8c3",
+            "origin": "core"
+        },
+        {
+            "name": "White",
+            "slug": "white",
+            "color": "#ffffff",
+            "origin": "core"
+        },
+        {
+            "name": "Pale pink",
+            "slug": "pale-pink",
+            "color": "#f78da7",
+            "origin": "core"
+        },
+        {
+            "name": "Vivid red",
+            "slug": "vivid-red",
+            "color": "#cf2e2e",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous vivid orange",
+            "slug": "luminous-vivid-orange",
+            "color": "#ff6900",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous vivid amber",
+            "slug": "luminous-vivid-amber",
+            "color": "#fcb900",
+            "origin": "core"
+        },
+        {
+            "name": "Light green cyan",
+            "slug": "light-green-cyan",
+            "color": "#7bdcb5",
+            "origin": "core"
+        },
+        {
+            "name": "Vivid green cyan",
+            "slug": "vivid-green-cyan",
+            "color": "#00d084",
+            "origin": "core"
+        },
+        {
+            "name": "Pale cyan blue",
+            "slug": "pale-cyan-blue",
+            "color": "#8ed1fc",
+            "origin": "core"
+        },
+        {
+            "name": "Vivid cyan blue",
+            "slug": "vivid-cyan-blue",
+            "color": "#0693e3",
+            "origin": "core"
+        },
+        {
+            "name": "Vivid purple",
+            "slug": "vivid-purple",
+            "color": "#9b51e0",
+            "origin": "core"
+        },
+        {
+            "name": "Accent Color",
+            "slug": "accent",
+            "color": "#cd2653"
+        },
+        {
+            "name": "Primary",
+            "slug": "primary",
+            "color": "#000000"
+        },
+        {
+            "name": "Secondary",
+            "slug": "secondary",
+            "color": "#6d6d6d"
+        },
+        {
+            "name": "Subtle Background",
+            "slug": "subtle-background",
+            "color": "#dcd7ca"
+        },
+        {
+            "name": "Background Color",
+            "slug": "background",
+            "color": "#f5efe0"
+        }
+    ],
+    "fontSizes": [
+        {
+            "name": "Small",
+            "shortName": "S",
+            "size": "18px",
+            "slug": "small"
+        },
+        {
+            "name": "Regular",
+            "shortName": "M",
+            "size": "21px",
+            "slug": "normal"
+        },
+        {
+            "name": "Large",
+            "shortName": "L",
+            "size": "26.25px",
+            "slug": "large"
+        },
+        {
+            "name": "Larger",
+            "shortName": "XL",
+            "size": "32px",
+            "slug": "larger"
+        }
     ],
     "__experimentalFeatures": {
         "color": {
-            "palette": [
-                {
-                    "name": "Accent Color",
-                    "slug": "accent",
-                    "color": "#cd2653"
-                },
-                {
-                    "name": "Primary",
-                    "slug": "primary",
-                    "color": "#000000"
-                },
-                {
-                    "name": "Secondary",
-                    "slug": "secondary",
-                    "color": "#6d6d6d"
-                },
-                {
-                    "name": "Subtle Background",
-                    "slug": "subtle-background",
-                    "color": "#dcd7ca"
-                },
-                {
-                    "name": "Background Color",
-                    "slug": "background",
-                    "color": "#f5efe0"
-                }
-            ],
-            "gradients": [
-                {
-                    "name": "Vivid cyan blue to vivid purple",
-                    "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
-                    "slug": "vivid-cyan-blue-to-vivid-purple"
-                },
-                {
-                    "name": "Light green cyan to vivid green cyan",
-                    "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
-                    "slug": "light-green-cyan-to-vivid-green-cyan"
-                },
-                {
-                    "name": "Luminous vivid amber to luminous vivid orange",
-                    "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
-                    "slug": "luminous-vivid-amber-to-luminous-vivid-orange"
-                },
-                {
-                    "name": "Luminous vivid orange to vivid red",
-                    "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
-                    "slug": "luminous-vivid-orange-to-vivid-red"
-                },
-                {
-                    "name": "Very light gray to cyan bluish gray",
-                    "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
-                    "slug": "very-light-gray-to-cyan-bluish-gray"
-                },
-                {
-                    "name": "Cool to warm spectrum",
-                    "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
-                    "slug": "cool-to-warm-spectrum"
-                },
-                {
-                    "name": "Blush light purple",
-                    "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
-                    "slug": "blush-light-purple"
-                },
-                {
-                    "name": "Blush bordeaux",
-                    "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
-                    "slug": "blush-bordeaux"
-                },
-                {
-                    "name": "Luminous dusk",
-                    "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
-                    "slug": "luminous-dusk"
-                },
-                {
-                    "name": "Pale ocean",
-                    "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
-                    "slug": "pale-ocean"
-                },
-                {
-                    "name": "Electric grass",
-                    "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
-                    "slug": "electric-grass"
-                },
-                {
-                    "name": "Midnight",
-                    "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
-                    "slug": "midnight"
-                }
-            ],
             "duotone": [
                 {
                     "name": "Dark grayscale",
@@ -352,49 +370,17 @@
                     "slug": "blue-orange"
                 }
             ],
-            "custom": true,
-            "link": false,
-            "customGradient": true
+            "link": false
         },
         "typography": {
             "dropCap": true,
-            "customFontSize": true,
-            "customLineHeight": false,
             "customFontStyle": true,
             "customFontWeight": true,
             "customTextTransforms": true,
-            "customTextDecorations": true,
-            "fontSizes": [
-                {
-                    "name": "Small",
-                    "shortName": "S",
-                    "size": "18px",
-                    "slug": "small"
-                },
-                {
-                    "name": "Regular",
-                    "shortName": "M",
-                    "size": "21px",
-                    "slug": "normal"
-                },
-                {
-                    "name": "Large",
-                    "shortName": "L",
-                    "size": "26.25px",
-                    "slug": "large"
-                },
-                {
-                    "name": "Larger",
-                    "shortName": "XL",
-                    "size": "32px",
-                    "slug": "larger"
-                }
-            ]
+            "customTextDecorations": true
         },
         "spacing": {
-            "customMargin": false,
-            "customPadding": false,
-            "units": false
+            "customMargin": false
         },
         "border": {
             "customColor": false,
@@ -409,5 +395,79 @@
                 }
             }
         }
-    }
+    },
+    "gradients": [
+        {
+            "name": "Vivid cyan blue to vivid purple",
+            "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
+            "slug": "vivid-cyan-blue-to-vivid-purple",
+            "origin": "core"
+        },
+        {
+            "name": "Light green cyan to vivid green cyan",
+            "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
+            "slug": "light-green-cyan-to-vivid-green-cyan",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous vivid amber to luminous vivid orange",
+            "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
+            "slug": "luminous-vivid-amber-to-luminous-vivid-orange",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous vivid orange to vivid red",
+            "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
+            "slug": "luminous-vivid-orange-to-vivid-red",
+            "origin": "core"
+        },
+        {
+            "name": "Very light gray to cyan bluish gray",
+            "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
+            "slug": "very-light-gray-to-cyan-bluish-gray",
+            "origin": "core"
+        },
+        {
+            "name": "Cool to warm spectrum",
+            "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
+            "slug": "cool-to-warm-spectrum",
+            "origin": "core"
+        },
+        {
+            "name": "Blush light purple",
+            "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
+            "slug": "blush-light-purple",
+            "origin": "core"
+        },
+        {
+            "name": "Blush bordeaux",
+            "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
+            "slug": "blush-bordeaux",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous dusk",
+            "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
+            "slug": "luminous-dusk",
+            "origin": "core"
+        },
+        {
+            "name": "Pale ocean",
+            "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
+            "slug": "pale-ocean",
+            "origin": "core"
+        },
+        {
+            "name": "Electric grass",
+            "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
+            "slug": "electric-grass",
+            "origin": "core"
+        },
+        {
+            "name": "Midnight",
+            "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
+            "slug": "midnight",
+            "origin": "core"
+        }
+    ]
 }

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
@@ -1,741 +1,585 @@
 {
-  "imageDefaultSize": "large",
-  "__unstableEnableFullSiteEditingBlocks": true,
-  "styles": [
-
-  ],
-  "supportsTemplateMode": true,
-  "supportsLayout": true,
-  "widgetTypesToHideFromLegacyWidgetBlock": [
-    "pages",
-    "calendar",
-    "archives",
-    "media_audio",
-    "media_image",
-    "media_gallery",
-    "media_video",
-    "meta",
-    "search",
-    "text",
-    "categories",
-    "recent-posts",
-    "recent-comments",
-    "rss",
-    "tag_cloud",
-    "nav_menu",
-    "custom_html",
-    "block"
-  ],
-  "__experimentalFeatures": {
-    "defaults": {
-      "color": {
-        "palette": [
-          {
-            "slug": "black",
-            "color": "#000000",
-            "name": "Black"
-          },
-          {
-            "slug": "dark-gray",
-            "color": "#28303D",
-            "name": "Dark Gray"
-          },
-          {
-            "slug": "gray",
-            "color": "#39414D",
-            "name": "Gray"
-          },
-          {
-            "slug": "green",
-            "color": "#D1E4DD",
-            "name": "Green"
-          },
-          {
-            "slug": "blue",
-            "color": "#D1DFE4",
-            "name": "Blue"
-          },
-          {
-            "slug": "purple",
-            "color": "#D1D1E4",
-            "name": "Purple"
-          },
-          {
-            "slug": "red",
-            "color": "#E4D1D1",
-            "name": "Red"
-          },
-          {
-            "slug": "orange",
-            "color": "#E4DAD1",
-            "name": "Orange"
-          },
-          {
-            "slug": "yellow",
-            "color": "#EEEADD",
-            "name": "Yellow"
-          },
-          {
-            "slug": "white",
-            "color": "#FFFFFF",
-            "name": "White"
-          }
-        ],
-        "gradients": [
-          {
-            "slug": "purple-to-yellow",
-            "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
-            "name": "Purple to Yellow"
-          },
-          {
-            "slug": "yellow-to-purple",
-            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
-            "name": "Yellow to Purple"
-          },
-          {
-            "slug": "green-to-yellow",
-            "gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
-            "name": "Green to Yellow"
-          },
-          {
-            "slug": "yellow-to-green",
-            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
-            "name": "Yellow to Green"
-          },
-          {
-            "slug": "red-to-yellow",
-            "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
-            "name": "Red to Yellow"
-          },
-          {
-            "slug": "yellow-to-red",
-            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
-            "name": "Yellow to Red"
-          },
-          {
-            "slug": "purple-to-red",
-            "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
-            "name": "Purple to Red"
-          },
-          {
-            "slug": "red-to-purple",
-            "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
-            "name": "Red to Purple"
-          }
-        ],
-        "custom": true,
-        "link": true,
-        "customGradient": true
-      },
-      "typography": {
-        "dropCap": true,
-        "customFontSize": true,
-        "customLineHeight": true,
-        "customFontStyle": true,
-        "customFontWeight": true,
-        "customTextTransforms": true,
-        "customTextDecorations": true,
-        "fontSizes": [
-          {
-            "slug": "extra-small",
-            "size": "16px",
-            "name": "Extra small"
-          },
-          {
-            "slug": "small",
-            "size": "18px",
-            "name": "Small"
-          },
-          {
-            "slug": "normal",
-            "size": "20px",
-            "name": "Normal"
-          },
-          {
-            "slug": "large",
-            "size": "24px",
-            "name": "Large"
-          },
-          {
-            "slug": "extra-large",
-            "size": "40px",
-            "name": "Extra large"
-          },
-          {
-            "slug": "huge",
-            "size": "96px",
-            "name": "Huge"
-          },
-          {
-            "slug": "gigantic",
-            "size": "144px",
-            "name": "Gigantic"
-          }
-        ],
-        "fontFamilies": [
-          {
-            "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
-            "slug": "system-font",
-            "name": "System Font"
-          },
-          {
-            "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
-            "slug": "helvetica-arial"
-          },
-          {
-            "fontFamily": "Geneva, Tahoma, Verdana, sans-serif",
-            "slug": "geneva-verdana"
-          },
-          {
-            "fontFamily": "Cambria, Georgia, serif",
-            "slug": "cambria-georgia"
-          },
-          {
-            "fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
-            "slug": "hoefler-times-new-roman"
-          }
-        ]
-      },
-      "spacing": {
-        "customPadding": true,
-        "units": [
-          "px",
-          "em",
-          "rem",
-          "vh",
-          "vw"
-        ]
-      },
-      "border": {
-        "customColor": false,
-        "customRadius": false,
-        "customStyle": false,
-        "customWidth": false
-      },
-      "layout": {
-        "contentSize": "610px",
-        "wideSize": "1240px"
-      },
-      "custom": {
-        "font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-        "line-height": {
-          "body": 1.7,
-          "heading": 1.3,
-          "page-title": 1.1
-        },
-        "spacing": {
-          "unit": "20px",
-          "horizontal": "25px",
-          "vertical": "30px"
-        },
-        "font-weight": {
-          "light": "300",
-          "normal": "normal"
-        }
-      }
+    "__unstableEnableFullSiteEditingBlocks": true,
+    "alignWide": false,
+    "allowedBlockTypes": true,
+    "allowedMimeTypes": {
+        "jpg|jpeg|jpe": "image/jpeg",
+        "gif": "image/gif",
+        "png": "image/png",
+        "bmp": "image/bmp",
+        "tiff|tif": "image/tiff",
+        "webp": "image/webp",
+        "ico": "image/x-icon",
+        "heic": "image/heic",
+        "asf|asx": "video/x-ms-asf",
+        "wmv": "video/x-ms-wmv",
+        "wmx": "video/x-ms-wmx",
+        "wm": "video/x-ms-wm",
+        "avi": "video/avi",
+        "divx": "video/divx",
+        "flv": "video/x-flv",
+        "mov|qt": "video/quicktime",
+        "mpeg|mpg|mpe": "video/mpeg",
+        "mp4|m4v": "video/mp4",
+        "ogv": "video/ogg",
+        "webm": "video/webm",
+        "mkv": "video/x-matroska",
+        "3gp|3gpp": "video/3gpp",
+        "3g2|3gp2": "video/3gpp2",
+        "txt|asc|c|cc|h|srt": "text/plain",
+        "csv": "text/csv",
+        "tsv": "text/tab-separated-values",
+        "ics": "text/calendar",
+        "rtx": "text/richtext",
+        "css": "text/css",
+        "htm|html": "text/html",
+        "vtt": "text/vtt",
+        "dfxp": "application/ttaf+xml",
+        "mp3|m4a|m4b": "audio/mpeg",
+        "aac": "audio/aac",
+        "ra|ram": "audio/x-realaudio",
+        "wav": "audio/wav",
+        "ogg|oga": "audio/ogg",
+        "flac": "audio/flac",
+        "mid|midi": "audio/midi",
+        "wma": "audio/x-ms-wma",
+        "wax": "audio/x-ms-wax",
+        "mka": "audio/x-matroska",
+        "rtf": "application/rtf",
+        "js": "application/javascript",
+        "pdf": "application/pdf",
+        "class": "application/java",
+        "tar": "application/x-tar",
+        "zip": "application/zip",
+        "gz|gzip": "application/x-gzip",
+        "rar": "application/rar",
+        "7z": "application/x-7z-compressed",
+        "psd": "application/octet-stream",
+        "xcf": "application/octet-stream",
+        "doc": "application/msword",
+        "pot|pps|ppt": "application/vnd.ms-powerpoint",
+        "wri": "application/vnd.ms-write",
+        "xla|xls|xlt|xlw": "application/vnd.ms-excel",
+        "mdb": "application/vnd.ms-access",
+        "mpp": "application/vnd.ms-project",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "docm": "application/vnd.ms-word.document.macroEnabled.12",
+        "dotx": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+        "dotm": "application/vnd.ms-word.template.macroEnabled.12",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
+        "xlsb": "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+        "xltx": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+        "xltm": "application/vnd.ms-excel.template.macroEnabled.12",
+        "xlam": "application/vnd.ms-excel.addin.macroEnabled.12",
+        "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "pptm": "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+        "ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+        "ppsm": "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
+        "potx": "application/vnd.openxmlformats-officedocument.presentationml.template",
+        "potm": "application/vnd.ms-powerpoint.template.macroEnabled.12",
+        "ppam": "application/vnd.ms-powerpoint.addin.macroEnabled.12",
+        "sldx": "application/vnd.openxmlformats-officedocument.presentationml.slide",
+        "sldm": "application/vnd.ms-powerpoint.slide.macroEnabled.12",
+        "onetoc|onetoc2|onetmp|onepkg": "application/onenote",
+        "oxps": "application/oxps",
+        "xps": "application/vnd.ms-xpsdocument",
+        "odt": "application/vnd.oasis.opendocument.text",
+        "odp": "application/vnd.oasis.opendocument.presentation",
+        "ods": "application/vnd.oasis.opendocument.spreadsheet",
+        "odg": "application/vnd.oasis.opendocument.graphics",
+        "odc": "application/vnd.oasis.opendocument.chart",
+        "odb": "application/vnd.oasis.opendocument.database",
+        "odf": "application/vnd.oasis.opendocument.formula",
+        "wp|wpd": "application/wordperfect",
+        "key": "application/vnd.apple.keynote",
+        "numbers": "application/vnd.apple.numbers",
+        "pages": "application/vnd.apple.pages"
     },
-    "core/button": {
-      "border": {
-        "customRadius": true
-      }
-    }
-  },
-  "__experimentalGlobalStylesUserEntityId": 5,
-  "__experimentalGlobalStylesBaseStyles": {
-    "settings": {
-      "defaults": {
+    "blockCategories": [
+        {
+            "slug": "text",
+            "title": "Text",
+            "icon": null
+        },
+        {
+            "slug": "media",
+            "title": "Media",
+            "icon": null
+        },
+        {
+            "slug": "design",
+            "title": "Design",
+            "icon": null
+        },
+        {
+            "slug": "widgets",
+            "title": "Widgets",
+            "icon": null
+        },
+        {
+            "slug": "theme",
+            "title": "Theme",
+            "icon": null
+        },
+        {
+            "slug": "embed",
+            "title": "Embeds",
+            "icon": null
+        },
+        {
+            "slug": "reusable",
+            "title": "Reusable Blocks",
+            "icon": null
+        }
+    ],
+    "isRTL": false,
+    "imageDefaultSize": "large",
+    "imageDimensions": {
+        "thumbnail": {
+            "width": 150,
+            "height": 150,
+            "crop": true
+        },
+        "medium": {
+            "width": 300,
+            "height": 300,
+            "crop": false
+        },
+        "large": {
+            "width": 1024,
+            "height": 1024,
+            "crop": false
+        }
+    },
+    "imageEditing": true,
+    "imageSizes": [
+        {
+            "slug": "thumbnail",
+            "name": "Thumbnail"
+        },
+        {
+            "slug": "medium",
+            "name": "Medium"
+        },
+        {
+            "slug": "large",
+            "name": "Large"
+        },
+        {
+            "slug": "full",
+            "name": "Full Size"
+        }
+    ],
+    "maxUploadFileSize": 2097152,
+    "defaultTemplatePartAreas": [
+        {
+            "area": "uncategorized",
+            "label": "General",
+            "description": "General templates often perform a specific role like displaying post content, and are not tied to any particular area.",
+            "icon": "layout",
+            "area_tag": "div"
+        },
+        {
+            "area": "header",
+            "label": "Header",
+            "description": "The Header template defines a page area that typically contains a title, logo, and main navigation.",
+            "icon": "header",
+            "area_tag": "header"
+        },
+        {
+            "area": "footer",
+            "label": "Footer",
+            "description": "The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.",
+            "icon": "footer",
+            "area_tag": "footer"
+        }
+    ],
+    "styles": [],
+    "supportsTemplateMode": true,
+    "supportsLayout": true,
+    "widgetTypesToHideFromLegacyWidgetBlock": [
+        "pages",
+        "calendar",
+        "archives",
+        "media_audio",
+        "media_image",
+        "media_gallery",
+        "media_video",
+        "meta",
+        "search",
+        "text",
+        "categories",
+        "recent-posts",
+        "recent-comments",
+        "rss",
+        "tag_cloud",
+        "nav_menu",
+        "custom_html",
+        "block"
+    ],
+    "__experimentalStyles": {
         "color": {
-          "palette": [
-            {
-              "slug": "black",
-              "color": "#000000",
-              "name": "Black"
-            },
-            {
-              "slug": "dark-gray",
-              "color": "#28303D",
-              "name": "Dark Gray"
-            },
-            {
-              "slug": "gray",
-              "color": "#39414D",
-              "name": "Gray"
-            },
-            {
-              "slug": "green",
-              "color": "#D1E4DD",
-              "name": "Green"
-            },
-            {
-              "slug": "blue",
-              "color": "#D1DFE4",
-              "name": "Blue"
-            },
-            {
-              "slug": "purple",
-              "color": "#D1D1E4",
-              "name": "Purple"
-            },
-            {
-              "slug": "red",
-              "color": "#E4D1D1",
-              "name": "Red"
-            },
-            {
-              "slug": "orange",
-              "color": "#E4DAD1",
-              "name": "Orange"
-            },
-            {
-              "slug": "yellow",
-              "color": "#EEEADD",
-              "name": "Yellow"
-            },
-            {
-              "slug": "white",
-              "color": "#FFFFFF",
-              "name": "White"
-            }
-          ],
-          "gradients": [
-            {
-              "slug": "purple-to-yellow",
-              "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
-              "name": "Purple to Yellow"
-            },
-            {
-              "slug": "yellow-to-purple",
-              "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
-              "name": "Yellow to Purple"
-            },
-            {
-              "slug": "green-to-yellow",
-              "gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
-              "name": "Green to Yellow"
-            },
-            {
-              "slug": "yellow-to-green",
-              "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
-              "name": "Yellow to Green"
-            },
-            {
-              "slug": "red-to-yellow",
-              "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
-              "name": "Red to Yellow"
-            },
-            {
-              "slug": "yellow-to-red",
-              "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
-              "name": "Yellow to Red"
-            },
-            {
-              "slug": "purple-to-red",
-              "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
-              "name": "Purple to Red"
-            },
-            {
-              "slug": "red-to-purple",
-              "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
-              "name": "Red to Purple"
-            }
-          ],
-          "custom": true,
-          "link": true,
-          "customGradient": true
+            "background": "var(--wp--preset--color--green)",
+            "text": "var(--wp--preset--color--dark-gray)"
         },
         "typography": {
-          "dropCap": true,
-          "customFontSize": true,
-          "customLineHeight": true,
-          "customFontStyle": true,
-          "customFontWeight": true,
-          "customTextTransforms": true,
-          "customTextDecorations": true,
-          "fontSizes": [
-            {
-              "slug": "extra-small",
-              "size": "16px",
-              "name": "Extra small"
+            "fontSize": "var(--wp--preset--font-size--normal)",
+            "lineHeight": "var(--wp--custom--line-height--body)"
+        },
+        "elements": {
+            "link": {
+                "color": {
+                    "text": "var(--wp--preset--color--dark-gray)"
+                }
             },
-            {
-              "slug": "small",
-              "size": "18px",
-              "name": "Small"
+            "h1": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--gigantic)",
+                    "lineHeight": "var(--wp--custom--line-height--page-title)",
+                    "fontWeight": "var(--wp--custom--font-weight--normal)"
+                }
             },
-            {
-              "slug": "normal",
-              "size": "20px",
-              "name": "Normal"
+            "h2": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--extra-large)",
+                    "lineHeight": "var(--wp--custom--line-height--heading)",
+                    "fontWeight": "var(--wp--custom--font-weight--normal)"
+                }
             },
-            {
-              "slug": "large",
-              "size": "24px",
-              "name": "Large"
+            "h3": {
+                "typography": {
+                    "fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
+                    "lineHeight": "var(--wp--custom--line-height--heading)",
+                    "fontWeight": "var(--wp--custom--font-weight--normal)"
+                }
             },
-            {
-              "slug": "extra-large",
-              "size": "40px",
-              "name": "Extra large"
+            "h4": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--large)",
+                    "lineHeight": "var(--wp--custom--line-height--heading)"
+                }
             },
-            {
-              "slug": "huge",
-              "size": "96px",
-              "name": "Huge"
+            "h5": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--small)",
+                    "lineHeight": "var(--wp--custom--line-height--heading)"
+                }
             },
-            {
-              "slug": "gigantic",
-              "size": "144px",
-              "name": "Gigantic"
+            "h6": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--extra-small)",
+                    "lineHeight": "var(--wp--custom--line-height--heading)"
+                }
             }
-          ],
-          "fontFamilies": [
-            {
-              "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
-              "slug": "system-font",
-              "name": "System Font"
+        },
+        "blocks": {
+            "core/site-tagline": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--small)",
+                    "lineHeight": 1.4
+                }
             },
-            {
-              "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
-              "slug": "helvetica-arial"
+            "core/post-author": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--extra-small)",
+                    "lineHeight": "var(--wp--custom--line-height--body)"
+                }
             },
-            {
-              "fontFamily": "Geneva, Tahoma, Verdana, sans-serif",
-              "slug": "geneva-verdana"
+            "core/post-date": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--extra-small)",
+                    "lineHeight": "var(--wp--custom--line-height--body)"
+                }
             },
-            {
-              "fontFamily": "Cambria, Georgia, serif",
-              "slug": "cambria-georgia"
-            },
-            {
-              "fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
-              "slug": "hoefler-times-new-roman"
+            "core/site-title": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--large)",
+                    "fontWeight": "var(--wp--custom--font-weight--normal)",
+                    "textTransform": "uppercase"
+                }
             }
-          ]
+        }
+    },
+    "__experimentalFeatures": {
+        "color": {
+            "palette": [
+                {
+                    "slug": "black",
+                    "color": "#000000",
+                    "name": "Black"
+                },
+                {
+                    "slug": "dark-gray",
+                    "color": "#28303D",
+                    "name": "Dark Gray"
+                },
+                {
+                    "slug": "gray",
+                    "color": "#39414D",
+                    "name": "Gray"
+                },
+                {
+                    "slug": "green",
+                    "color": "#D1E4DD",
+                    "name": "Green"
+                },
+                {
+                    "slug": "blue",
+                    "color": "#D1DFE4",
+                    "name": "Blue"
+                },
+                {
+                    "slug": "purple",
+                    "color": "#D1D1E4",
+                    "name": "Purple"
+                },
+                {
+                    "slug": "red",
+                    "color": "#E4D1D1",
+                    "name": "Red"
+                },
+                {
+                    "slug": "orange",
+                    "color": "#E4DAD1",
+                    "name": "Orange"
+                },
+                {
+                    "slug": "yellow",
+                    "color": "#EEEADD",
+                    "name": "Yellow"
+                },
+                {
+                    "slug": "white",
+                    "color": "#FFFFFF",
+                    "name": "White"
+                }
+            ],
+            "gradients": [
+                {
+                    "slug": "purple-to-yellow",
+                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
+                    "name": "Purple to Yellow"
+                },
+                {
+                    "slug": "yellow-to-purple",
+                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
+                    "name": "Yellow to Purple"
+                },
+                {
+                    "slug": "green-to-yellow",
+                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
+                    "name": "Green to Yellow"
+                },
+                {
+                    "slug": "yellow-to-green",
+                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
+                    "name": "Yellow to Green"
+                },
+                {
+                    "slug": "red-to-yellow",
+                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
+                    "name": "Red to Yellow"
+                },
+                {
+                    "slug": "yellow-to-red",
+                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
+                    "name": "Yellow to Red"
+                },
+                {
+                    "slug": "purple-to-red",
+                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
+                    "name": "Purple to Red"
+                },
+                {
+                    "slug": "red-to-purple",
+                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
+                    "name": "Red to Purple"
+                }
+            ],
+            "duotone": [
+                {
+                    "name": "Dark grayscale",
+                    "colors": [
+                        "#000000",
+                        "#7f7f7f"
+                    ],
+                    "slug": "dark-grayscale"
+                },
+                {
+                    "name": "Grayscale",
+                    "colors": [
+                        "#000000",
+                        "#ffffff"
+                    ],
+                    "slug": "grayscale"
+                },
+                {
+                    "name": "Purple and yellow",
+                    "colors": [
+                        "#8c00b7",
+                        "#fcff41"
+                    ],
+                    "slug": "purple-yellow"
+                },
+                {
+                    "name": "Blue and red",
+                    "colors": [
+                        "#000097",
+                        "#ff4747"
+                    ],
+                    "slug": "blue-red"
+                },
+                {
+                    "name": "Midnight",
+                    "colors": [
+                        "#000000",
+                        "#00a5ff"
+                    ],
+                    "slug": "midnight"
+                },
+                {
+                    "name": "Magenta and yellow",
+                    "colors": [
+                        "#c7005a",
+                        "#fff278"
+                    ],
+                    "slug": "magenta-yellow"
+                },
+                {
+                    "name": "Purple and green",
+                    "colors": [
+                        "#a60072",
+                        "#67ff66"
+                    ],
+                    "slug": "purple-green"
+                },
+                {
+                    "name": "Blue and orange",
+                    "colors": [
+                        "#1900d8",
+                        "#ffa96b"
+                    ],
+                    "slug": "blue-orange"
+                }
+            ],
+            "custom": true,
+            "link": true,
+            "customGradient": true
+        },
+        "typography": {
+            "dropCap": true,
+            "customFontSize": true,
+            "customLineHeight": true,
+            "customFontStyle": true,
+            "customFontWeight": true,
+            "customTextTransforms": true,
+            "customTextDecorations": true,
+            "fontSizes": [
+                {
+                    "slug": "extra-small",
+                    "size": "16px",
+                    "name": "Extra small"
+                },
+                {
+                    "slug": "small",
+                    "size": "18px",
+                    "name": "Small"
+                },
+                {
+                    "slug": "normal",
+                    "size": "20px",
+                    "name": "Normal"
+                },
+                {
+                    "slug": "large",
+                    "size": "24px",
+                    "name": "Large"
+                },
+                {
+                    "slug": "extra-large",
+                    "size": "40px",
+                    "name": "Extra large"
+                },
+                {
+                    "slug": "huge",
+                    "size": "96px",
+                    "name": "Huge"
+                },
+                {
+                    "slug": "gigantic",
+                    "size": "144px",
+                    "name": "Gigantic"
+                }
+            ],
+            "fontFamilies": [
+                {
+                    "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
+                    "slug": "system-font",
+                    "name": "System Font"
+                },
+                {
+                    "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
+                    "slug": "helvetica-arial"
+                },
+                {
+                    "fontFamily": "Geneva, Tahoma, Verdana, sans-serif",
+                    "slug": "geneva-verdana"
+                },
+                {
+                    "fontFamily": "Cambria, Georgia, serif",
+                    "slug": "cambria-georgia"
+                },
+                {
+                    "fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
+                    "slug": "hoefler-times-new-roman"
+                }
+            ]
         },
         "spacing": {
-          "customPadding": true,
-          "units": [
-            "px",
-            "em",
-            "rem",
-            "vh",
-            "vw"
-          ]
+            "customMargin": false,
+            "customPadding": true,
+            "units": [
+                "px",
+                "em",
+                "rem",
+                "vh",
+                "vw"
+            ]
         },
         "border": {
-          "customColor": false,
-          "customRadius": false,
-          "customStyle": false,
-          "customWidth": false
+            "customColor": false,
+            "customRadius": false,
+            "customStyle": false,
+            "customWidth": false
+        },
+        "blocks": {
+            "core/button": {
+                "border": {
+                    "customRadius": true
+                }
+            }
         },
         "layout": {
-          "contentSize": "610px",
-          "wideSize": "1240px"
+            "contentSize": "610px",
+            "wideSize": "1240px"
         },
         "custom": {
-          "font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
-          "line-height": {
-            "body": 1.7,
-            "heading": 1.3,
-            "page-title": 1.1
-          },
-          "spacing": {
-            "unit": "20px",
-            "horizontal": "25px",
-            "vertical": "30px"
-          },
-          "font-weight": {
-            "light": "300",
-            "normal": "normal"
-          }
+            "font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+            "line-height": {
+                "body": 1.7,
+                "heading": 1.3,
+                "page-title": 1.1
+            },
+            "spacing": {
+                "unit": "20px",
+                "horizontal": "25px",
+                "vertical": "30px"
+            },
+            "font-weight": {
+                "light": "300",
+                "normal": "normal"
+            }
         }
-      },
-      "core/button": {
-        "border": {
-          "customRadius": true
-        }
-      }
-    },
-    "templateParts": [
-      {
-        "name": "header",
-        "area": "header"
-      },
-      {
-        "name": "footer",
-        "area": "footer"
-      }
-    ],
-    "styles": {
-      "root": {
-        "color": {
-          "background": "var(--wp--preset--color--green)",
-          "text": "var(--wp--preset--color--dark-gray)",
-          "link": "var(--wp--preset--color--dark-gray)"
-        },
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--normal)",
-          "lineHeight": "var(--wp--custom--line-height--body)"
-        }
-      },
-      "core/heading/h1": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--gigantic)",
-          "lineHeight": "var(--wp--custom--line-height--page-title)",
-          "fontWeight": "var(--wp--custom--font-weight--normal)"
-        }
-      },
-      "core/heading/h2": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--extra-large)",
-          "lineHeight": "var(--wp--custom--line-height--heading)",
-          "fontWeight": "var(--wp--custom--font-weight--normal)"
-        }
-      },
-      "core/heading/h3": {
-        "typography": {
-          "fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
-          "lineHeight": "var(--wp--custom--line-height--heading)",
-          "fontWeight": "var(--wp--custom--font-weight--normal)"
-        }
-      },
-      "core/heading/h4": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--large)",
-          "lineHeight": "var(--wp--custom--line-height--heading)"
-        }
-      },
-      "core/heading/h5": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--small)",
-          "lineHeight": "var(--wp--custom--line-height--heading)"
-        }
-      },
-      "core/heading/h6": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--extra-small)",
-          "lineHeight": "var(--wp--custom--line-height--heading)"
-        }
-      },
-      "core/site-tagline": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--small)",
-          "lineHeight": 1.4
-        }
-      },
-      "core/post-author": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--extra-small)",
-          "lineHeight": "var(--wp--custom--line-height--body)"
-        }
-      },
-      "core/post-date": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--extra-small)",
-          "lineHeight": "var(--wp--custom--line-height--body)"
-        }
-      },
-      "core/post-hierarchical-terms": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--extra-small)",
-          "lineHeight": "var(--wp--custom--line-height--body)"
-        }
-      },
-      "core/post-tags": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--extra-small)",
-          "lineHeight": "var(--wp--custom--line-height--body)"
-        }
-      },
-      "core/site-title": {
-        "typography": {
-          "fontSize": "var(--wp--preset--font-size--large)",
-          "fontWeight": "var(--wp--custom--font-weight--normal)",
-          "textTransform": "uppercase"
-        }
-      }
-    },
-    "customTemplates": [
-      {
-        "name": "page-home",
-        "title": "Page without title"
-      }
-    ]
-  },
-  "alignWide": false,
-  "allowedBlockTypes": true,
-  "allowedMimeTypes": {
-    "jpg|jpeg|jpe": "image/jpeg",
-    "gif": "image/gif",
-    "png": "image/png",
-    "bmp": "image/bmp",
-    "tiff|tif": "image/tiff",
-    "ico": "image/x-icon",
-    "heic": "image/heic",
-    "asf|asx": "video/x-ms-asf",
-    "wmv": "video/x-ms-wmv",
-    "wmx": "video/x-ms-wmx",
-    "wm": "video/x-ms-wm",
-    "avi": "video/avi",
-    "divx": "video/divx",
-    "flv": "video/x-flv",
-    "mov|qt": "video/quicktime",
-    "mpeg|mpg|mpe": "video/mpeg",
-    "mp4|m4v": "video/mp4",
-    "ogv": "video/ogg",
-    "webm": "video/webm",
-    "mkv": "video/x-matroska",
-    "3gp|3gpp": "video/3gpp",
-    "3g2|3gp2": "video/3gpp2",
-    "txt|asc|c|cc|h|srt": "text/plain",
-    "csv": "text/csv",
-    "tsv": "text/tab-separated-values",
-    "ics": "text/calendar",
-    "rtx": "text/richtext",
-    "css": "text/css",
-    "htm|html": "text/html",
-    "vtt": "text/vtt",
-    "dfxp": "application/ttaf+xml",
-    "mp3|m4a|m4b": "audio/mpeg",
-    "aac": "audio/aac",
-    "ra|ram": "audio/x-realaudio",
-    "wav": "audio/wav",
-    "ogg|oga": "audio/ogg",
-    "flac": "audio/flac",
-    "mid|midi": "audio/midi",
-    "wma": "audio/x-ms-wma",
-    "wax": "audio/x-ms-wax",
-    "mka": "audio/x-matroska",
-    "rtf": "application/rtf",
-    "js": "application/javascript",
-    "pdf": "application/pdf",
-    "class": "application/java",
-    "tar": "application/x-tar",
-    "zip": "application/zip",
-    "gz|gzip": "application/x-gzip",
-    "rar": "application/rar",
-    "7z": "application/x-7z-compressed",
-    "psd": "application/octet-stream",
-    "xcf": "application/octet-stream",
-    "doc": "application/msword",
-    "pot|pps|ppt": "application/vnd.ms-powerpoint",
-    "wri": "application/vnd.ms-write",
-    "xla|xls|xlt|xlw": "application/vnd.ms-excel",
-    "mdb": "application/vnd.ms-access",
-    "mpp": "application/vnd.ms-project",
-    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-    "docm": "application/vnd.ms-word.document.macroEnabled.12",
-    "dotx": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-    "dotm": "application/vnd.ms-word.template.macroEnabled.12",
-    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    "xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
-    "xlsb": "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
-    "xltx": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
-    "xltm": "application/vnd.ms-excel.template.macroEnabled.12",
-    "xlam": "application/vnd.ms-excel.addin.macroEnabled.12",
-    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-    "pptm": "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
-    "ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
-    "ppsm": "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
-    "potx": "application/vnd.openxmlformats-officedocument.presentationml.template",
-    "potm": "application/vnd.ms-powerpoint.template.macroEnabled.12",
-    "ppam": "application/vnd.ms-powerpoint.addin.macroEnabled.12",
-    "sldx": "application/vnd.openxmlformats-officedocument.presentationml.slide",
-    "sldm": "application/vnd.ms-powerpoint.slide.macroEnabled.12",
-    "onetoc|onetoc2|onetmp|onepkg": "application/onenote",
-    "oxps": "application/oxps",
-    "xps": "application/vnd.ms-xpsdocument",
-    "odt": "application/vnd.oasis.opendocument.text",
-    "odp": "application/vnd.oasis.opendocument.presentation",
-    "ods": "application/vnd.oasis.opendocument.spreadsheet",
-    "odg": "application/vnd.oasis.opendocument.graphics",
-    "odc": "application/vnd.oasis.opendocument.chart",
-    "odb": "application/vnd.oasis.opendocument.database",
-    "odf": "application/vnd.oasis.opendocument.formula",
-    "wp|wpd": "application/wordperfect",
-    "key": "application/vnd.apple.keynote",
-    "numbers": "application/vnd.apple.numbers",
-    "pages": "application/vnd.apple.pages"
-  },
-  "blockCategories": [
-    {
-      "slug": "text",
-      "title": "Text",
-      "icon": null
-    },
-    {
-      "slug": "media",
-      "title": "Media",
-      "icon": null
-    },
-    {
-      "slug": "design",
-      "title": "Design",
-      "icon": null
-    },
-    {
-      "slug": "widgets",
-      "title": "Widgets",
-      "icon": null
-    },
-    {
-      "slug": "theme",
-      "title": "Theme",
-      "icon": null
-    },
-    {
-      "slug": "embed",
-      "title": "Embeds",
-      "icon": null
-    },
-    {
-      "slug": "reusable",
-      "title": "Reusable Blocks",
-      "icon": null
     }
-  ],
-  "disableCustomColors": false,
-  "disableCustomFontSizes": false,
-  "disableCustomGradients": false,
-  "enableCustomLineHeight": false,
-  "enableCustomSpacing": false,
-  "enableCustomUnits": true,
-  "isRTL": false,
-  "imageDimensions": {
-    "thumbnail": {
-      "width": 150,
-      "height": 150,
-      "crop": true
-    },
-    "medium": {
-      "width": 300,
-      "height": 300,
-      "crop": false
-    },
-    "large": {
-      "width": 1024,
-      "height": 1024,
-      "crop": false
-    }
-  },
-  "imageEditing": true,
-  "imageSizes": [
-    {
-      "slug": "thumbnail",
-      "name": "Thumbnail"
-    },
-    {
-      "slug": "medium",
-      "name": "Medium"
-    },
-    {
-      "slug": "large",
-      "name": "Large"
-    },
-    {
-      "slug": "full",
-      "name": "Full Size"
-    }
-  ],
-  "maxUploadFileSize": 2097152
 }

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
@@ -1,180 +1,741 @@
 {
-    "__unstableEnableFullSiteEditingBlocks": true,
-    "alignWide": false,
-    "allowedBlockTypes": true,
-    "allowedMimeTypes": {
-        "jpg|jpeg|jpe": "image/jpeg",
-        "gif": "image/gif",
-        "png": "image/png",
-        "bmp": "image/bmp",
-        "tiff|tif": "image/tiff",
-        "ico": "image/x-icon",
-        "heic": "image/heic",
-        "asf|asx": "video/x-ms-asf",
-        "wmv": "video/x-ms-wmv",
-        "wmx": "video/x-ms-wmx",
-        "wm": "video/x-ms-wm",
-        "avi": "video/avi",
-        "divx": "video/divx",
-        "flv": "video/x-flv",
-        "mov|qt": "video/quicktime",
-        "mpeg|mpg|mpe": "video/mpeg",
-        "mp4|m4v": "video/mp4",
-        "ogv": "video/ogg",
-        "webm": "video/webm",
-        "mkv": "video/x-matroska",
-        "3gp|3gpp": "video/3gpp",
-        "3g2|3gp2": "video/3gpp2",
-        "txt|asc|c|cc|h|srt": "text/plain",
-        "csv": "text/csv",
-        "tsv": "text/tab-separated-values",
-        "ics": "text/calendar",
-        "rtx": "text/richtext",
-        "css": "text/css",
-        "htm|html": "text/html",
-        "vtt": "text/vtt",
-        "dfxp": "application/ttaf+xml",
-        "mp3|m4a|m4b": "audio/mpeg",
-        "aac": "audio/aac",
-        "ra|ram": "audio/x-realaudio",
-        "wav": "audio/wav",
-        "ogg|oga": "audio/ogg",
-        "flac": "audio/flac",
-        "mid|midi": "audio/midi",
-        "wma": "audio/x-ms-wma",
-        "wax": "audio/x-ms-wax",
-        "mka": "audio/x-matroska",
-        "rtf": "application/rtf",
-        "js": "application/javascript",
-        "pdf": "application/pdf",
-        "class": "application/java",
-        "tar": "application/x-tar",
-        "zip": "application/zip",
-        "gz|gzip": "application/x-gzip",
-        "rar": "application/rar",
-        "7z": "application/x-7z-compressed",
-        "psd": "application/octet-stream",
-        "xcf": "application/octet-stream",
-        "doc": "application/msword",
-        "pot|pps|ppt": "application/vnd.ms-powerpoint",
-        "wri": "application/vnd.ms-write",
-        "xla|xls|xlt|xlw": "application/vnd.ms-excel",
-        "mdb": "application/vnd.ms-access",
-        "mpp": "application/vnd.ms-project",
-        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        "docm": "application/vnd.ms-word.document.macroEnabled.12",
-        "dotx": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
-        "dotm": "application/vnd.ms-word.template.macroEnabled.12",
-        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
-        "xlsb": "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
-        "xltx": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
-        "xltm": "application/vnd.ms-excel.template.macroEnabled.12",
-        "xlam": "application/vnd.ms-excel.addin.macroEnabled.12",
-        "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-        "pptm": "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
-        "ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
-        "ppsm": "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
-        "potx": "application/vnd.openxmlformats-officedocument.presentationml.template",
-        "potm": "application/vnd.ms-powerpoint.template.macroEnabled.12",
-        "ppam": "application/vnd.ms-powerpoint.addin.macroEnabled.12",
-        "sldx": "application/vnd.openxmlformats-officedocument.presentationml.slide",
-        "sldm": "application/vnd.ms-powerpoint.slide.macroEnabled.12",
-        "onetoc|onetoc2|onetmp|onepkg": "application/onenote",
-        "oxps": "application/oxps",
-        "xps": "application/vnd.ms-xpsdocument",
-        "odt": "application/vnd.oasis.opendocument.text",
-        "odp": "application/vnd.oasis.opendocument.presentation",
-        "ods": "application/vnd.oasis.opendocument.spreadsheet",
-        "odg": "application/vnd.oasis.opendocument.graphics",
-        "odc": "application/vnd.oasis.opendocument.chart",
-        "odb": "application/vnd.oasis.opendocument.database",
-        "odf": "application/vnd.oasis.opendocument.formula",
-        "wp|wpd": "application/wordperfect",
-        "key": "application/vnd.apple.keynote",
-        "numbers": "application/vnd.apple.numbers",
-        "pages": "application/vnd.apple.pages"
-    },
-    "blockCategories": [
-        {
-            "slug": "text",
-            "title": "Text",
-            "icon": null
-        },
-        {
-            "slug": "media",
-            "title": "Media",
-            "icon": null
-        },
-        {
-            "slug": "design",
-            "title": "Design",
-            "icon": null
-        },
-        {
-            "slug": "widgets",
-            "title": "Widgets",
-            "icon": null
-        },
-        {
-            "slug": "theme",
-            "title": "Theme",
-            "icon": null
-        },
-        {
-            "slug": "embed",
-            "title": "Embeds",
-            "icon": null
-        },
-        {
-            "slug": "reusable",
-            "title": "Reusable Blocks",
-            "icon": null
-        }
-    ],
-    "disableCustomColors": false,
-    "disableCustomFontSizes": false,
-    "disableCustomGradients": false,
-    "enableCustomLineHeight": false,
-    "enableCustomSpacing": false,
-    "enableCustomUnits": true,
-    "isRTL": false,
-    "imageDefaultSize": "large",
-    "imageDimensions": {
-        "thumbnail": {
-            "width": 150,
-            "height": 150,
-            "crop": true
-        },
-        "medium": {
-            "width": 300,
-            "height": 300,
-            "crop": false
-        },
-        "large": {
-            "width": 1024,
-            "height": 1024,
-            "crop": false
-        }
-    },
-    "imageEditing": true,
-    "imageSizes": [
-        {
-            "slug": "thumbnail",
-            "name": "Thumbnail"
-        },
-        {
-            "slug": "medium",
-            "name": "Medium"
-        },
-        {
+  "imageDefaultSize": "large",
+  "__unstableEnableFullSiteEditingBlocks": true,
+  "styles": [
+
+  ],
+  "supportsTemplateMode": true,
+  "supportsLayout": true,
+  "widgetTypesToHideFromLegacyWidgetBlock": [
+    "pages",
+    "calendar",
+    "archives",
+    "media_audio",
+    "media_image",
+    "media_gallery",
+    "media_video",
+    "meta",
+    "search",
+    "text",
+    "categories",
+    "recent-posts",
+    "recent-comments",
+    "rss",
+    "tag_cloud",
+    "nav_menu",
+    "custom_html",
+    "block"
+  ],
+  "__experimentalFeatures": {
+    "defaults": {
+      "color": {
+        "palette": [
+          {
+            "slug": "black",
+            "color": "#000000",
+            "name": "Black"
+          },
+          {
+            "slug": "dark-gray",
+            "color": "#28303D",
+            "name": "Dark Gray"
+          },
+          {
+            "slug": "gray",
+            "color": "#39414D",
+            "name": "Gray"
+          },
+          {
+            "slug": "green",
+            "color": "#D1E4DD",
+            "name": "Green"
+          },
+          {
+            "slug": "blue",
+            "color": "#D1DFE4",
+            "name": "Blue"
+          },
+          {
+            "slug": "purple",
+            "color": "#D1D1E4",
+            "name": "Purple"
+          },
+          {
+            "slug": "red",
+            "color": "#E4D1D1",
+            "name": "Red"
+          },
+          {
+            "slug": "orange",
+            "color": "#E4DAD1",
+            "name": "Orange"
+          },
+          {
+            "slug": "yellow",
+            "color": "#EEEADD",
+            "name": "Yellow"
+          },
+          {
+            "slug": "white",
+            "color": "#FFFFFF",
+            "name": "White"
+          }
+        ],
+        "gradients": [
+          {
+            "slug": "purple-to-yellow",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
+            "name": "Purple to Yellow"
+          },
+          {
+            "slug": "yellow-to-purple",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
+            "name": "Yellow to Purple"
+          },
+          {
+            "slug": "green-to-yellow",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
+            "name": "Green to Yellow"
+          },
+          {
+            "slug": "yellow-to-green",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
+            "name": "Yellow to Green"
+          },
+          {
+            "slug": "red-to-yellow",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
+            "name": "Red to Yellow"
+          },
+          {
+            "slug": "yellow-to-red",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
+            "name": "Yellow to Red"
+          },
+          {
+            "slug": "purple-to-red",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
+            "name": "Purple to Red"
+          },
+          {
+            "slug": "red-to-purple",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
+            "name": "Red to Purple"
+          }
+        ],
+        "custom": true,
+        "link": true,
+        "customGradient": true
+      },
+      "typography": {
+        "dropCap": true,
+        "customFontSize": true,
+        "customLineHeight": true,
+        "customFontStyle": true,
+        "customFontWeight": true,
+        "customTextTransforms": true,
+        "customTextDecorations": true,
+        "fontSizes": [
+          {
+            "slug": "extra-small",
+            "size": "16px",
+            "name": "Extra small"
+          },
+          {
+            "slug": "small",
+            "size": "18px",
+            "name": "Small"
+          },
+          {
+            "slug": "normal",
+            "size": "20px",
+            "name": "Normal"
+          },
+          {
             "slug": "large",
+            "size": "24px",
             "name": "Large"
+          },
+          {
+            "slug": "extra-large",
+            "size": "40px",
+            "name": "Extra large"
+          },
+          {
+            "slug": "huge",
+            "size": "96px",
+            "name": "Huge"
+          },
+          {
+            "slug": "gigantic",
+            "size": "144px",
+            "name": "Gigantic"
+          }
+        ],
+        "fontFamilies": [
+          {
+            "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
+            "slug": "system-font",
+            "name": "System Font"
+          },
+          {
+            "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
+            "slug": "helvetica-arial"
+          },
+          {
+            "fontFamily": "Geneva, Tahoma, Verdana, sans-serif",
+            "slug": "geneva-verdana"
+          },
+          {
+            "fontFamily": "Cambria, Georgia, serif",
+            "slug": "cambria-georgia"
+          },
+          {
+            "fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
+            "slug": "hoefler-times-new-roman"
+          }
+        ]
+      },
+      "spacing": {
+        "customPadding": true,
+        "units": [
+          "px",
+          "em",
+          "rem",
+          "vh",
+          "vw"
+        ]
+      },
+      "border": {
+        "customColor": false,
+        "customRadius": false,
+        "customStyle": false,
+        "customWidth": false
+      },
+      "layout": {
+        "contentSize": "610px",
+        "wideSize": "1240px"
+      },
+      "custom": {
+        "font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+        "line-height": {
+          "body": 1.7,
+          "heading": 1.3,
+          "page-title": 1.1
         },
-        {
-            "slug": "full",
-            "name": "Full Size"
+        "spacing": {
+          "unit": "20px",
+          "horizontal": "25px",
+          "vertical": "30px"
+        },
+        "font-weight": {
+          "light": "300",
+          "normal": "normal"
         }
+      }
+    },
+    "core/button": {
+      "border": {
+        "customRadius": true
+      }
+    }
+  },
+  "__experimentalGlobalStylesUserEntityId": 5,
+  "__experimentalGlobalStylesBaseStyles": {
+    "settings": {
+      "defaults": {
+        "color": {
+          "palette": [
+            {
+              "slug": "black",
+              "color": "#000000",
+              "name": "Black"
+            },
+            {
+              "slug": "dark-gray",
+              "color": "#28303D",
+              "name": "Dark Gray"
+            },
+            {
+              "slug": "gray",
+              "color": "#39414D",
+              "name": "Gray"
+            },
+            {
+              "slug": "green",
+              "color": "#D1E4DD",
+              "name": "Green"
+            },
+            {
+              "slug": "blue",
+              "color": "#D1DFE4",
+              "name": "Blue"
+            },
+            {
+              "slug": "purple",
+              "color": "#D1D1E4",
+              "name": "Purple"
+            },
+            {
+              "slug": "red",
+              "color": "#E4D1D1",
+              "name": "Red"
+            },
+            {
+              "slug": "orange",
+              "color": "#E4DAD1",
+              "name": "Orange"
+            },
+            {
+              "slug": "yellow",
+              "color": "#EEEADD",
+              "name": "Yellow"
+            },
+            {
+              "slug": "white",
+              "color": "#FFFFFF",
+              "name": "White"
+            }
+          ],
+          "gradients": [
+            {
+              "slug": "purple-to-yellow",
+              "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
+              "name": "Purple to Yellow"
+            },
+            {
+              "slug": "yellow-to-purple",
+              "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
+              "name": "Yellow to Purple"
+            },
+            {
+              "slug": "green-to-yellow",
+              "gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
+              "name": "Green to Yellow"
+            },
+            {
+              "slug": "yellow-to-green",
+              "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
+              "name": "Yellow to Green"
+            },
+            {
+              "slug": "red-to-yellow",
+              "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
+              "name": "Red to Yellow"
+            },
+            {
+              "slug": "yellow-to-red",
+              "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
+              "name": "Yellow to Red"
+            },
+            {
+              "slug": "purple-to-red",
+              "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
+              "name": "Purple to Red"
+            },
+            {
+              "slug": "red-to-purple",
+              "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
+              "name": "Red to Purple"
+            }
+          ],
+          "custom": true,
+          "link": true,
+          "customGradient": true
+        },
+        "typography": {
+          "dropCap": true,
+          "customFontSize": true,
+          "customLineHeight": true,
+          "customFontStyle": true,
+          "customFontWeight": true,
+          "customTextTransforms": true,
+          "customTextDecorations": true,
+          "fontSizes": [
+            {
+              "slug": "extra-small",
+              "size": "16px",
+              "name": "Extra small"
+            },
+            {
+              "slug": "small",
+              "size": "18px",
+              "name": "Small"
+            },
+            {
+              "slug": "normal",
+              "size": "20px",
+              "name": "Normal"
+            },
+            {
+              "slug": "large",
+              "size": "24px",
+              "name": "Large"
+            },
+            {
+              "slug": "extra-large",
+              "size": "40px",
+              "name": "Extra large"
+            },
+            {
+              "slug": "huge",
+              "size": "96px",
+              "name": "Huge"
+            },
+            {
+              "slug": "gigantic",
+              "size": "144px",
+              "name": "Gigantic"
+            }
+          ],
+          "fontFamilies": [
+            {
+              "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
+              "slug": "system-font",
+              "name": "System Font"
+            },
+            {
+              "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
+              "slug": "helvetica-arial"
+            },
+            {
+              "fontFamily": "Geneva, Tahoma, Verdana, sans-serif",
+              "slug": "geneva-verdana"
+            },
+            {
+              "fontFamily": "Cambria, Georgia, serif",
+              "slug": "cambria-georgia"
+            },
+            {
+              "fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
+              "slug": "hoefler-times-new-roman"
+            }
+          ]
+        },
+        "spacing": {
+          "customPadding": true,
+          "units": [
+            "px",
+            "em",
+            "rem",
+            "vh",
+            "vw"
+          ]
+        },
+        "border": {
+          "customColor": false,
+          "customRadius": false,
+          "customStyle": false,
+          "customWidth": false
+        },
+        "layout": {
+          "contentSize": "610px",
+          "wideSize": "1240px"
+        },
+        "custom": {
+          "font-primary": "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif",
+          "line-height": {
+            "body": 1.7,
+            "heading": 1.3,
+            "page-title": 1.1
+          },
+          "spacing": {
+            "unit": "20px",
+            "horizontal": "25px",
+            "vertical": "30px"
+          },
+          "font-weight": {
+            "light": "300",
+            "normal": "normal"
+          }
+        }
+      },
+      "core/button": {
+        "border": {
+          "customRadius": true
+        }
+      }
+    },
+    "templateParts": [
+      {
+        "name": "header",
+        "area": "header"
+      },
+      {
+        "name": "footer",
+        "area": "footer"
+      }
     ],
-    "maxUploadFileSize": 2097152
+    "styles": {
+      "root": {
+        "color": {
+          "background": "var(--wp--preset--color--green)",
+          "text": "var(--wp--preset--color--dark-gray)",
+          "link": "var(--wp--preset--color--dark-gray)"
+        },
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--normal)",
+          "lineHeight": "var(--wp--custom--line-height--body)"
+        }
+      },
+      "core/heading/h1": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--gigantic)",
+          "lineHeight": "var(--wp--custom--line-height--page-title)",
+          "fontWeight": "var(--wp--custom--font-weight--normal)"
+        }
+      },
+      "core/heading/h2": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--extra-large)",
+          "lineHeight": "var(--wp--custom--line-height--heading)",
+          "fontWeight": "var(--wp--custom--font-weight--normal)"
+        }
+      },
+      "core/heading/h3": {
+        "typography": {
+          "fontSize": "calc(1.25 * var(--wp--preset--font-size--large))",
+          "lineHeight": "var(--wp--custom--line-height--heading)",
+          "fontWeight": "var(--wp--custom--font-weight--normal)"
+        }
+      },
+      "core/heading/h4": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--large)",
+          "lineHeight": "var(--wp--custom--line-height--heading)"
+        }
+      },
+      "core/heading/h5": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--small)",
+          "lineHeight": "var(--wp--custom--line-height--heading)"
+        }
+      },
+      "core/heading/h6": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--extra-small)",
+          "lineHeight": "var(--wp--custom--line-height--heading)"
+        }
+      },
+      "core/site-tagline": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--small)",
+          "lineHeight": 1.4
+        }
+      },
+      "core/post-author": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--extra-small)",
+          "lineHeight": "var(--wp--custom--line-height--body)"
+        }
+      },
+      "core/post-date": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--extra-small)",
+          "lineHeight": "var(--wp--custom--line-height--body)"
+        }
+      },
+      "core/post-hierarchical-terms": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--extra-small)",
+          "lineHeight": "var(--wp--custom--line-height--body)"
+        }
+      },
+      "core/post-tags": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--extra-small)",
+          "lineHeight": "var(--wp--custom--line-height--body)"
+        }
+      },
+      "core/site-title": {
+        "typography": {
+          "fontSize": "var(--wp--preset--font-size--large)",
+          "fontWeight": "var(--wp--custom--font-weight--normal)",
+          "textTransform": "uppercase"
+        }
+      }
+    },
+    "customTemplates": [
+      {
+        "name": "page-home",
+        "title": "Page without title"
+      }
+    ]
+  },
+  "alignWide": false,
+  "allowedBlockTypes": true,
+  "allowedMimeTypes": {
+    "jpg|jpeg|jpe": "image/jpeg",
+    "gif": "image/gif",
+    "png": "image/png",
+    "bmp": "image/bmp",
+    "tiff|tif": "image/tiff",
+    "ico": "image/x-icon",
+    "heic": "image/heic",
+    "asf|asx": "video/x-ms-asf",
+    "wmv": "video/x-ms-wmv",
+    "wmx": "video/x-ms-wmx",
+    "wm": "video/x-ms-wm",
+    "avi": "video/avi",
+    "divx": "video/divx",
+    "flv": "video/x-flv",
+    "mov|qt": "video/quicktime",
+    "mpeg|mpg|mpe": "video/mpeg",
+    "mp4|m4v": "video/mp4",
+    "ogv": "video/ogg",
+    "webm": "video/webm",
+    "mkv": "video/x-matroska",
+    "3gp|3gpp": "video/3gpp",
+    "3g2|3gp2": "video/3gpp2",
+    "txt|asc|c|cc|h|srt": "text/plain",
+    "csv": "text/csv",
+    "tsv": "text/tab-separated-values",
+    "ics": "text/calendar",
+    "rtx": "text/richtext",
+    "css": "text/css",
+    "htm|html": "text/html",
+    "vtt": "text/vtt",
+    "dfxp": "application/ttaf+xml",
+    "mp3|m4a|m4b": "audio/mpeg",
+    "aac": "audio/aac",
+    "ra|ram": "audio/x-realaudio",
+    "wav": "audio/wav",
+    "ogg|oga": "audio/ogg",
+    "flac": "audio/flac",
+    "mid|midi": "audio/midi",
+    "wma": "audio/x-ms-wma",
+    "wax": "audio/x-ms-wax",
+    "mka": "audio/x-matroska",
+    "rtf": "application/rtf",
+    "js": "application/javascript",
+    "pdf": "application/pdf",
+    "class": "application/java",
+    "tar": "application/x-tar",
+    "zip": "application/zip",
+    "gz|gzip": "application/x-gzip",
+    "rar": "application/rar",
+    "7z": "application/x-7z-compressed",
+    "psd": "application/octet-stream",
+    "xcf": "application/octet-stream",
+    "doc": "application/msword",
+    "pot|pps|ppt": "application/vnd.ms-powerpoint",
+    "wri": "application/vnd.ms-write",
+    "xla|xls|xlt|xlw": "application/vnd.ms-excel",
+    "mdb": "application/vnd.ms-access",
+    "mpp": "application/vnd.ms-project",
+    "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "docm": "application/vnd.ms-word.document.macroEnabled.12",
+    "dotx": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+    "dotm": "application/vnd.ms-word.template.macroEnabled.12",
+    "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
+    "xlsb": "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+    "xltx": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+    "xltm": "application/vnd.ms-excel.template.macroEnabled.12",
+    "xlam": "application/vnd.ms-excel.addin.macroEnabled.12",
+    "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "pptm": "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+    "ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+    "ppsm": "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
+    "potx": "application/vnd.openxmlformats-officedocument.presentationml.template",
+    "potm": "application/vnd.ms-powerpoint.template.macroEnabled.12",
+    "ppam": "application/vnd.ms-powerpoint.addin.macroEnabled.12",
+    "sldx": "application/vnd.openxmlformats-officedocument.presentationml.slide",
+    "sldm": "application/vnd.ms-powerpoint.slide.macroEnabled.12",
+    "onetoc|onetoc2|onetmp|onepkg": "application/onenote",
+    "oxps": "application/oxps",
+    "xps": "application/vnd.ms-xpsdocument",
+    "odt": "application/vnd.oasis.opendocument.text",
+    "odp": "application/vnd.oasis.opendocument.presentation",
+    "ods": "application/vnd.oasis.opendocument.spreadsheet",
+    "odg": "application/vnd.oasis.opendocument.graphics",
+    "odc": "application/vnd.oasis.opendocument.chart",
+    "odb": "application/vnd.oasis.opendocument.database",
+    "odf": "application/vnd.oasis.opendocument.formula",
+    "wp|wpd": "application/wordperfect",
+    "key": "application/vnd.apple.keynote",
+    "numbers": "application/vnd.apple.numbers",
+    "pages": "application/vnd.apple.pages"
+  },
+  "blockCategories": [
+    {
+      "slug": "text",
+      "title": "Text",
+      "icon": null
+    },
+    {
+      "slug": "media",
+      "title": "Media",
+      "icon": null
+    },
+    {
+      "slug": "design",
+      "title": "Design",
+      "icon": null
+    },
+    {
+      "slug": "widgets",
+      "title": "Widgets",
+      "icon": null
+    },
+    {
+      "slug": "theme",
+      "title": "Theme",
+      "icon": null
+    },
+    {
+      "slug": "embed",
+      "title": "Embeds",
+      "icon": null
+    },
+    {
+      "slug": "reusable",
+      "title": "Reusable Blocks",
+      "icon": null
+    }
+  ],
+  "disableCustomColors": false,
+  "disableCustomFontSizes": false,
+  "disableCustomGradients": false,
+  "enableCustomLineHeight": false,
+  "enableCustomSpacing": false,
+  "enableCustomUnits": true,
+  "isRTL": false,
+  "imageDimensions": {
+    "thumbnail": {
+      "width": 150,
+      "height": 150,
+      "crop": true
+    },
+    "medium": {
+      "width": 300,
+      "height": 300,
+      "crop": false
+    },
+    "large": {
+      "width": 1024,
+      "height": 1024,
+      "crop": false
+    }
+  },
+  "imageEditing": true,
+  "imageSizes": [
+    {
+      "slug": "thumbnail",
+      "name": "Thumbnail"
+    },
+    {
+      "slug": "medium",
+      "name": "Medium"
+    },
+    {
+      "slug": "large",
+      "name": "Large"
+    },
+    {
+      "slug": "full",
+      "name": "Full Size"
+    }
+  ],
+  "maxUploadFileSize": 2097152
 }

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
@@ -8,6 +8,7 @@
         "png": "image/png",
         "bmp": "image/bmp",
         "tiff|tif": "image/tiff",
+        "webp": "image/webp",
         "ico": "image/x-icon",
         "heic": "image/heic",
         "asf|asx": "video/x-ms-asf",
@@ -132,9 +133,9 @@
             "icon": null
         }
     ],
-    "disableCustomColors": true,
-    "disableCustomFontSizes": true,
-    "disableCustomGradients": true,
+    "disableCustomColors": false,
+    "disableCustomFontSizes": false,
+    "disableCustomGradients": false,
     "enableCustomLineHeight": true,
     "enableCustomSpacing": true,
     "enableCustomUnits": true,
@@ -177,6 +178,32 @@
         }
     ],
     "maxUploadFileSize": 536870912,
+    "defaultTemplatePartAreas": [
+        {
+            "area": "uncategorized",
+            "label": "General",
+            "description": "General templates often perform a specific role like displaying post content, and are not tied to any particular area.",
+            "icon": "layout",
+            "area_tag": "div"
+        },
+        {
+            "area": "header",
+            "label": "Header",
+            "description": "The Header template defines a page area that typically contains a title, logo, and main navigation.",
+            "icon": "header",
+            "area_tag": "header"
+        },
+        {
+            "area": "footer",
+            "label": "Footer",
+            "description": "The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.",
+            "icon": "footer",
+            "area_tag": "footer"
+        }
+    ],
+    "styles": [],
+    "supportsTemplateMode": true,
+    "supportsLayout": true,
     "__experimentalStyles": {
         "color": {
             "background": "var(--wp--preset--color--green)",
@@ -239,6 +266,19 @@
                     "lineHeight": 1.4
                 }
             },
+            "core/button": {
+                "border": {
+                    "radius": "0px"
+                },
+                "color": {
+                    "background": "var(--wp--preset--color--gray)",
+                    "text": "var(--wp--preset--color--green)"
+                },
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--normal)",
+                    "fontWeight": 500
+                }
+            },
             "core/post-author": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--extra-small)",
@@ -251,17 +291,261 @@
                     "lineHeight": "var(--wp--custom--line-height--body)"
                 }
             },
+            "core/post-terms": {
+                "typography": {
+                    "fontSize": "var(--wp--preset--font-size--extra-small)",
+                    "lineHeight": "var(--wp--custom--line-height--body)"
+                }
+            },
             "core/site-title": {
                 "typography": {
                     "fontSize": "var(--wp--preset--font-size--large)",
                     "fontWeight": "var(--wp--custom--font-weight--normal)",
                     "textTransform": "uppercase"
                 }
+            },
+            "core/code": {
+                "spacing": {
+                    "padding": {
+                        "top": "var(--wp--custom--spacing--unit)",
+                        "bottom": "var(--wp--custom--spacing--unit)",
+                        "left": "var(--wp--custom--spacing--unit)",
+                        "right": "var(--wp--custom--spacing--unit)"
+                    }
+                },
+                "border": {
+                    "radius": "0px",
+                    "color": "var(--wp--preset--color--dark-gray)",
+                    "style": "solid",
+                    "width": "1.5px"
+                }
             }
         }
     },
     "__experimentalFeatures": {
         "color": {
+            "palette": {
+                "core": [
+                    {
+                        "name": "Black",
+                        "slug": "black",
+                        "color": "#000000"
+                    },
+                    {
+                        "name": "Cyan bluish gray",
+                        "slug": "cyan-bluish-gray",
+                        "color": "#abb8c3"
+                    },
+                    {
+                        "name": "White",
+                        "slug": "white",
+                        "color": "#ffffff"
+                    },
+                    {
+                        "name": "Pale pink",
+                        "slug": "pale-pink",
+                        "color": "#f78da7"
+                    },
+                    {
+                        "name": "Vivid red",
+                        "slug": "vivid-red",
+                        "color": "#cf2e2e"
+                    },
+                    {
+                        "name": "Luminous vivid orange",
+                        "slug": "luminous-vivid-orange",
+                        "color": "#ff6900"
+                    },
+                    {
+                        "name": "Luminous vivid amber",
+                        "slug": "luminous-vivid-amber",
+                        "color": "#fcb900"
+                    },
+                    {
+                        "name": "Light green cyan",
+                        "slug": "light-green-cyan",
+                        "color": "#7bdcb5"
+                    },
+                    {
+                        "name": "Vivid green cyan",
+                        "slug": "vivid-green-cyan",
+                        "color": "#00d084"
+                    },
+                    {
+                        "name": "Pale cyan blue",
+                        "slug": "pale-cyan-blue",
+                        "color": "#8ed1fc"
+                    },
+                    {
+                        "name": "Vivid cyan blue",
+                        "slug": "vivid-cyan-blue",
+                        "color": "#0693e3"
+                    },
+                    {
+                        "name": "Vivid purple",
+                        "slug": "vivid-purple",
+                        "color": "#9b51e0"
+                    }
+                ],
+                "theme": [
+                    {
+                        "slug": "black",
+                        "color": "#000000",
+                        "name": "Black"
+                    },
+                    {
+                        "slug": "dark-gray",
+                        "color": "#28303D",
+                        "name": "Dark Gray"
+                    },
+                    {
+                        "slug": "gray",
+                        "color": "#39414D",
+                        "name": "Gray"
+                    },
+                    {
+                        "slug": "green",
+                        "color": "#D1E4DD",
+                        "name": "Green"
+                    },
+                    {
+                        "slug": "blue",
+                        "color": "#D1DFE4",
+                        "name": "Blue"
+                    },
+                    {
+                        "slug": "purple",
+                        "color": "#D1D1E4",
+                        "name": "Purple"
+                    },
+                    {
+                        "slug": "red",
+                        "color": "#E4D1D1",
+                        "name": "Red"
+                    },
+                    {
+                        "slug": "orange",
+                        "color": "#E4DAD1",
+                        "name": "Orange"
+                    },
+                    {
+                        "slug": "yellow",
+                        "color": "#EEEADD",
+                        "name": "Yellow"
+                    },
+                    {
+                        "slug": "white",
+                        "color": "#FFFFFF",
+                        "name": "White"
+                    }
+                ]
+            },
+            "gradients": {
+                "core": [
+                    {
+                        "name": "Vivid cyan blue to vivid purple",
+                        "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
+                        "slug": "vivid-cyan-blue-to-vivid-purple"
+                    },
+                    {
+                        "name": "Light green cyan to vivid green cyan",
+                        "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
+                        "slug": "light-green-cyan-to-vivid-green-cyan"
+                    },
+                    {
+                        "name": "Luminous vivid amber to luminous vivid orange",
+                        "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
+                        "slug": "luminous-vivid-amber-to-luminous-vivid-orange"
+                    },
+                    {
+                        "name": "Luminous vivid orange to vivid red",
+                        "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
+                        "slug": "luminous-vivid-orange-to-vivid-red"
+                    },
+                    {
+                        "name": "Very light gray to cyan bluish gray",
+                        "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
+                        "slug": "very-light-gray-to-cyan-bluish-gray"
+                    },
+                    {
+                        "name": "Cool to warm spectrum",
+                        "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
+                        "slug": "cool-to-warm-spectrum"
+                    },
+                    {
+                        "name": "Blush light purple",
+                        "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
+                        "slug": "blush-light-purple"
+                    },
+                    {
+                        "name": "Blush bordeaux",
+                        "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
+                        "slug": "blush-bordeaux"
+                    },
+                    {
+                        "name": "Luminous dusk",
+                        "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
+                        "slug": "luminous-dusk"
+                    },
+                    {
+                        "name": "Pale ocean",
+                        "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
+                        "slug": "pale-ocean"
+                    },
+                    {
+                        "name": "Electric grass",
+                        "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
+                        "slug": "electric-grass"
+                    },
+                    {
+                        "name": "Midnight",
+                        "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
+                        "slug": "midnight"
+                    }
+                ],
+                "theme": [
+                    {
+                        "slug": "purple-to-yellow",
+                        "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
+                        "name": "Purple to Yellow"
+                    },
+                    {
+                        "slug": "yellow-to-purple",
+                        "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
+                        "name": "Yellow to Purple"
+                    },
+                    {
+                        "slug": "green-to-yellow",
+                        "gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
+                        "name": "Green to Yellow"
+                    },
+                    {
+                        "slug": "yellow-to-green",
+                        "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
+                        "name": "Yellow to Green"
+                    },
+                    {
+                        "slug": "red-to-yellow",
+                        "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
+                        "name": "Red to Yellow"
+                    },
+                    {
+                        "slug": "yellow-to-red",
+                        "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
+                        "name": "Yellow to Red"
+                    },
+                    {
+                        "slug": "purple-to-red",
+                        "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
+                        "name": "Purple to Red"
+                    },
+                    {
+                        "slug": "red-to-purple",
+                        "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
+                        "name": "Red to Purple"
+                    }
+                ]
+            },
             "duotone": [
                 {
                     "name": "Dark grayscale",
@@ -336,38 +620,107 @@
             "customFontWeight": true,
             "customTextTransforms": true,
             "customTextDecorations": true,
-            "fontFamilies": [
-                {
-                    "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
-                    "slug": "system-font",
-                    "name": "System Font"
-                },
-                {
-                    "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
-                    "slug": "helvetica-arial"
-                },
-                {
-                    "fontFamily": "Geneva, Tahoma, Verdana, sans-serif",
-                    "slug": "geneva-verdana"
-                },
-                {
-                    "fontFamily": "Cambria, Georgia, serif",
-                    "slug": "cambria-georgia"
-                },
-                {
-                    "fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
-                    "slug": "hoefler-times-new-roman"
-                }
-            ]
+            "customLetterSpacing": true,
+            "fontSizes": {
+                "core": [
+                    {
+                        "name": "Small",
+                        "slug": "small",
+                        "size": "13px"
+                    },
+                    {
+                        "name": "Normal",
+                        "slug": "normal",
+                        "size": "16px"
+                    },
+                    {
+                        "name": "Medium",
+                        "slug": "medium",
+                        "size": "20px"
+                    },
+                    {
+                        "name": "Large",
+                        "slug": "large",
+                        "size": "36px"
+                    },
+                    {
+                        "name": "Huge",
+                        "slug": "huge",
+                        "size": "42px"
+                    }
+                ],
+                "theme": [
+                    {
+                        "slug": "extra-small",
+                        "size": "16px",
+                        "name": "Extra small"
+                    },
+                    {
+                        "slug": "small",
+                        "size": "18px",
+                        "name": "Small"
+                    },
+                    {
+                        "slug": "normal",
+                        "size": "20px",
+                        "name": "Normal"
+                    },
+                    {
+                        "slug": "large",
+                        "size": "24px",
+                        "name": "Large"
+                    },
+                    {
+                        "slug": "extra-large",
+                        "size": "40px",
+                        "name": "Extra large"
+                    },
+                    {
+                        "slug": "huge",
+                        "size": "96px",
+                        "name": "Huge"
+                    },
+                    {
+                        "slug": "gigantic",
+                        "size": "144px",
+                        "name": "Gigantic"
+                    }
+                ]
+            },
+            "fontFamilies": {
+                "theme": [
+                    {
+                        "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
+                        "slug": "system-font",
+                        "name": "System Font"
+                    },
+                    {
+                        "fontFamily": "Helvetica Neue, Helvetica, Arial, sans-serif",
+                        "slug": "helvetica-arial"
+                    },
+                    {
+                        "fontFamily": "Geneva, Tahoma, Verdana, sans-serif",
+                        "slug": "geneva-verdana"
+                    },
+                    {
+                        "fontFamily": "Cambria, Georgia, serif",
+                        "slug": "cambria-georgia"
+                    },
+                    {
+                        "fontFamily": "Hoefler Text, Baskerville Old Face, Garamond, Times New Roman, serif",
+                        "slug": "hoefler-times-new-roman"
+                    }
+                ]
+            }
         },
         "spacing": {
             "customMargin": false
         },
         "border": {
-            "customColor": false,
-            "customRadius": false,
-            "customStyle": false,
-            "customWidth": false
+            "customColor": true,
+            "customRadius": true,
+            "customStyle": true,
+            "customWidth": true
         },
         "blocks": {
             "core/button": {
@@ -399,66 +752,6 @@
         }
     },
     "colors": [
-        {
-            "name": "Cyan bluish gray",
-            "slug": "cyan-bluish-gray",
-            "color": "#abb8c3",
-            "origin": "core"
-        },
-        {
-            "name": "Pale pink",
-            "slug": "pale-pink",
-            "color": "#f78da7",
-            "origin": "core"
-        },
-        {
-            "name": "Vivid red",
-            "slug": "vivid-red",
-            "color": "#cf2e2e",
-            "origin": "core"
-        },
-        {
-            "name": "Luminous vivid orange",
-            "slug": "luminous-vivid-orange",
-            "color": "#ff6900",
-            "origin": "core"
-        },
-        {
-            "name": "Luminous vivid amber",
-            "slug": "luminous-vivid-amber",
-            "color": "#fcb900",
-            "origin": "core"
-        },
-        {
-            "name": "Light green cyan",
-            "slug": "light-green-cyan",
-            "color": "#7bdcb5",
-            "origin": "core"
-        },
-        {
-            "name": "Vivid green cyan",
-            "slug": "vivid-green-cyan",
-            "color": "#00d084",
-            "origin": "core"
-        },
-        {
-            "name": "Pale cyan blue",
-            "slug": "pale-cyan-blue",
-            "color": "#8ed1fc",
-            "origin": "core"
-        },
-        {
-            "name": "Vivid cyan blue",
-            "slug": "vivid-cyan-blue",
-            "color": "#0693e3",
-            "origin": "core"
-        },
-        {
-            "name": "Vivid purple",
-            "slug": "vivid-purple",
-            "color": "#9b51e0",
-            "origin": "core"
-        },
         {
             "slug": "black",
             "color": "#000000",
@@ -511,78 +804,6 @@
         }
     ],
     "gradients": [
-        {
-            "name": "Vivid cyan blue to vivid purple",
-            "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
-            "slug": "vivid-cyan-blue-to-vivid-purple",
-            "origin": "core"
-        },
-        {
-            "name": "Light green cyan to vivid green cyan",
-            "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
-            "slug": "light-green-cyan-to-vivid-green-cyan",
-            "origin": "core"
-        },
-        {
-            "name": "Luminous vivid amber to luminous vivid orange",
-            "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
-            "slug": "luminous-vivid-amber-to-luminous-vivid-orange",
-            "origin": "core"
-        },
-        {
-            "name": "Luminous vivid orange to vivid red",
-            "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
-            "slug": "luminous-vivid-orange-to-vivid-red",
-            "origin": "core"
-        },
-        {
-            "name": "Very light gray to cyan bluish gray",
-            "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
-            "slug": "very-light-gray-to-cyan-bluish-gray",
-            "origin": "core"
-        },
-        {
-            "name": "Cool to warm spectrum",
-            "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
-            "slug": "cool-to-warm-spectrum",
-            "origin": "core"
-        },
-        {
-            "name": "Blush light purple",
-            "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
-            "slug": "blush-light-purple",
-            "origin": "core"
-        },
-        {
-            "name": "Blush bordeaux",
-            "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
-            "slug": "blush-bordeaux",
-            "origin": "core"
-        },
-        {
-            "name": "Luminous dusk",
-            "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
-            "slug": "luminous-dusk",
-            "origin": "core"
-        },
-        {
-            "name": "Pale ocean",
-            "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
-            "slug": "pale-ocean",
-            "origin": "core"
-        },
-        {
-            "name": "Electric grass",
-            "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
-            "slug": "electric-grass",
-            "origin": "core"
-        },
-        {
-            "name": "Midnight",
-            "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
-            "slug": "midnight",
-            "origin": "core"
-        },
         {
             "slug": "purple-to-yellow",
             "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
@@ -1,0 +1,180 @@
+{
+    "__unstableEnableFullSiteEditingBlocks": true,
+    "alignWide": false,
+    "allowedBlockTypes": true,
+    "allowedMimeTypes": {
+        "jpg|jpeg|jpe": "image/jpeg",
+        "gif": "image/gif",
+        "png": "image/png",
+        "bmp": "image/bmp",
+        "tiff|tif": "image/tiff",
+        "ico": "image/x-icon",
+        "heic": "image/heic",
+        "asf|asx": "video/x-ms-asf",
+        "wmv": "video/x-ms-wmv",
+        "wmx": "video/x-ms-wmx",
+        "wm": "video/x-ms-wm",
+        "avi": "video/avi",
+        "divx": "video/divx",
+        "flv": "video/x-flv",
+        "mov|qt": "video/quicktime",
+        "mpeg|mpg|mpe": "video/mpeg",
+        "mp4|m4v": "video/mp4",
+        "ogv": "video/ogg",
+        "webm": "video/webm",
+        "mkv": "video/x-matroska",
+        "3gp|3gpp": "video/3gpp",
+        "3g2|3gp2": "video/3gpp2",
+        "txt|asc|c|cc|h|srt": "text/plain",
+        "csv": "text/csv",
+        "tsv": "text/tab-separated-values",
+        "ics": "text/calendar",
+        "rtx": "text/richtext",
+        "css": "text/css",
+        "htm|html": "text/html",
+        "vtt": "text/vtt",
+        "dfxp": "application/ttaf+xml",
+        "mp3|m4a|m4b": "audio/mpeg",
+        "aac": "audio/aac",
+        "ra|ram": "audio/x-realaudio",
+        "wav": "audio/wav",
+        "ogg|oga": "audio/ogg",
+        "flac": "audio/flac",
+        "mid|midi": "audio/midi",
+        "wma": "audio/x-ms-wma",
+        "wax": "audio/x-ms-wax",
+        "mka": "audio/x-matroska",
+        "rtf": "application/rtf",
+        "js": "application/javascript",
+        "pdf": "application/pdf",
+        "class": "application/java",
+        "tar": "application/x-tar",
+        "zip": "application/zip",
+        "gz|gzip": "application/x-gzip",
+        "rar": "application/rar",
+        "7z": "application/x-7z-compressed",
+        "psd": "application/octet-stream",
+        "xcf": "application/octet-stream",
+        "doc": "application/msword",
+        "pot|pps|ppt": "application/vnd.ms-powerpoint",
+        "wri": "application/vnd.ms-write",
+        "xla|xls|xlt|xlw": "application/vnd.ms-excel",
+        "mdb": "application/vnd.ms-access",
+        "mpp": "application/vnd.ms-project",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "docm": "application/vnd.ms-word.document.macroEnabled.12",
+        "dotx": "application/vnd.openxmlformats-officedocument.wordprocessingml.template",
+        "dotm": "application/vnd.ms-word.template.macroEnabled.12",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "xlsm": "application/vnd.ms-excel.sheet.macroEnabled.12",
+        "xlsb": "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+        "xltx": "application/vnd.openxmlformats-officedocument.spreadsheetml.template",
+        "xltm": "application/vnd.ms-excel.template.macroEnabled.12",
+        "xlam": "application/vnd.ms-excel.addin.macroEnabled.12",
+        "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "pptm": "application/vnd.ms-powerpoint.presentation.macroEnabled.12",
+        "ppsx": "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
+        "ppsm": "application/vnd.ms-powerpoint.slideshow.macroEnabled.12",
+        "potx": "application/vnd.openxmlformats-officedocument.presentationml.template",
+        "potm": "application/vnd.ms-powerpoint.template.macroEnabled.12",
+        "ppam": "application/vnd.ms-powerpoint.addin.macroEnabled.12",
+        "sldx": "application/vnd.openxmlformats-officedocument.presentationml.slide",
+        "sldm": "application/vnd.ms-powerpoint.slide.macroEnabled.12",
+        "onetoc|onetoc2|onetmp|onepkg": "application/onenote",
+        "oxps": "application/oxps",
+        "xps": "application/vnd.ms-xpsdocument",
+        "odt": "application/vnd.oasis.opendocument.text",
+        "odp": "application/vnd.oasis.opendocument.presentation",
+        "ods": "application/vnd.oasis.opendocument.spreadsheet",
+        "odg": "application/vnd.oasis.opendocument.graphics",
+        "odc": "application/vnd.oasis.opendocument.chart",
+        "odb": "application/vnd.oasis.opendocument.database",
+        "odf": "application/vnd.oasis.opendocument.formula",
+        "wp|wpd": "application/wordperfect",
+        "key": "application/vnd.apple.keynote",
+        "numbers": "application/vnd.apple.numbers",
+        "pages": "application/vnd.apple.pages"
+    },
+    "blockCategories": [
+        {
+            "slug": "text",
+            "title": "Text",
+            "icon": null
+        },
+        {
+            "slug": "media",
+            "title": "Media",
+            "icon": null
+        },
+        {
+            "slug": "design",
+            "title": "Design",
+            "icon": null
+        },
+        {
+            "slug": "widgets",
+            "title": "Widgets",
+            "icon": null
+        },
+        {
+            "slug": "theme",
+            "title": "Theme",
+            "icon": null
+        },
+        {
+            "slug": "embed",
+            "title": "Embeds",
+            "icon": null
+        },
+        {
+            "slug": "reusable",
+            "title": "Reusable Blocks",
+            "icon": null
+        }
+    ],
+    "disableCustomColors": false,
+    "disableCustomFontSizes": false,
+    "disableCustomGradients": false,
+    "enableCustomLineHeight": false,
+    "enableCustomSpacing": false,
+    "enableCustomUnits": true,
+    "isRTL": false,
+    "imageDefaultSize": "large",
+    "imageDimensions": {
+        "thumbnail": {
+            "width": 150,
+            "height": 150,
+            "crop": true
+        },
+        "medium": {
+            "width": 300,
+            "height": 300,
+            "crop": false
+        },
+        "large": {
+            "width": 1024,
+            "height": 1024,
+            "crop": false
+        }
+    },
+    "imageEditing": true,
+    "imageSizes": [
+        {
+            "slug": "thumbnail",
+            "name": "Thumbnail"
+        },
+        {
+            "slug": "medium",
+            "name": "Medium"
+        },
+        {
+            "slug": "large",
+            "name": "Large"
+        },
+        {
+            "slug": "full",
+            "name": "Full Size"
+        }
+    ],
+    "maxUploadFileSize": 2097152
+}

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
@@ -8,7 +8,6 @@
         "png": "image/png",
         "bmp": "image/bmp",
         "tiff|tif": "image/tiff",
-        "webp": "image/webp",
         "ico": "image/x-icon",
         "heic": "image/heic",
         "asf|asx": "video/x-ms-asf",
@@ -133,6 +132,12 @@
             "icon": null
         }
     ],
+    "disableCustomColors": true,
+    "disableCustomFontSizes": true,
+    "disableCustomGradients": true,
+    "enableCustomLineHeight": true,
+    "enableCustomSpacing": true,
+    "enableCustomUnits": true,
     "isRTL": false,
     "imageDefaultSize": "large",
     "imageDimensions": {
@@ -171,53 +176,7 @@
             "name": "Full Size"
         }
     ],
-    "maxUploadFileSize": 2097152,
-    "defaultTemplatePartAreas": [
-        {
-            "area": "uncategorized",
-            "label": "General",
-            "description": "General templates often perform a specific role like displaying post content, and are not tied to any particular area.",
-            "icon": "layout",
-            "area_tag": "div"
-        },
-        {
-            "area": "header",
-            "label": "Header",
-            "description": "The Header template defines a page area that typically contains a title, logo, and main navigation.",
-            "icon": "header",
-            "area_tag": "header"
-        },
-        {
-            "area": "footer",
-            "label": "Footer",
-            "description": "The Footer template defines a page area that typically contains site credits, social links, or any other combination of blocks.",
-            "icon": "footer",
-            "area_tag": "footer"
-        }
-    ],
-    "styles": [],
-    "supportsTemplateMode": true,
-    "supportsLayout": true,
-    "widgetTypesToHideFromLegacyWidgetBlock": [
-        "pages",
-        "calendar",
-        "archives",
-        "media_audio",
-        "media_image",
-        "media_gallery",
-        "media_video",
-        "meta",
-        "search",
-        "text",
-        "categories",
-        "recent-posts",
-        "recent-comments",
-        "rss",
-        "tag_cloud",
-        "nav_menu",
-        "custom_html",
-        "block"
-    ],
+    "maxUploadFileSize": 536870912,
     "__experimentalStyles": {
         "color": {
             "background": "var(--wp--preset--color--green)",
@@ -303,100 +262,6 @@
     },
     "__experimentalFeatures": {
         "color": {
-            "palette": [
-                {
-                    "slug": "black",
-                    "color": "#000000",
-                    "name": "Black"
-                },
-                {
-                    "slug": "dark-gray",
-                    "color": "#28303D",
-                    "name": "Dark Gray"
-                },
-                {
-                    "slug": "gray",
-                    "color": "#39414D",
-                    "name": "Gray"
-                },
-                {
-                    "slug": "green",
-                    "color": "#D1E4DD",
-                    "name": "Green"
-                },
-                {
-                    "slug": "blue",
-                    "color": "#D1DFE4",
-                    "name": "Blue"
-                },
-                {
-                    "slug": "purple",
-                    "color": "#D1D1E4",
-                    "name": "Purple"
-                },
-                {
-                    "slug": "red",
-                    "color": "#E4D1D1",
-                    "name": "Red"
-                },
-                {
-                    "slug": "orange",
-                    "color": "#E4DAD1",
-                    "name": "Orange"
-                },
-                {
-                    "slug": "yellow",
-                    "color": "#EEEADD",
-                    "name": "Yellow"
-                },
-                {
-                    "slug": "white",
-                    "color": "#FFFFFF",
-                    "name": "White"
-                }
-            ],
-            "gradients": [
-                {
-                    "slug": "purple-to-yellow",
-                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
-                    "name": "Purple to Yellow"
-                },
-                {
-                    "slug": "yellow-to-purple",
-                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
-                    "name": "Yellow to Purple"
-                },
-                {
-                    "slug": "green-to-yellow",
-                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
-                    "name": "Green to Yellow"
-                },
-                {
-                    "slug": "yellow-to-green",
-                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
-                    "name": "Yellow to Green"
-                },
-                {
-                    "slug": "red-to-yellow",
-                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
-                    "name": "Red to Yellow"
-                },
-                {
-                    "slug": "yellow-to-red",
-                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
-                    "name": "Yellow to Red"
-                },
-                {
-                    "slug": "purple-to-red",
-                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
-                    "name": "Purple to Red"
-                },
-                {
-                    "slug": "red-to-purple",
-                    "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
-                    "name": "Red to Purple"
-                }
-            ],
             "duotone": [
                 {
                     "name": "Dark grayscale",
@@ -463,55 +328,14 @@
                     "slug": "blue-orange"
                 }
             ],
-            "custom": true,
-            "link": true,
-            "customGradient": true
+            "link": true
         },
         "typography": {
             "dropCap": true,
-            "customFontSize": true,
-            "customLineHeight": true,
             "customFontStyle": true,
             "customFontWeight": true,
             "customTextTransforms": true,
             "customTextDecorations": true,
-            "fontSizes": [
-                {
-                    "slug": "extra-small",
-                    "size": "16px",
-                    "name": "Extra small"
-                },
-                {
-                    "slug": "small",
-                    "size": "18px",
-                    "name": "Small"
-                },
-                {
-                    "slug": "normal",
-                    "size": "20px",
-                    "name": "Normal"
-                },
-                {
-                    "slug": "large",
-                    "size": "24px",
-                    "name": "Large"
-                },
-                {
-                    "slug": "extra-large",
-                    "size": "40px",
-                    "name": "Extra large"
-                },
-                {
-                    "slug": "huge",
-                    "size": "96px",
-                    "name": "Huge"
-                },
-                {
-                    "slug": "gigantic",
-                    "size": "144px",
-                    "name": "Gigantic"
-                }
-            ],
             "fontFamilies": [
                 {
                     "fontFamily": "-apple-system,BlinkMacSystemFont,\"Segoe UI\",Roboto,Oxygen-Sans,Ubuntu,Cantarell,\"Helvetica Neue\",sans-serif",
@@ -537,15 +361,7 @@
             ]
         },
         "spacing": {
-            "customMargin": false,
-            "customPadding": true,
-            "units": [
-                "px",
-                "em",
-                "rem",
-                "vh",
-                "vw"
-            ]
+            "customMargin": false
         },
         "border": {
             "customColor": false,
@@ -581,5 +397,268 @@
                 "normal": "normal"
             }
         }
-    }
+    },
+    "colors": [
+        {
+            "name": "Cyan bluish gray",
+            "slug": "cyan-bluish-gray",
+            "color": "#abb8c3",
+            "origin": "core"
+        },
+        {
+            "name": "Pale pink",
+            "slug": "pale-pink",
+            "color": "#f78da7",
+            "origin": "core"
+        },
+        {
+            "name": "Vivid red",
+            "slug": "vivid-red",
+            "color": "#cf2e2e",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous vivid orange",
+            "slug": "luminous-vivid-orange",
+            "color": "#ff6900",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous vivid amber",
+            "slug": "luminous-vivid-amber",
+            "color": "#fcb900",
+            "origin": "core"
+        },
+        {
+            "name": "Light green cyan",
+            "slug": "light-green-cyan",
+            "color": "#7bdcb5",
+            "origin": "core"
+        },
+        {
+            "name": "Vivid green cyan",
+            "slug": "vivid-green-cyan",
+            "color": "#00d084",
+            "origin": "core"
+        },
+        {
+            "name": "Pale cyan blue",
+            "slug": "pale-cyan-blue",
+            "color": "#8ed1fc",
+            "origin": "core"
+        },
+        {
+            "name": "Vivid cyan blue",
+            "slug": "vivid-cyan-blue",
+            "color": "#0693e3",
+            "origin": "core"
+        },
+        {
+            "name": "Vivid purple",
+            "slug": "vivid-purple",
+            "color": "#9b51e0",
+            "origin": "core"
+        },
+        {
+            "slug": "black",
+            "color": "#000000",
+            "name": "Black"
+        },
+        {
+            "slug": "dark-gray",
+            "color": "#28303D",
+            "name": "Dark Gray"
+        },
+        {
+            "slug": "gray",
+            "color": "#39414D",
+            "name": "Gray"
+        },
+        {
+            "slug": "green",
+            "color": "#D1E4DD",
+            "name": "Green"
+        },
+        {
+            "slug": "blue",
+            "color": "#D1DFE4",
+            "name": "Blue"
+        },
+        {
+            "slug": "purple",
+            "color": "#D1D1E4",
+            "name": "Purple"
+        },
+        {
+            "slug": "red",
+            "color": "#E4D1D1",
+            "name": "Red"
+        },
+        {
+            "slug": "orange",
+            "color": "#E4DAD1",
+            "name": "Orange"
+        },
+        {
+            "slug": "yellow",
+            "color": "#EEEADD",
+            "name": "Yellow"
+        },
+        {
+            "slug": "white",
+            "color": "#FFFFFF",
+            "name": "White"
+        }
+    ],
+    "gradients": [
+        {
+            "name": "Vivid cyan blue to vivid purple",
+            "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)",
+            "slug": "vivid-cyan-blue-to-vivid-purple",
+            "origin": "core"
+        },
+        {
+            "name": "Light green cyan to vivid green cyan",
+            "gradient": "linear-gradient(135deg,rgb(122,220,180) 0%,rgb(0,208,130) 100%)",
+            "slug": "light-green-cyan-to-vivid-green-cyan",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous vivid amber to luminous vivid orange",
+            "gradient": "linear-gradient(135deg,rgba(252,185,0,1) 0%,rgba(255,105,0,1) 100%)",
+            "slug": "luminous-vivid-amber-to-luminous-vivid-orange",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous vivid orange to vivid red",
+            "gradient": "linear-gradient(135deg,rgba(255,105,0,1) 0%,rgb(207,46,46) 100%)",
+            "slug": "luminous-vivid-orange-to-vivid-red",
+            "origin": "core"
+        },
+        {
+            "name": "Very light gray to cyan bluish gray",
+            "gradient": "linear-gradient(135deg,rgb(238,238,238) 0%,rgb(169,184,195) 100%)",
+            "slug": "very-light-gray-to-cyan-bluish-gray",
+            "origin": "core"
+        },
+        {
+            "name": "Cool to warm spectrum",
+            "gradient": "linear-gradient(135deg,rgb(74,234,220) 0%,rgb(151,120,209) 20%,rgb(207,42,186) 40%,rgb(238,44,130) 60%,rgb(251,105,98) 80%,rgb(254,248,76) 100%)",
+            "slug": "cool-to-warm-spectrum",
+            "origin": "core"
+        },
+        {
+            "name": "Blush light purple",
+            "gradient": "linear-gradient(135deg,rgb(255,206,236) 0%,rgb(152,150,240) 100%)",
+            "slug": "blush-light-purple",
+            "origin": "core"
+        },
+        {
+            "name": "Blush bordeaux",
+            "gradient": "linear-gradient(135deg,rgb(254,205,165) 0%,rgb(254,45,45) 50%,rgb(107,0,62) 100%)",
+            "slug": "blush-bordeaux",
+            "origin": "core"
+        },
+        {
+            "name": "Luminous dusk",
+            "gradient": "linear-gradient(135deg,rgb(255,203,112) 0%,rgb(199,81,192) 50%,rgb(65,88,208) 100%)",
+            "slug": "luminous-dusk",
+            "origin": "core"
+        },
+        {
+            "name": "Pale ocean",
+            "gradient": "linear-gradient(135deg,rgb(255,245,203) 0%,rgb(182,227,212) 50%,rgb(51,167,181) 100%)",
+            "slug": "pale-ocean",
+            "origin": "core"
+        },
+        {
+            "name": "Electric grass",
+            "gradient": "linear-gradient(135deg,rgb(202,248,128) 0%,rgb(113,206,126) 100%)",
+            "slug": "electric-grass",
+            "origin": "core"
+        },
+        {
+            "name": "Midnight",
+            "gradient": "linear-gradient(135deg,rgb(2,3,129) 0%,rgb(40,116,252) 100%)",
+            "slug": "midnight",
+            "origin": "core"
+        },
+        {
+            "slug": "purple-to-yellow",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--yellow))",
+            "name": "Purple to Yellow"
+        },
+        {
+            "slug": "yellow-to-purple",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--purple))",
+            "name": "Yellow to Purple"
+        },
+        {
+            "slug": "green-to-yellow",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--green), var(--wp--preset--color--yellow))",
+            "name": "Green to Yellow"
+        },
+        {
+            "slug": "yellow-to-green",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--green))",
+            "name": "Yellow to Green"
+        },
+        {
+            "slug": "red-to-yellow",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--yellow))",
+            "name": "Red to Yellow"
+        },
+        {
+            "slug": "yellow-to-red",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--yellow), var(--wp--preset--color--red))",
+            "name": "Yellow to Red"
+        },
+        {
+            "slug": "purple-to-red",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--purple), var(--wp--preset--color--red))",
+            "name": "Purple to Red"
+        },
+        {
+            "slug": "red-to-purple",
+            "gradient": "linear-gradient(160deg, var(--wp--preset--color--red), var(--wp--preset--color--purple))",
+            "name": "Red to Purple"
+        }
+    ],
+    "fontSizes": [
+        {
+            "slug": "extra-small",
+            "size": "16px",
+            "name": "Extra small"
+        },
+        {
+            "slug": "small",
+            "size": "18px",
+            "name": "Small"
+        },
+        {
+            "slug": "normal",
+            "size": "20px",
+            "name": "Normal"
+        },
+        {
+            "slug": "large",
+            "size": "24px",
+            "name": "Large"
+        },
+        {
+            "slug": "extra-large",
+            "size": "40px",
+            "name": "Extra large"
+        },
+        {
+            "slug": "huge",
+            "size": "96px",
+            "name": "Huge"
+        },
+        {
+            "slug": "gigantic",
+            "size": "144px",
+            "name": "Gigantic"
+        }
+    ]
 }

--- a/WordPressKitTests/Utilities/ChecksumUtilTests.swift
+++ b/WordPressKitTests/Utilities/ChecksumUtilTests.swift
@@ -22,4 +22,3 @@ class ChecksumUtilTests: XCTestCase {
         return try! Data(contentsOf: json)
     }
 }
-

--- a/WordPressKitTests/Utilities/ChecksumUtilTests.swift
+++ b/WordPressKitTests/Utilities/ChecksumUtilTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import WordPressKit
+
+class ChecksumUtilTests: XCTestCase {
+    private let blockSettingsNOTThemeJSONResponseFilename = "wp-block-editor-v1-settings-success-NotThemeJSON"
+    private let blockSettingsThemeJSONResponseFilename = "wp-block-editor-v1-settings-success-ThemeJSON"
+    private let siteID = 1
+
+    func testChecksumGeneration() {
+        let firstObject = try! JSONDecoder().decode([RemoteBlockEditorSettings].self, from: mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename))
+        let firstChecksum = ChecksumUtil.checksum(from: firstObject)
+        XCTAssertFalse(firstChecksum.isEmpty)
+
+        let secondObject = try! JSONDecoder().decode([RemoteBlockEditorSettings].self, from: mockedData(withFilename: blockSettingsThemeJSONResponseFilename))
+        let secondChecksum = ChecksumUtil.checksum(from: secondObject)
+        XCTAssertFalse(secondChecksum.isEmpty)
+
+        XCTAssertNotEqual(firstChecksum, secondChecksum)
+    }
+
+    func mockedData(withFilename filename: String) -> Data {
+        let json = Bundle(for: BlockEditorSettingsServiceRemoteTests.self).url(forResource: filename, withExtension: "json")!
+        return try! Data(contentsOf: json)
+    }
+}
+

--- a/WordPressKitTests/Utilities/ChecksumUtilTests.swift
+++ b/WordPressKitTests/Utilities/ChecksumUtilTests.swift
@@ -4,14 +4,13 @@ import XCTest
 class ChecksumUtilTests: XCTestCase {
     private let blockSettingsNOTThemeJSONResponseFilename = "wp-block-editor-v1-settings-success-NotThemeJSON"
     private let blockSettingsThemeJSONResponseFilename = "wp-block-editor-v1-settings-success-ThemeJSON"
-    private let siteID = 1
 
     func testChecksumGeneration() {
-        let firstObject = try! JSONDecoder().decode([RemoteBlockEditorSettings].self, from: mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename))
+        let firstObject = try! JSONDecoder().decode(RemoteBlockEditorSettings.self, from: mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename))
         let firstChecksum = ChecksumUtil.checksum(from: firstObject)
         XCTAssertFalse(firstChecksum.isEmpty)
 
-        let secondObject = try! JSONDecoder().decode([RemoteBlockEditorSettings].self, from: mockedData(withFilename: blockSettingsThemeJSONResponseFilename))
+        let secondObject = try! JSONDecoder().decode(RemoteBlockEditorSettings.self, from: mockedData(withFilename: blockSettingsThemeJSONResponseFilename))
         let secondChecksum = ChecksumUtil.checksum(from: secondObject)
         XCTAssertFalse(secondChecksum.isEmpty)
 
@@ -19,7 +18,7 @@ class ChecksumUtilTests: XCTestCase {
     }
 
     func mockedData(withFilename filename: String) -> Data {
-        let json = Bundle(for: BlockEditorSettingsServiceRemoteTests.self).url(forResource: filename, withExtension: "json")!
+        let json = Bundle(for: ChecksumUtilTests.self).url(forResource: filename, withExtension: "json")!
         return try! Data(contentsOf: json)
     }
 }


### PR DESCRIPTION
### Description
**Fixes** https://github.com/wordpress-mobile/gutenberg-mobile/issues/3163
**Related PRs** 
- `WordPress-iOS` https://github.com/wordpress-mobile/WordPress-iOS/pull/16411
- `Gutenberg-Mobile` https://github.com/wordpress-mobile/gutenberg-mobile/pull/3459
- `Gutenberg` https://github.com/WordPress/gutenberg/pull/30544

## Tests:
📓 This can be tested along side https://github.com/wordpress-mobile/WordPress-iOS/pull/16411

### Regression Tests:
These should be run on a site with "Global Style Settings" disabled or a site that doesn't have WordPress 5.8 installed:

- [x] Default Colors - Check that default colors still load - [steps](https://github.com/wordpress-mobile/test-cases/blob/gss-updates/test-cases/gutenberg/editor-theme.md#tc001) 
- [x] Default Gradients - Check that default gradients still load - [steps](https://github.com/wordpress-mobile/test-cases/blob/gss-updates/test-cases/gutenberg/editor-theme.md#tc002)
- [x] Custom Colors - Check that custom colors load in the editor - [steps](https://github.com/wordpress-mobile/test-cases/blob/gss-updates/test-cases/gutenberg/editor-theme.md#tc003)
- [x] Custom Gradients - Check that custom gradients load in the editor - [steps](https://github.com/wordpress-mobile/test-cases/blob/gss-updates/test-cases/gutenberg/editor-theme.md#tc004)
- [x] Offline Support - [steps](https://github.com/wordpress-mobile/test-cases/blob/gss-updates/test-cases/gutenberg/editor-theme.md#tc005)

### Tests:
These should be run on a site with "Global Style Settings" enabled and a site that has WordPress 5.8 installed:
- [x]  FSE Colors and Gradients - [steps](https://github.com/wordpress-mobile/test-cases/blob/gss-updates/test-cases/gutenberg/editor-theme.md#tc007)
- [x] Offline Support - [steps](https://github.com/wordpress-mobile/test-cases/blob/gss-updates/test-cases/gutenberg/editor-theme.md#tc008)

----- 

- [x] Please check here if your pull request includes additional test coverage.
