### PR TITLE
Likes: add ability to exclude user IDs from Likes responses.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.34.0-beta.2"
+  s.version       = "4.34.0-beta.3"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.h
+++ b/WordPressKit/CommentServiceRemoteREST.h
@@ -83,15 +83,17 @@
  Requests a list of users that liked the comment with the specified ID. Due to
  API limitation, up to 90 users will be returned from the endpoint.
  
- @param commentID   The ID for the comment. Cannot be nil.
- @param count       Number of records to retrieve. Cannot be nil. If 0, will default to endpoint max.
- @param before      Filter results to Likes before this date/time string. Can be nil.
- @param success     The block that will be executed on success. Can be nil.
- @param failure     The block that will be executed on failure. Can be nil.
+ @param commentID       The ID for the comment. Cannot be nil.
+ @param count           Number of records to retrieve. Cannot be nil. If 0, will default to endpoint max.
+ @param before          Filter results to Likes before this date/time string. Can be nil.
+ @param excludeUserIDs  Array of user IDs to exclude from response. Can be nil.
+ @param success         The block that will be executed on success. Can be nil.
+ @param failure         The block that will be executed on failure. Can be nil.
  */
 - (void)getLikesForCommentID:(NSNumber * _Nonnull)commentID
                        count:(NSNumber * _Nonnull)count
                       before:(NSString * _Nullable)before
+              excludeUserIDs:(NSArray<NSNumber *> * _Nullable)excludeUserIDs
                      success:(void (^ _Nullable)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber * _Nonnull found))success
                      failure:(void (^ _Nullable)(NSError * _Nullable))failure;
 

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -392,6 +392,7 @@
 - (void)getLikesForCommentID:(NSNumber *)commentID
                        count:(NSNumber *)count
                       before:(NSString *)before
+              excludeUserIDs:(NSArray<NSNumber *> *)excludeUserIDs
                      success:(void (^)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber *found))success
                      failure:(void (^)(NSError *))failure
 {
@@ -409,10 +410,14 @@
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{ @"number": count }];
     
