### PR TITLE
Add pagination support to Post and Comment Likes endpoints.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ workflows:
           xcode-version: *xcode-version
           podspec-path: *podspec
           bundle-install: true
+          additional-parameters: "--allow-warnings"
       - ios/publish-podspec:
           name: Publish to a8c Spec Repo
           xcode-version: *xcode-version

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.33.0-beta.1"
+  s.version       = "4.34.0-beta.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.h
+++ b/WordPressKit/CommentServiceRemoteREST.h
@@ -83,12 +83,16 @@
  Requests a list of users that liked the comment with the specified ID. Due to
  API limitation, up to 90 users will be returned from the endpoint.
  
- @param commentID The ID for the comment. Cannot be nil.
- @param success The block that will be executed on success. Can be nil.
- @param failure The block that will be executed on failure. Can be nil.
+ @param commentID   The ID for the comment. Cannot be nil.
+ @param count       Number of records to retrieve.
+ @param before      Filter results to Likes before this date/time string. Can be nil.
+ @param success     The block that will be executed on success. Can be nil.
+ @param failure     The block that will be executed on failure. Can be nil.
  */
 - (void)getLikesForCommentID:(NSNumber *)commentID
-                     success:(void (^)(NSArray<RemoteLikeUser *> *))success
-                     failure:(void (^)(NSError *))failure;
+                       count:(NSNumber *)count
+                      before:(NSString * _Nullable)before
+                     success:(void (^ _Nullable)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber * _Nonnull found))success
+                     failure:(void (^ _Nullable)(NSError * _Nullable))failure;
 
 @end

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -390,7 +390,9 @@
 }
 
 - (void)getLikesForCommentID:(NSNumber *)commentID
-                     success:(void (^)(NSArray<RemoteLikeUser *> *))success
+                       count:(NSNumber *)count
+                      before:(NSString *)before
+                     success:(void (^)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber *found))success
                      failure:(void (^)(NSError *))failure
 {
     NSParameterAssert(commentID);
@@ -400,12 +402,25 @@
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
     NSNumber *siteID = self.siteID;
 
+    // If no count provided, default to endpoint max.
+    if (count == 0) {
+        count = @90;
+    }
+    
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{ @"number": count }];
+    
+    if (before != nil) {
+        parameters[@"before"] = before;
+    }
+    
     [self.wordPressComRestApi GET:requestUrl
-                       parameters:nil
+                       parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
             NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
-            success([self remoteUsersFromJSONArray:jsonUsers commentID:commentID siteID:siteID]);
+            NSArray<RemoteLikeUser *> *users = [self remoteUsersFromJSONArray:jsonUsers commentID:commentID siteID:siteID];
+            NSNumber *found = [responseObject numberForKey:@"found"] ?: @0;
+            success(users, found);
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {

--- a/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/PostServiceRemoteREST.h
@@ -63,11 +63,15 @@
  *              endpoint.
  *
  *  @param      postID      The ID for the post. Cannot be nil.
+ *  @param      count       Number of records to retrieve.
+ *  @param      before      Filter results to Likes before this date/time string. Can be nil.
  *  @param      success     The block that will be executed on success. Can be nil.
  *  @param      failure     The block that will be executed on failure. Can be nil.
  */
 - (void)getLikesForPostID:(NSNumber *)postID
-                  success:(void (^)(NSArray<RemoteLikeUser *> *))success
-                  failure:(void (^)(NSError *))failure;
+                    count:(NSNumber *)count
+                   before:(NSString * _Nullable)before
+                  success:(void (^ _Nullable)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber * _Nonnull found))success
+                  failure:(void (^ _Nullable)(NSError * _Nullable))failure;
 
 @end

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -311,22 +311,37 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 }
 
 - (void)getLikesForPostID:(NSNumber *)postID
