### PR TITLE
Issue/14055 - Mark referrer as spam

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.35.0"
+  s.version       = "4.36.0-beta.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		931924241F1662FA0069CBCC /* JSONLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931924231F1662FA0069CBCC /* JSONLoader.swift */; };
 		9368C7851EC5EF1B0092CE8E /* WordPressKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9368C77B1EC5EF1B0092CE8E /* WordPressKit.framework */; };
 		9368C78C1EC5EF1B0092CE8E /* WordPressKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9368C77E1EC5EF1B0092CE8E /* WordPressKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		937250EC267A15060086075F /* stats-referrer-mark-as-spam.json in Resources */ = {isa = PBXBuildFile; fileRef = 937250EB267A15060086075F /* stats-referrer-mark-as-spam.json */; };
 		93AB06041EE8838400EF8764 /* RemoteTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AB06031EE8838400EF8764 /* RemoteTestCase.swift */; };
 		93BD273B1EE73282002BB00B /* AccountServiceRemote.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BD27381EE73282002BB00B /* AccountServiceRemote.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93BD273C1EE73282002BB00B /* AccountServiceRemoteREST.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BD27391EE73282002BB00B /* AccountServiceRemoteREST.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -975,6 +976,7 @@
 		9368C77F1EC5EF1B0092CE8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9368C7841EC5EF1B0092CE8E /* WordPressKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WordPressKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9368C78B1EC5EF1B0092CE8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		937250EB267A15060086075F /* stats-referrer-mark-as-spam.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-referrer-mark-as-spam.json"; sourceTree = "<group>"; };
 		93AB06031EE8838400EF8764 /* RemoteTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteTestCase.swift; sourceTree = "<group>"; };
 		93BD27381EE73282002BB00B /* AccountServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountServiceRemote.h; sourceTree = "<group>"; };
 		93BD27391EE73282002BB00B /* AccountServiceRemoteREST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountServiceRemoteREST.h; sourceTree = "<group>"; };
@@ -1845,6 +1847,7 @@
 				40819770221DFDB600A298E4 /* stats-posts-data.json */,
 				40819774221E497C00A298E4 /* stats-published-posts.json */,
 				404057DB221C9FD70060250C /* stats-referrer-data.json */,
+				937250EB267A15060086075F /* stats-referrer-mark-as-spam.json */,
 				404057D7221C98690060250C /* stats-clicks-data.json */,
 				404057D3221C5FC30060250C /* stats-countries-data.json */,
 				404057CF221C46780060250C /* stats-videos-data.json */,
@@ -2458,6 +2461,7 @@
 				BA5AEF6B24923DAC007D8E49 /* plugin-state-jetpack.json in Resources */,
 				436D564C211CCCB900CEAA33 /* domain-contact-information-response-success.json in Resources */,
 				FFA4D4AD2423B1FE00BF5180 /* wp-admin-post-new.html in Resources */,
+				937250EC267A15060086075F /* stats-referrer-mark-as-spam.json in Resources */,
 				BA9A7F7F24C6895600925E81 /* plugin-directory-jetpack-beta.json in Resources */,
 				E6B0461425E5B6F500DF6F4F /* sites-invites-links-generate.json in Resources */,
 				93BD275A1EE73442002BB00B /* is-available-email-success.json in Resources */,

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -59,6 +59,28 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
         })
     }
 
+    /// Used to mark or unmark referrer as spam, depending of the current value.
+    /// - parameters:
+    ///   - referrerDomain: A referrer's domain.
+    ///   - currentValue: Current value of the `isSpam` referrer's property.
+    public func toggleSpamState(for referrerDomain: String,
+                                currentValue: Bool,
+                                success: @escaping () -> Void,
+                                failure: @escaping (Error) -> Void) {
+        let path: String
+        if currentValue {
+            path = self.path(forEndpoint: "sites/\(siteID)/stats/referrers/spam/delete?domain=\(referrerDomain)", withVersion: ._1_1)
+        } else {
+            path = self.path(forEndpoint: "sites/\(siteID)/stats/referrers/spam/new?domain=\(referrerDomain)", withVersion: ._1_1)
+        }
+
+        wordPressComRestApi.POST(path, parameters: nil) { object, _ in
+            success()
+        } failure: { error, _ in
+            failure(error)
+        }
+    }
+
     /// Used to fetch data about site over a specific timeframe.
     /// - parameters:
     ///   - period: An enum representing whether either a day, a week, a month or a year worth's of data.

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -4,7 +4,7 @@ import Foundation
 // one and rename this to not have "V2" in it, but we want to keep the old one around
 // for a while still.
 
