### PR TITLE
Specify pointer nullability types

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.34.0-beta.1"
+  s.version       = "4.34.0-beta.2"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.h
+++ b/WordPressKit/CommentServiceRemoteREST.h
@@ -19,78 +19,78 @@
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
-- (void)syncHierarchicalCommentsForPost:(NSNumber *)postID
+- (void)syncHierarchicalCommentsForPost:(NSNumber * _Nonnull)postID
                                    page:(NSUInteger)page
                                  number:(NSUInteger)number
-                                success:(void (^)(NSArray *comments))success
-                                failure:(void (^)(NSError *error))failure;
+                                success:(void (^ _Nullable)(NSArray * _Nonnull comments))success
+                                failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  Update a comment with a commentID
  */
-- (void)updateCommentWithID:(NSNumber *)commentID
-                    content:(NSString *)content
-                    success:(void (^)(void))success
-                    failure:(void (^)(NSError *error))failure;
+- (void)updateCommentWithID:(NSNumber * _Nonnull)commentID
+                    content:(NSString * _Nonnull)content
+                    success:(void (^ _Nullable)(void))success
+                    failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  Adds a reply to a post with postID
  */
-- (void)replyToPostWithID:(NSNumber *)postID
-                  content:(NSString *)content
-                  success:(void (^)(RemoteComment *comment))success
-                  failure:(void (^)(NSError *error))failure;
+- (void)replyToPostWithID:(NSNumber * _Nonnull)postID
+                  content:(NSString * _Nonnull)content
+                  success:(void (^ _Nullable)(RemoteComment * _Nonnull comment))success
+                  failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  Adds a reply to a comment with commentID.
  */
-- (void)replyToCommentWithID:(NSNumber *)commentID
-                     content:(NSString *)content
-                     success:(void (^)(RemoteComment *comment))success
-                     failure:(void (^)(NSError *error))failure;
+- (void)replyToCommentWithID:(NSNumber * _Nonnull)commentID
+                     content:(NSString * _Nonnull)content
+                     success:(void (^ _Nullable)(RemoteComment * _Nonnull comment))success
+                     failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  Moderate a comment with a commentID
  */
-- (void)moderateCommentWithID:(NSNumber *)commentID
-                       status:(NSString *)status
-                      success:(void (^)(void))success
-                      failure:(void (^)(NSError *error))failure;
+- (void)moderateCommentWithID:(NSNumber * _Nonnull)commentID
+                       status:(NSString * _Nonnull)status
+                      success:(void (^ _Nullable)(void))success
+                      failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  Trashes a comment with a commentID
  */
-- (void)trashCommentWithID:(NSNumber *)commentID
-                   success:(void (^)(void))success
-                   failure:(void (^)(NSError *error))failure;
+- (void)trashCommentWithID:(NSNumber * _Nonnull)commentID
+                   success:(void (^ _Nullable)(void))success
+                   failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  Like a comment with a commentID
  */
-- (void)likeCommentWithID:(NSNumber *)commentID
-                  success:(void (^)(void))success
-                  failure:(void (^)(NSError *error))failure;
+- (void)likeCommentWithID:(NSNumber * _Nonnull)commentID
+                  success:(void (^ _Nullable)(void))success
+                  failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 
 /**
  Unlike a comment with a commentID
  */
-- (void)unlikeCommentWithID:(NSNumber *)commentID
-                    success:(void (^)(void))success
-                    failure:(void (^)(NSError *error))failure;
+- (void)unlikeCommentWithID:(NSNumber * _Nonnull)commentID
+                    success:(void (^ _Nullable)(void))success
+                    failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  Requests a list of users that liked the comment with the specified ID. Due to
  API limitation, up to 90 users will be returned from the endpoint.
  
  @param commentID   The ID for the comment. Cannot be nil.
- @param count       Number of records to retrieve.
+ @param count       Number of records to retrieve. Cannot be nil. If 0, will default to endpoint max.
  @param before      Filter results to Likes before this date/time string. Can be nil.
  @param success     The block that will be executed on success. Can be nil.
  @param failure     The block that will be executed on failure. Can be nil.
  */
