### PR TITLE
Add reason property to JetpackScan

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.37.0-beta.4"
+  s.version       = "4.37.0-beta.5"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/Jetpack Scan/JetpackScan.swift
+++ b/WordPressKit/Jetpack Scan/JetpackScan.swift
@@ -24,6 +24,9 @@ public struct JetpackScan: Decodable {
     /// The state of the current scan
     public var state: JetpackScanState
 
+    /// If a scan is in an unavailable state, this will return the reason
+    public var reason: String?
+
     /// If there is a scan in progress, this will return its status
     public var current: JetpackScanStatus?
 
@@ -44,7 +47,7 @@ public struct JetpackScan: Decodable {
 
     // MARK: - Private: Decodable
     private enum CodingKeys: String, CodingKey {
-        case mostRecent, state, current, threats, credentials
+        case mostRecent, state, reason, current, threats, credentials
     }
 }
 


### PR DESCRIPTION
### Description

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/16725

This PR adds a `reason` property to the JetpackScan object. This lets us determine the reason why the scan state is `unavailable`.

### Testing Details

Please test with https://github.com/wordpress-mobile/WordPress-iOS/pull/16817
