### PR TITLE
pass on the statusCode if one exists

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.34.1"
+  s.version       = "4.35.0-beta.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -301,7 +301,6 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
     private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
         let responseCode = statusCode ?? error.code
-
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -300,7 +300,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     @objc public static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
 
     private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
-        let responseCode = statusCode ?? error.code
+        let responseCode = statusCode == 403 ? 403 : error.code
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -300,12 +300,14 @@ open class WordPressOrgXMLRPCApi: NSObject {
     @objc public static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
 
     private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
+        let responseCode = ( (statusCode != nil) ? statusCode! : error.code );
+        
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyDataString] = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyStatusCode] = statusCode
-            return NSError(domain: error.domain, code: error.code, userInfo: userInfo as? [String: Any])
+            return NSError(domain: error.domain, code: responseCode, userInfo: userInfo as? [String: Any])
         }
         return error
     }

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -300,8 +300,8 @@ open class WordPressOrgXMLRPCApi: NSObject {
     @objc public static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
 
     private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
-        let responseCode = ( (statusCode != nil) ? statusCode! : error.code );
-        
+        let responseCode = statusCode ?? error.code
+
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data


### PR DESCRIPTION
### Description

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16337

This Pr makes sure that we pass on the statusCode to the error object. 
This helps code down the line know what the response code is and act accordingly. 

Before:
<img  width="200" src="https://user-images.githubusercontent.com/115071/119910903-0c7e0e80-bf0d-11eb-87cf-e44b82c5dee7.png" />

After:
<img  width="200" src="https://user-images.githubusercontent.com/115071/119910919-16a00d00-bf0d-11eb-9192-7c553f278c33.png" />

### Testing Details
Apply this patch and build the WordPress App. 

Try to add a new .org site.  
Type in the wrong username and password. Notice that the error makes sense.

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

- [x] Please check here if your pull request includes additional test coverage.
