### PR TITLE
Comments: update Comment fetching and parsing

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.37.0-beta.2"
+  s.version       = "4.37.0-beta.3"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -29,7 +29,6 @@
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
-                                 @"context": @"edit",
                                  @"force": @"wpcom", // Force fetching data from shadow site on Jetpack sites
                                  @"number": @(maximumComments)
                                  }];

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -452,7 +452,6 @@
     comment.authorUrl = jsonDictionary[@"author"][@"URL"];
     comment.authorAvatarURL = [jsonDictionary stringForKeyPath:@"author.avatar_URL"];
     comment.commentID = jsonDictionary[@"ID"];
-    comment.content = jsonDictionary[@"raw_content"];
     comment.date = [NSDate dateWithWordPressComJSONString:jsonDictionary[@"date"]];
     comment.link = jsonDictionary[@"URL"];
     comment.parentID = [jsonDictionary numberForKeyPath:@"parent.ID"];
@@ -463,6 +462,12 @@
     comment.isLiked = [[jsonDictionary numberForKey:@"i_like"] boolValue];
     comment.likeCount = [jsonDictionary numberForKey:@"like_count"];
     comment.canModerate = [[jsonDictionary numberForKey:@"can_moderate"] boolValue];
+
+    // Ref: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/413
+    // The `context:edit` parameter is no longer passed when fetching Comments,
+    // which results in the`content` property containing HTML.
+    // So use the `raw_content` property instead.
+    comment.content = jsonDictionary[@"raw_content"];
 
     return comment;
 }

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -452,7 +452,7 @@
     comment.authorUrl = jsonDictionary[@"author"][@"URL"];
     comment.authorAvatarURL = [jsonDictionary stringForKeyPath:@"author.avatar_URL"];
     comment.commentID = jsonDictionary[@"ID"];
-    comment.content = jsonDictionary[@"content"];
+    comment.content = jsonDictionary[@"raw_content"];
     comment.date = [NSDate dateWithWordPressComJSONString:jsonDictionary[@"date"]];
     comment.link = jsonDictionary[@"URL"];
     comment.parentID = [jsonDictionary numberForKeyPath:@"parent.ID"];

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -462,6 +462,7 @@
     comment.type = jsonDictionary[@"type"];
     comment.isLiked = [[jsonDictionary numberForKey:@"i_like"] boolValue];
     comment.likeCount = [jsonDictionary numberForKey:@"like_count"];
+    comment.canModerate = [[jsonDictionary numberForKey:@"can_moderate"] boolValue];
 
     return comment;
 }

--- a/WordPressKit/Plugin Management/SelfHostedPluginManagementClient.swift
+++ b/WordPressKit/Plugin Management/SelfHostedPluginManagementClient.swift
@@ -141,7 +141,6 @@ public class SelfHostedPluginManagementClient: PluginManagementClient {
                            settingsURL: nil)
     }
 
-
     // MARK: - Unsupported
     public func updatePlugin(pluginID: String, success: @escaping (PluginState) -> Void, failure: @escaping (Error) -> Void) {
         // NOOP - Not supported by the WP.org REST API

--- a/WordPressKit/RemoteComment.h
+++ b/WordPressKit/RemoteComment.h
@@ -16,4 +16,5 @@
 @property (nonatomic, strong) NSString *type;
 @property (nonatomic) BOOL isLiked;
 @property (nonatomic, strong) NSNumber *likeCount;
+@property (nonatomic) BOOL canModerate;
 @end


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/16685
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16768

This updates Comment fetching and parsing:
- Removes the `context:edit` parameter to allow fetching Comments for all user roles.
- Adds the `can_moderate` flag to `RemoteComment`.
-  Use `raw_content` instead of `content` for the Comment's content. The `context:edit` parameter removed the HTML from the `content`. Since that parameter was removed, `content` now contains HTML. So use `raw_content` instead since it does not.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
