### PR TITLE
Merge 4.35.0 into trunk

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.34.1"
+  s.version       = "4.35.0-beta.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.35.0-beta.1"
+  s.version       = "4.35.0"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.34.0"
+  s.version       = "4.34.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/AccountServiceRemoteREST.m
+++ b/WordPressKit/AccountServiceRemoteREST.m
@@ -35,7 +35,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
          failure:(void (^)(NSError *))failure
 {
     if (filterJetpackSites) {
-        [self getBlogsWithParameters:@{@"filters": @"jetpack, atomic"} success:success failure:failure];
+        [self getBlogsWithParameters:@{@"filters": @"jetpack"} success:success failure:failure];
     } else {
         [self getBlogsWithSuccess:success failure:failure];
     }

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -301,7 +301,6 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
     private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
         let responseCode = statusCode ?? error.code
-
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -300,7 +300,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     @objc public static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
 
     private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
-        let responseCode = statusCode ?? error.code
+        let responseCode = statusCode == 403 ? 403 : error.code
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -300,12 +300,14 @@ open class WordPressOrgXMLRPCApi: NSObject {
     @objc public static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
 
     private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
+        let responseCode = ( (statusCode != nil) ? statusCode! : error.code );
+        
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyDataString] = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyStatusCode] = statusCode
-            return NSError(domain: error.domain, code: error.code, userInfo: userInfo as? [String: Any])
+            return NSError(domain: error.domain, code: responseCode, userInfo: userInfo as? [String: Any])
         }
         return error
     }

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -300,8 +300,8 @@ open class WordPressOrgXMLRPCApi: NSObject {
     @objc public static let WordPressOrgXMLRPCApiErrorKeyStatusCode: NSError.UserInfoKey = "WordPressOrgXMLRPCApiErrorKeyStatusCode"
 
     private func convertError(_ error: NSError, data: Data?, statusCode: Int? = nil) -> NSError {
-        let responseCode = ( (statusCode != nil) ? statusCode! : error.code );
-        
+        let responseCode = statusCode ?? error.code
+
         if let data = data {
             var userInfo: [AnyHashable: Any] = error.userInfo
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data


### PR DESCRIPTION
Merges the 4.35.0 changes into `trunk`.

If CI is green, we should be good to merge.

---

This is the first time I create a release as part of the WordPress iOS code freeze. I tried to reverse engineer the process by looking at the Git and PRs history. This is what I've been doing:

1. Bump the version on `develop` (as I couldn't see any recent PR that merged a release branch into `develop`)
2. Tag the version bump commit
3. Push `develop` and the tag
4. Checkout `trunk`, create merge branch, merge `develop` into merge branch
5. Open this PR

I noticed that @jkmassel's PRs don't have a merge commit 🤔 How to you do such a thing?!