-    if (before != nil) {
+    if (before) {
         parameters[@"before"] = before;
     }
     
+    if (excludeUserIDs) {
+        parameters[@"exclude"] = excludeUserIDs;
+    }
+
     [self.wordPressComRestApi GET:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {

--- a/WordPressKit/PostServiceRemoteREST.h
+++ b/WordPressKit/PostServiceRemoteREST.h
@@ -62,15 +62,17 @@
  *  @discussion Due to the API limitation, up to 90 users will be returned from the
  *              endpoint.
  *
- *  @param      postID      The ID for the post. Cannot be nil.
- *  @param      count       Number of records to retrieve. Cannot be nil. If 0, will default to endpoint max.
- *  @param      before      Filter results to Likes before this date/time string. Can be nil.
- *  @param      success     The block that will be executed on success. Can be nil.
- *  @param      failure     The block that will be executed on failure. Can be nil.
+ *  @param      postID          The ID for the post. Cannot be nil.
+ *  @param      count           Number of records to retrieve. Cannot be nil. If 0, will default to endpoint max.
+ *  @param      before          Filter results to Likes before this date/time string. Can be nil.
+ *  @param      excludeUserIDs  Array of user IDs to exclude from response. Can be nil.
+ *  @param      success         The block that will be executed on success. Can be nil.
+ *  @param      failure         The block that will be executed on failure. Can be nil.
  */
 - (void)getLikesForPostID:(NSNumber * _Nonnull)postID
                     count:(NSNumber * _Nonnull)count
                    before:(NSString * _Nullable)before
+           excludeUserIDs:(NSArray<NSNumber *> * _Nullable)excludeUserIDs
                   success:(void (^ _Nullable)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber * _Nonnull found))success
                   failure:(void (^ _Nullable)(NSError * _Nullable))failure;
 

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -331,11 +331,11 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{ @"number": count }];
     
-    if (before != nil) {
+    if (before) {
         parameters[@"before"] = before;
     }
     
-    if (excludeUserIDs != nil) {
+    if (excludeUserIDs) {
         parameters[@"exclude"] = excludeUserIDs;
     }
 

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -313,6 +313,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 - (void)getLikesForPostID:(NSNumber *)postID
                     count:(NSNumber *)count
                    before:(NSString *)before
+           excludeUserIDs:(NSArray<NSNumber *> *)excludeUserIDs
                   success:(void (^)(NSArray<RemoteLikeUser *> * _Nonnull users, NSNumber *found))success
                   failure:(void (^)(NSError * _Nullable))failure
 {
@@ -334,6 +335,10 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
         parameters[@"before"] = before;
     }
     
+    if (excludeUserIDs != nil) {
+        parameters[@"exclude"] = excludeUserIDs;
+    }
+
     [self.wordPressComRestApi GET:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {

--- a/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTLikesTests.swift
@@ -29,7 +29,11 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetching comment likes should succeed")
 
         stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForCommentID(NSNumber(value: commentId), count: 0, before: nil, success: { users, totalLikes in
+        remote.getLikesForCommentID(NSNumber(value: commentId),
+                                    count: 0,
+                                    before: nil,
+                                    excludeUserIDs: nil,
+                                    success: { users, totalLikes in
             guard let user = users.first else {
                 XCTFail("Failed to retrieve mock comment likes")
                 return
@@ -57,7 +61,11 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Failure block should be called when fetching post likes fails")
 
         stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getLikesForCommentID(NSNumber(value: commentId), count: 0, before: nil, success: { _, _ in
+        remote.getLikesForCommentID(NSNumber(value: commentId),
+                                    count: 0,
+                                    before: nil,
+                                    excludeUserIDs: nil,
+                                    success: { _, _ in
         XCTFail("This callback shouldn't get called")
         }, failure: { error in
             XCTAssertNotNil(error)
@@ -71,7 +79,11 @@ final class CommentServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetching comment likes should succeed")
 
         stubRemoteResponse(commentLikesEndpoint, filename: fetchCommentLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForCommentID(NSNumber(value: commentId), count: 0, before: nil, success: { users, _ in
+        remote.getLikesForCommentID(NSNumber(value: commentId),
+                                    count: 0,
+                                    before: nil,
+                                    excludeUserIDs: nil,
+                                    success: { users, _ in
             guard let userWithPreferredBlog = users.first,
                   let userWithoutPreferredBlog = users.last else {
                 XCTFail("Failed to retrieve mock comment likes")

--- a/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
+++ b/WordPressKitTests/PostServiceRemoteRESTLikesTests.swift
@@ -29,7 +29,11 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetch likes should succeed")
 
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForPostID(NSNumber(value: postId), count: 0, before: nil, success: { users, totalLikes in
+        remote.getLikesForPostID(NSNumber(value: postId),
+                                 count: 0,
+                                 before: nil,
+                                 excludeUserIDs: nil,
+                                 success: { users, totalLikes in
             guard let user = users.first else {
                 XCTFail("Failed to retrieve mock post likes")
                 return
@@ -57,7 +61,11 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Failure block should be called when fetching post likes fails")
 
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesFailureFilename, contentType: .ApplicationJSON, status: 403)
-        remote.getLikesForPostID(NSNumber(value: postId), count: 0, before: nil, success: { _, _ in
+        remote.getLikesForPostID(NSNumber(value: postId),
+                                 count: 0,
+                                 before: nil,
+                                 excludeUserIDs: nil,
+                                 success: { _, _ in
         XCTFail("This callback shouldn't get called")
         }, failure: { error in
             XCTAssertNotNil(error)
@@ -71,7 +79,11 @@ final class PostServiceRemoteRESTLikesTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Fetch likes should succeed")
 
         stubRemoteResponse(postLikesEndpoint, filename: fetchPostLikesSuccessFilename, contentType: .ApplicationJSON)
-        remote.getLikesForPostID(NSNumber(value: postId), count: 0, before: nil, success: { users, _ in
+        remote.getLikesForPostID(NSNumber(value: postId),
+                                 count: 0,
+                                 before: nil,
+                                 excludeUserIDs: nil,
+                                 success: { users, _ in
             guard let userWithPreferredBlog = users.first,
                   let userWithoutPreferredBlog = users.last else {
                 XCTFail("Failed to retrieve mock post likes")


### PR DESCRIPTION
### Description

WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16553

This adds the ability to exclude user IDs from Likes responses.

### Testing Details

Can be tested with linked WPiOS PR.

- [x] Please check here if your pull request includes additional test coverage.
