### PR TITLE
Removed unnecessary `@objc` annotations from `Country` and `State` entities

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.36.0"
+  s.version       = "4.37.0-beta.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/Country.swift
+++ b/WordPressKit/Country.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc public class Country: NSObject, Codable {
+public class Country: NSObject, Codable {
     public var code: String?
     public var name: String?
 }

--- a/WordPressKit/State.swift
+++ b/WordPressKit/State.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc public class State: NSObject, Codable {
+public class State: NSObject, Codable {
     public var code: String?
     public var name: String?
 }


### PR DESCRIPTION

### Description
Because of this issue https://github.com/woocommerce/woocommerce-ios/pull/4486 we decided with my team that is better to update WordPressKit, removing the `@objc` annotations from `Country` and `State` since they are unnecessary.


### Testing Details
Just run the project and make sure that everything works.


- [ ] Please check here if your pull request includes additional test coverage.