-- (void)getLikesForCommentID:(NSNumber *)commentID
-                       count:(NSNumber *)count
+- (void)getLikesForCommentID:(NSNumber * _Nonnull)commentID
+                       count:(NSNumber * _Nonnull)count
                       before:(NSString * _Nullable)before
                      success:(void (^ _Nullable)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber * _Nonnull found))success
                      failure:(void (^ _Nullable)(NSError * _Nullable))failure;

--- a/WordPressKit/CommentServiceRemoteREST.h
+++ b/WordPressKit/CommentServiceRemoteREST.h
@@ -22,8 +22,8 @@
 - (void)syncHierarchicalCommentsForPost:(NSNumber * _Nonnull)postID
                                    page:(NSUInteger)page
                                  number:(NSUInteger)number
-                                success:(void (^ _Nullable)(NSArray * _Nonnull comments))success
-                                failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                                success:(void (^ _Nullable)(NSArray * _Nullable comments))success
+                                failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  Update a comment with a commentID
@@ -31,23 +31,23 @@
 - (void)updateCommentWithID:(NSNumber * _Nonnull)commentID
                     content:(NSString * _Nonnull)content
                     success:(void (^ _Nullable)(void))success
-                    failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                    failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  Adds a reply to a post with postID
  */
 - (void)replyToPostWithID:(NSNumber * _Nonnull)postID
                   content:(NSString * _Nonnull)content
-                  success:(void (^ _Nullable)(RemoteComment * _Nonnull comment))success
-                  failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                  success:(void (^ _Nullable)(RemoteComment * _Nullable comment))success
+                  failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  Adds a reply to a comment with commentID.
  */
 - (void)replyToCommentWithID:(NSNumber * _Nonnull)commentID
                      content:(NSString * _Nonnull)content
-                     success:(void (^ _Nullable)(RemoteComment * _Nonnull comment))success
-                     failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                     success:(void (^ _Nullable)(RemoteComment * _Nullable comment))success
+                     failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  Moderate a comment with a commentID
@@ -55,21 +55,21 @@
 - (void)moderateCommentWithID:(NSNumber * _Nonnull)commentID
                        status:(NSString * _Nonnull)status
                       success:(void (^ _Nullable)(void))success
-                      failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                      failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  Trashes a comment with a commentID
  */
 - (void)trashCommentWithID:(NSNumber * _Nonnull)commentID
                    success:(void (^ _Nullable)(void))success
-                   failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                   failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  Like a comment with a commentID
  */
 - (void)likeCommentWithID:(NSNumber * _Nonnull)commentID
                   success:(void (^ _Nullable)(void))success
-                  failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                  failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 
 /**
@@ -77,7 +77,7 @@
  */
 - (void)unlikeCommentWithID:(NSNumber * _Nonnull)commentID
                     success:(void (^ _Nullable)(void))success
-                    failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                    failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  Requests a list of users that liked the comment with the specified ID. Due to

--- a/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/PostServiceRemoteREST.h
@@ -24,8 +24,8 @@
 - (void)createPost:(RemotePost * _Nonnull)post
          withMedia:(RemoteMedia * _Nullable)media
    requestEnqueued:(void (^ _Nullable)(NSNumber * _Nonnull taskID))requestEnqueued
-           success:(void (^ _Nullable)(RemotePost * _Nonnull))success
-           failure:(void (^ _Nullable)(NSError * _Nonnull))failure;
+           success:(void (^ _Nullable)(RemotePost * _Nullable))success
+           failure:(void (^ _Nullable)(NSError * _Nullable))failure;
 
 /**
  *  @brief      Saves a post.
@@ -39,8 +39,8 @@
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)autoSave:(RemotePost * _Nonnull)post
-         success:(void (^ _Nullable)(RemotePost * _Nonnull post, NSString * _Nonnull previewURL))success
-         failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+         success:(void (^ _Nullable)(RemotePost * _Nullable post, NSString * _Nullable previewURL))success
+         failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  *  @brief      Get autosave revision of a post.
@@ -53,8 +53,8 @@
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
 - (void)getAutoSaveForPost:(RemotePost * _Nonnull)post
-                   success:(void (^ _Nullable)(RemotePost * _Nonnull))success
-                   failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
+                   success:(void (^ _Nullable)(RemotePost * _Nullable))success
+                   failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**
  *  @brief      Requests a list of users that liked the post with the specified ID.

--- a/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/PostServiceRemoteREST.h
@@ -21,11 +21,11 @@
  *  @param  success         The block that will be executed on success.  Can be nil.
  *  @param  failure         The block that will be executed on failure.  Can be nil.
  */