-                  success:(void (^)(NSArray<RemoteLikeUser *> * _Nonnull))success
+                    count:(NSNumber *)count
+                   before:(NSString *)before
+                  success:(void (^)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber *found))success
                   failure:(void (^)(NSError * _Nullable))failure
 {
     NSParameterAssert(postID);
-    
+
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/likes", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
     NSNumber *siteID = self.siteID;
 
+    // If no count provided, default to endpoint max.
+    if (count == 0) {
+        count = @90;
+    }
+    
+    NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{ @"number": count }];
+    
+    if (before != nil) {
+        parameters[@"before"] = before;
+    }
+    
     [self.wordPressComRestApi GET:requestUrl
-                       parameters:nil
+                       parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
-                NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
-                success([self remoteUsersFromJSONArray:jsonUsers postID:postID siteID:siteID]);
+            NSArray *jsonUsers = responseObject[@"likes"] ?: @[];
+            NSArray<RemoteLikeUser *> *users = [self remoteUsersFromJSONArray:jsonUsers postID:postID siteID:siteID];
+            NSNumber *found = [responseObject numberForKey:@"found"] ?: @0;
+            success(users, found);
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {

--- a/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
@@ -29,8 +29,8 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetching comment likes should succeed")
 
         stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForCommentID(NSNumber(value: commentId), success: { users in
-            guard let user = users?.first else {
+        remote.getLikesForCommentID(NSNumber(value: commentId), count: 0, before: nil, success: { users, totalLikes in
+            guard let user = users.first else {
                 XCTFail("Failed to retrieve mock comment likes")
                 return
             }
@@ -43,6 +43,7 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.bio, "user bio")
             XCTAssertEqual(user.likedCommentID, NSNumber(value: 1))
             XCTAssertEqual(user.likedSiteID, NSNumber(value: 0))
+            XCTAssertEqual(totalLikes, NSNumber(value: 3))
             expect.fulfill()
 
         }, failure: { _ in
@@ -56,7 +57,7 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Failure block should be called when fetching post likes fails")
 
         stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getLikesForCommentID(NSNumber(value: commentId), success: { _ in
+        remote.getLikesForCommentID(NSNumber(value: commentId), count: 0, before: nil, success: { _, _ in
         XCTFail("This callback shouldn't get called")
         }, failure: { error in
             XCTAssertNotNil(error)
@@ -70,9 +71,9 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetching comment likes should succeed")
 
         stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForCommentID(NSNumber(value: commentId), success: { users in
-            guard let userWithPreferredBlog = users?.first,
-                  let userWithoutPreferredBlog = users?.last else {
+        remote.getLikesForCommentID(NSNumber(value: commentId), count: 0, before: nil, success: { users, _ in
+            guard let userWithPreferredBlog = users.first,
+                  let userWithoutPreferredBlog = users.last else {
                 XCTFail("Failed to retrieve mock comment likes")
                 return
             }

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -29,8 +29,8 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetch likes should succeed")
 
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForPostID(NSNumber(value: postId), success: { users in
-            guard let user = users?.first else {
+        remote.getLikesForPostID(NSNumber(value: postId), count: 0, before: nil, success: { users, totalLikes in
+            guard let user = users.first else {
                 XCTFail("Failed to retrieve mock post likes")
                 return
             }
@@ -43,6 +43,7 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(user.bio, "user bio")
             XCTAssertEqual(user.likedPostID, NSNumber(value: 1))
             XCTAssertEqual(user.likedSiteID, NSNumber(value: 0))
+            XCTAssertEqual(totalLikes, NSNumber(value: 3))
             expect.fulfill()
 
         }, failure: { _ in
@@ -56,7 +57,7 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Failure block should be called when fetching post likes fails")
 
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getLikesForPostID(NSNumber(value: postId), success: { _ in
+        remote.getLikesForPostID(NSNumber(value: postId), count: 0, before: nil, success: { _, _ in
         XCTFail("This callback shouldn't get called")
         }, failure: { error in
             XCTAssertNotNil(error)
@@ -70,9 +71,9 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetch likes should succeed")
 
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForPostID(NSNumber(value: postId), success: { users in
-            guard let userWithPreferredBlog = users?.first,
-                  let userWithoutPreferredBlog = users?.last else {
+        remote.getLikesForPostID(NSNumber(value: postId), count: 0, before: nil, success: { users, _ in
+            guard let userWithPreferredBlog = users.first,
+                  let userWithoutPreferredBlog = users.last else {
                 XCTFail("Failed to retrieve mock post likes")
                 return
             }


### PR DESCRIPTION
### Description

Ref: n/a
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16518

This adds pagination support to Post and Comment Likes endpoints. Both `getLikesFor` methods now accept two new params:
- `count`: Number of records to retrieve. Used for the `number` endpoint param.
- `before`: String version of a date/time to fetch likes before. Used for the `before` endpoint param.

### Testing Details

Can be tested with referenced WPiOS PR.

- [x] Please check here if your pull request includes additional test coverage.