-public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
+open class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
 
     public enum ResponseError: Error {
         case decodingFailure
@@ -67,7 +67,7 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
     /// - parameters:
     ///   - referrerDomain: A referrer's domain.
     ///   - currentValue: Current value of the `isSpam` referrer's property.
-    public func toggleSpamState(for referrerDomain: String,
+    open func toggleSpamState(for referrerDomain: String,
                                 currentValue: Bool,
                                 success: @escaping () -> Void,
                                 failure: @escaping (Error) -> Void) {

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -10,6 +10,10 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
         case decodingFailure
     }
 
+    public enum MarkAsSpamResponseError: Error {
+        case unsuccessful
+    }
+
     public let siteID: Int
     private let siteTimezone: TimeZone
 

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -297,7 +297,7 @@ private extension StatsServiceRemoteV2 {
         return self.path(forEndpoint: "sites/\(siteID)/stats/referrers/spam/\(action)?domain=\(referrerDomain)", withVersion: ._1_1)
     }
 
-    struct MarkAsSpamResponse  {
+    struct MarkAsSpamResponse {
         let success: Bool
 
         init?(dictionary: [String: AnyObject]) {

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -72,7 +72,7 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
                                 success: @escaping () -> Void,
                                 failure: @escaping (Error) -> Void) {
         let path = pathForToggleSpamStateEndpoint(referrerDomain: referrerDomain, markAsSpam: !currentValue)
-        wordPressComRestApi.POST(path, parameters: nil) { object, _ in
+        wordPressComRestApi.POST(path, parameters: nil, success: { object, _ in
             guard
                 let dictionary = object as? [String: AnyObject],
                 let response = MarkAsSpamResponse(dictionary: dictionary) else {
@@ -86,9 +86,9 @@ public class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
             }
 
             success()
-        } failure: { error, _ in
+        }, failure: { error, _ in
             failure(error)
-        }
+        })
     }
 
     /// Used to fetch data about site over a specific timeframe.

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -283,6 +283,26 @@ extension StatsServiceRemoteV2 {
 
 }
 
+// MARK: - Mark referrer as spam helpers
+
+private extension StatsServiceRemoteV2 {
+    func pathForToggleSpamStateEndpoint(referrerDomain: String, markAsSpam: Bool) -> String {
+        let action = markAsSpam ? "new" : "delete"
+        return self.path(forEndpoint: "sites/\(siteID)/stats/referrers/spam/\(action)?domain=\(referrerDomain)", withVersion: ._1_1)
+    }
+
+    struct MarkAsSpamResponse  {
+        let success: Bool
+
+        init?(dictionary: [String: AnyObject]) {
+            guard let value = dictionary["success"] as? Bool else {
+                return nil
+            }
+            self.success = value
+        }
+    }
+}
+
 // This serves both as a way to get the query properties in a "nice" way,
 // but also as a way to narrow down the generic type in `getInsight(completion:)` method.
 public protocol StatsInsightData {

--- a/WordPressKit/Time Interval/StatsTopReferrersTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopReferrersTimeIntervalData.swift
@@ -5,7 +5,7 @@ public struct StatsTopReferrersTimeIntervalData {
     public let totalReferrerViewsCount: Int
     public let otherReferrerViewsCount: Int
 
-    public let referrers: [StatsReferrer]
+    public var referrers: [StatsReferrer]
 
     public init(period: StatsPeriodUnit,
                 periodEndDate: Date,
@@ -26,7 +26,8 @@ public struct StatsReferrer {
     public let url: URL?
     public let iconURL: URL?
 
-    public let children: [StatsReferrer]
+    public var children: [StatsReferrer]
+    public var isSpam = false
 
     public init(title: String,
                 viewsCount: Int,

--- a/WordPressKitTests/Mock Data/stats-referrer-mark-as-spam.json
+++ b/WordPressKitTests/Mock Data/stats-referrer-mark-as-spam.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/WordPressKitTests/StatsRemoteV2Tests.swift
+++ b/WordPressKitTests/StatsRemoteV2Tests.swift
@@ -22,6 +22,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     let getPublishedPostsFilename = "stats-published-posts.json"
     let getDownloadsDataFilename = "stats-file-downloads.json"
     let getPostsDetailsFilename = "stats-post-details.json"
+    let toggleSpamStateResponseFilename = "stats-referrer-mark-as-spam.json"
 
     // MARK: - Properties
 
@@ -37,6 +38,11 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     var sitePublishedPostsEndpoint: String { return "sites/\(siteID)/posts/" }
     var siteDownloadsDataEndpoint: String { return "sites/\(siteID)/stats/file-downloads/" }
     var sitePostDetailsEndpoint: String { return "sites/\(siteID)/stats/post/9001" }
+
+    func toggleSpamStateEndpoint(for referrerDomain: String, markAsSpam: Bool) -> String {
+        let action = markAsSpam ? "new" : "delete"
+        return "sites/\(siteID)/stats/referrers/spam/\(action)?domain=\(referrerDomain)"
+    }
 
     var remote: StatsServiceRemoteV2!
 
@@ -611,6 +617,36 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(summary?.summaryData[9].periodStartDate, nineMonthsFromMay1)
 
             expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testMarkReferrerAsSpam() {
+        let expect = expectation(description: "It should mark referrer as spam")
+
+        let aDomain = "domain.com"
+        stubRemoteResponse(toggleSpamStateEndpoint(for: aDomain, markAsSpam: true), filename: toggleSpamStateResponseFilename, contentType: .ApplicationJSON)
+
+        remote.toggleSpamState(for: aDomain, currentValue: false) {
+            expect.fulfill()
+        } failure: { error in
+            XCTFail("Marking referrer as spam failed, reason: \(error.localizedDescription)")
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testUnmarkReferrerAsSpam() {
+        let expect = expectation(description: "It should unmark referrer as spam")
+
+        let aDomain = "domain.com"
+        stubRemoteResponse(toggleSpamStateEndpoint(for: aDomain, markAsSpam: false), filename: toggleSpamStateResponseFilename, contentType: .ApplicationJSON)
+
+        remote.toggleSpamState(for: aDomain, currentValue: true) {
+            expect.fulfill()
+        } failure: { error in
+            XCTFail("Unmarking referrer as spam failed, reason: \(error.localizedDescription)")
         }
 
         waitForExpectations(timeout: timeout, handler: nil)

--- a/WordPressKitTests/StatsRemoteV2Tests.swift
+++ b/WordPressKitTests/StatsRemoteV2Tests.swift
@@ -628,11 +628,11 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         let aDomain = "domain.com"
         stubRemoteResponse(toggleSpamStateEndpoint(for: aDomain, markAsSpam: true), filename: toggleSpamStateResponseFilename, contentType: .ApplicationJSON)
 
-        remote.toggleSpamState(for: aDomain, currentValue: false) {
+        remote.toggleSpamState(for: aDomain, currentValue: false, success: {
             expect.fulfill()
-        } failure: { error in
+        }, failure: { error in
             XCTFail("Marking referrer as spam failed, reason: \(error.localizedDescription)")
-        }
+        })
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -643,11 +643,11 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         let aDomain = "domain.com"
         stubRemoteResponse(toggleSpamStateEndpoint(for: aDomain, markAsSpam: false), filename: toggleSpamStateResponseFilename, contentType: .ApplicationJSON)
 
-        remote.toggleSpamState(for: aDomain, currentValue: true) {
+        remote.toggleSpamState(for: aDomain, currentValue: true, success: {
             expect.fulfill()
-        } failure: { error in
+        }, failure: { error in
             XCTFail("Unmarking referrer as spam failed, reason: \(error.localizedDescription)")
-        }
+        })
 
         waitForExpectations(timeout: timeout, handler: nil)
     }


### PR DESCRIPTION
### Mark referrer as spam

Part of [#14055](https://github.com/wordpress-mobile/WordPress-iOS/issues/14055)

This PR includes needed changes to the `StatsTopReferrersTimeIntervalData` and `StatsReferrer`, in order to be able to mark referrers as spam. It does so by adding `isSpam: Bool` to the `StatsReferrer`, and by making `children` and `referrers` properties mutable.
Also, a method is added to the `StatsServiceRemoteV2` for marking / unmarking referrers as spam.

- [x] Please check here if your pull request includes additional test coverage.