-- (void)createPost:(RemotePost *)post
-         withMedia:(RemoteMedia *)media
-   requestEnqueued:(void (^)(NSNumber *taskID))requestEnqueued
-           success:(void (^)(RemotePost *))success
-           failure:(void (^)(NSError *))failure;
+- (void)createPost:(RemotePost * _Nonnull)post
+         withMedia:(RemoteMedia * _Nullable)media
+   requestEnqueued:(void (^ _Nullable)(NSNumber * _Nonnull taskID))requestEnqueued
+           success:(void (^ _Nullable)(RemotePost * _Nonnull))success
+           failure:(void (^ _Nullable)(NSError * _Nonnull))failure;
 
 /**
  *  @brief      Saves a post.
@@ -38,9 +38,9 @@
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
-- (void)autoSave:(RemotePost *)post
-         success:(void (^)(RemotePost *post, NSString *previewURL))success
-         failure:(void (^)(NSError *error))failure;
+- (void)autoSave:(RemotePost * _Nonnull)post
+         success:(void (^ _Nullable)(RemotePost * _Nonnull post, NSString * _Nonnull previewURL))success
+         failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  *  @brief      Get autosave revision of a post.
@@ -52,9 +52,9 @@
  *  @param      success     The block that will be executed on success.  Can be nil.
  *  @param      failure     The block that will be executed on failure.  Can be nil.
  */
-- (void)getAutoSaveForPost:(RemotePost *)post
-                   success:(void (^)(RemotePost *))success
-                   failure:(void (^)(NSError *error))failure;
+- (void)getAutoSaveForPost:(RemotePost * _Nonnull)post
+                   success:(void (^ _Nullable)(RemotePost * _Nonnull))success
+                   failure:(void (^ _Nullable)(NSError * _Nonnull error))failure;
 
 /**
  *  @brief      Requests a list of users that liked the post with the specified ID.
@@ -63,13 +63,13 @@
  *              endpoint.
  *
  *  @param      postID      The ID for the post. Cannot be nil.
- *  @param      count       Number of records to retrieve.
+ *  @param      count       Number of records to retrieve. Cannot be nil. If 0, will default to endpoint max.
  *  @param      before      Filter results to Likes before this date/time string. Can be nil.
  *  @param      success     The block that will be executed on success. Can be nil.
  *  @param      failure     The block that will be executed on failure. Can be nil.
  */
-- (void)getLikesForPostID:(NSNumber *)postID
-                    count:(NSNumber *)count
+- (void)getLikesForPostID:(NSNumber * _Nonnull)postID
+                    count:(NSNumber * _Nonnull)count
                    before:(NSString * _Nullable)before
                   success:(void (^ _Nullable)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber * _Nonnull found))success
                   failure:(void (^ _Nullable)(NSError * _Nullable))failure;

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -253,16 +253,6 @@
                 failure:^(NSError *error) {}];
 }
 
-- (void)testThatAutoSavePostThrowsExceptionWithoutPost
-{
-    PostServiceRemoteREST *service = nil;
-    
-    XCTAssertNoThrow(service = [self service]);
-    XCTAssertThrows([service autoSave:nil
-                                success:^(RemotePost *post, NSString *previewURL) {}
-                                failure:^(NSError *error) {}]);
-}
-
 - (void)testThatGetAutoSaveForPostWorks
 {
     NSNumber *dotComID = @10;


### PR DESCRIPTION
### Description

Fixes #n/a
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16530

This specifies `_Nullable`/`_Nonnull` for pointers to silence the warnings.

### Testing Details
- Verify there are no longer nullability warnings. Ex:
```
/WordPressKit.framework/Headers/PostServiceRemoteREST.h:24:32: note: insert '_Nullable' if the pointer may be null
/WordPressKit.framework/Headers/PostServiceRemoteREST.h:24:32: note: insert '_Nonnull' if the pointer should never be null
```
- Functionality can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
