### PR TITLE
Update Global Styles endpoint to support non-experimental paths

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.37.0"
+  s.version       = "4.38.0-beta.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/BlockEditorSettingsServiceRemote.swift
+++ b/WordPressKit/BlockEditorSettingsServiceRemote.swift
@@ -43,13 +43,8 @@ public extension BlockEditorSettingsServiceRemote {
 public extension BlockEditorSettingsServiceRemote {
     typealias BlockEditorSettingsCompletionHandler = (Swift.Result<RemoteBlockEditorSettings?, Error>) -> Void
 
-    /* This endpoint was released as part of WP 5.8 with the __experimental flag.
-    * Starting with Gutenberg 11.1 the endpoint will be available without the __experimental flag.
-    * Gutenberg 11.1 will be included in WP 5.9.
-    */
-    func fetchBlockEditorSettings(forSiteID siteID: Int?, requiresExperimental: Bool, _ completion: @escaping BlockEditorSettingsCompletionHandler) {
-        let experimentalComponent = requiresExperimental ? "/__experimental" : ""
-        let requestPath = "\(experimentalComponent)/wp-block-editor/v1/settings"
+    func fetchBlockEditorSettings(forSiteID siteID: Int?, _ completion: @escaping BlockEditorSettingsCompletionHandler) {
+        let requestPath = "/wp-block-editor/v1/settings"
         let parameters: [String: AnyObject] = ["context": "mobile" as AnyObject]
         let modifiedPath = remoteAPI.requestPath(fromOrgPath: requestPath, with: siteID)
 

--- a/WordPressKit/BlockEditorSettingsServiceRemote.swift
+++ b/WordPressKit/BlockEditorSettingsServiceRemote.swift
@@ -45,8 +45,11 @@ public extension BlockEditorSettingsServiceRemote {
 
     func fetchBlockEditorSettings(_ completion: @escaping BlockEditorSettingsCompletionHandler) {
         let requestPath = "/__experimental/wp-block-editor/v1/settings"
+    func fetchBlockEditorSettings(forSiteID siteID: Int?, _ completion: @escaping BlockEditorSettingsCompletionHandler) {
         let parameters: [String: AnyObject] = ["context": "mobile" as AnyObject]
-        remoteAPI.GET(requestPath, parameters: parameters) { [weak self] (result, _) in
+        let modifiedPath = remoteAPI.requestPath(fromOrgPath: requestPath, with: siteID)
+
+        remoteAPI.GET(modifiedPath, parameters: parameters) { [weak self] (result, _) in
             guard let `self` = self else { return }
             switch result {
             case .success(let response):

--- a/WordPressKit/BlockEditorSettingsServiceRemote.swift
+++ b/WordPressKit/BlockEditorSettingsServiceRemote.swift
@@ -43,9 +43,13 @@ public extension BlockEditorSettingsServiceRemote {
 public extension BlockEditorSettingsServiceRemote {
     typealias BlockEditorSettingsCompletionHandler = (Swift.Result<RemoteBlockEditorSettings?, Error>) -> Void
 
-    func fetchBlockEditorSettings(_ completion: @escaping BlockEditorSettingsCompletionHandler) {
-        let requestPath = "/__experimental/wp-block-editor/v1/settings"
-    func fetchBlockEditorSettings(forSiteID siteID: Int?, _ completion: @escaping BlockEditorSettingsCompletionHandler) {
+    /* This endpoint was released as part of WP 5.8 with the __experimental flag.
+    * Starting with Gutenberg 11.1 the endpoint will be available without the __experimental flag.
+    * Gutenberg 11.1 will be included in WP 5.9.
+    */
+    func fetchBlockEditorSettings(forSiteID siteID: Int?, requiresExperimental: Bool, _ completion: @escaping BlockEditorSettingsCompletionHandler) {
+        let experimentalComponent = requiresExperimental ? "/__experimental" : ""
+        let requestPath = "\(experimentalComponent)/wp-block-editor/v1/settings"
         let parameters: [String: AnyObject] = ["context": "mobile" as AnyObject]
         let modifiedPath = remoteAPI.requestPath(fromOrgPath: requestPath, with: siteID)
 

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -556,7 +556,12 @@ extension WordPressComRestApi: WordPressRestApi {
 
     public func requestPath(fromOrgPath path: String, with siteID: Int?) -> String {
         guard let siteID = siteID else { return path }
-        return path.replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(siteID)/")
+
+        if path.contains("/wp-block-editor/v1/") {
+            return path.replacingOccurrences(of: "/wp-block-editor/v1/", with: "/wp-block-editor/v1/sites/\(siteID)/")
+        } else {
+            return path.replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(siteID)/")
+        }
     }
 }
 

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -557,11 +557,8 @@ extension WordPressComRestApi: WordPressRestApi {
     public func requestPath(fromOrgPath path: String, with siteID: Int?) -> String {
         guard let siteID = siteID else { return path }
 
-        if path.contains("/wp-block-editor/v1/") {
-            return path.replacingOccurrences(of: "/wp-block-editor/v1/", with: "/wp-block-editor/v1/sites/\(siteID)/")
-        } else {
-            return path.replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(siteID)/")
-        }
+        return path.replacingOccurrences(of: "/wp/v2/", with: "/wp/v2/sites/\(siteID)/")
+            .replacingOccurrences(of: "/wp-block-editor/v1/", with: "/wp-block-editor/v1/sites/\(siteID)/")
     }
 }
 

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -134,7 +134,7 @@ extension BlockEditorSettingsServiceRemoteTests {
     func testFetchBlockEditorSettingsNotThemeJSON() {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
-        service.fetchBlockEditorSettings { (response) in
+        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: false) { (response) in
             switch response {
             case .success(let result):
                 self.validateFetchBlockEditorSettingsResults(result)
@@ -154,7 +154,7 @@ extension BlockEditorSettingsServiceRemoteTests {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
         let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
 
-        service.fetchBlockEditorSettings { (response) in
+        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: false) { (response) in
             switch response {
             case .success(let result):
                 self.validateFetchBlockEditorSettingsResults(result)
@@ -185,7 +185,7 @@ extension BlockEditorSettingsServiceRemoteTests {
 
     func testFetchBlockEditorSettingsFailure() {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
-        service.fetchBlockEditorSettings { (response) in
+        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: false) { (response) in
             switch response {
             case .success:
                 XCTFail("This Request should have failed")
@@ -199,9 +199,58 @@ extension BlockEditorSettingsServiceRemoteTests {
         validateFetchBlockEditorSettingsRequest()
     }
 
+    func testFetchBlockEditorSettingsOrgEndpoint() {
+        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
+        let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
+        let mockOrgRemoteApi = MockWordPressOrgRestApi()
+        service = BlockEditorSettingsServiceRemote(remoteAPI: mockOrgRemoteApi)
+
+        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: false) { (response) in
+            waitExpectation.fulfill()
+        }
+        mockOrgRemoteApi.completionPassedIn!(.success(mockedResponse), HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertTrue(mockOrgRemoteApi.getMethodCalled)
+        XCTAssertEqual(mockOrgRemoteApi.URLStringPassedIn!, "/wp-block-editor/v1/settings")
+        XCTAssertEqual((mockOrgRemoteApi.parametersPassedIn as! [String: String])["context"], "mobile")
+    }
+
+    func testFetchBlockEditorSettingsOrgExperimentalEndpoint() {
+        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
+        let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
+        let mockOrgRemoteApi = MockWordPressOrgRestApi()
+        service = BlockEditorSettingsServiceRemote(remoteAPI: mockOrgRemoteApi)
+
+        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: true) { (response) in
+            waitExpectation.fulfill()
+        }
+        mockOrgRemoteApi.completionPassedIn!(.success(mockedResponse), HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertTrue(mockOrgRemoteApi.getMethodCalled)
+        XCTAssertEqual(mockOrgRemoteApi.URLStringPassedIn!, "/__experimental/wp-block-editor/v1/settings")
+        XCTAssertEqual((mockOrgRemoteApi.parametersPassedIn as! [String: String])["context"], "mobile")
+    }
+
+    func testFetchBlockEditorSettingsExperimentalEndpoint() {
+        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
+        let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
+
+        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: true) { (response) in
+            waitExpectation.fulfill()
+        }
+        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertTrue(self.mockRemoteApi.getMethodCalled)
+        XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/__experimental/wp-block-editor/v1/sites/1/settings")
+        XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["context"], "mobile")
+    }
+
     private func validateFetchBlockEditorSettingsRequest() {
         XCTAssertTrue(self.mockRemoteApi.getMethodCalled)
-        XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/__experimental/wp-block-editor/v1/settings")
+        XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/wp-block-editor/v1/sites/1/settings")
         XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["context"], "mobile")
     }
 

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -134,7 +134,7 @@ extension BlockEditorSettingsServiceRemoteTests {
     func testFetchBlockEditorSettingsNotThemeJSON() {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
         let mockedResponse = mockedData(withFilename: blockSettingsNOTThemeJSONResponseFilename)
-        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: false) { (response) in
+        service.fetchBlockEditorSettings(forSiteID: siteID) { (response) in
             switch response {
             case .success(let result):
                 self.validateFetchBlockEditorSettingsResults(result)
@@ -154,7 +154,7 @@ extension BlockEditorSettingsServiceRemoteTests {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
         let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
 
-        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: false) { (response) in
+        service.fetchBlockEditorSettings(forSiteID: siteID) { (response) in
             switch response {
             case .success(let result):
                 self.validateFetchBlockEditorSettingsResults(result)
@@ -185,7 +185,7 @@ extension BlockEditorSettingsServiceRemoteTests {
 
     func testFetchBlockEditorSettingsFailure() {
         let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
-        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: false) { (response) in
+        service.fetchBlockEditorSettings(forSiteID: siteID) { (response) in
             switch response {
             case .success:
                 XCTFail("This Request should have failed")
@@ -205,7 +205,7 @@ extension BlockEditorSettingsServiceRemoteTests {
         let mockOrgRemoteApi = MockWordPressOrgRestApi()
         service = BlockEditorSettingsServiceRemote(remoteAPI: mockOrgRemoteApi)
 
-        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: false) { (response) in
+        service.fetchBlockEditorSettings(forSiteID: siteID) { (response) in
             waitExpectation.fulfill()
         }
         mockOrgRemoteApi.completionPassedIn!(.success(mockedResponse), HTTPURLResponse())
@@ -214,38 +214,6 @@ extension BlockEditorSettingsServiceRemoteTests {
         XCTAssertTrue(mockOrgRemoteApi.getMethodCalled)
         XCTAssertEqual(mockOrgRemoteApi.URLStringPassedIn!, "/wp-block-editor/v1/settings")
         XCTAssertEqual((mockOrgRemoteApi.parametersPassedIn as! [String: String])["context"], "mobile")
-    }
-
-    func testFetchBlockEditorSettingsOrgExperimentalEndpoint() {
-        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
-        let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
-        let mockOrgRemoteApi = MockWordPressOrgRestApi()
-        service = BlockEditorSettingsServiceRemote(remoteAPI: mockOrgRemoteApi)
-
-        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: true) { (response) in
-            waitExpectation.fulfill()
-        }
-        mockOrgRemoteApi.completionPassedIn!(.success(mockedResponse), HTTPURLResponse())
-
-        waitForExpectations(timeout: 0.1)
-        XCTAssertTrue(mockOrgRemoteApi.getMethodCalled)
-        XCTAssertEqual(mockOrgRemoteApi.URLStringPassedIn!, "/__experimental/wp-block-editor/v1/settings")
-        XCTAssertEqual((mockOrgRemoteApi.parametersPassedIn as! [String: String])["context"], "mobile")
-    }
-
-    func testFetchBlockEditorSettingsExperimentalEndpoint() {
-        let waitExpectation = expectation(description: "Block Settings should be successfully fetched")
-        let mockedResponse = mockedData(withFilename: blockSettingsThemeJSONResponseFilename)
-
-        service.fetchBlockEditorSettings(forSiteID: siteID, requiresExperimental: true) { (response) in
-            waitExpectation.fulfill()
-        }
-        mockRemoteApi.successBlockPassedIn!(mockedResponse as AnyObject, HTTPURLResponse())
-
-        waitForExpectations(timeout: 0.1)
-        XCTAssertTrue(self.mockRemoteApi.getMethodCalled)
-        XCTAssertEqual(self.mockRemoteApi.URLStringPassedIn!, "/__experimental/wp-block-editor/v1/sites/1/settings")
-        XCTAssertEqual((self.mockRemoteApi.parametersPassedIn as! [String: String])["context"], "mobile")
     }
 
     private func validateFetchBlockEditorSettingsRequest() {

--- a/WordPressKitTests/MockWordPressComRestApi.swift
+++ b/WordPressKitTests/MockWordPressComRestApi.swift
@@ -67,7 +67,7 @@ class MockWordPressOrgRestApi: WordPressOrgRestApi {
         super.init(apiBase: URL(string: "https://example.com")!)
     }
 
-    override func GET(_ path: String, parameters: [String : AnyObject]?, completion: @escaping WordPressOrgRestApi.Completion) -> Progress? {
+    override func GET(_ path: String, parameters: [String: AnyObject]?, completion: @escaping WordPressOrgRestApi.Completion) -> Progress? {
         getMethodCalled = true
         URLStringPassedIn = path
         parametersPassedIn = parameters as AnyObject?

--- a/WordPressKitTests/MockWordPressComRestApi.swift
+++ b/WordPressKitTests/MockWordPressComRestApi.swift
@@ -56,3 +56,33 @@ class MockWordPressComRestApi: WordPressComRestApi {
         return method
     }
 }
+
+class MockWordPressOrgRestApi: WordPressOrgRestApi {
+    var getMethodCalled = false
+    var URLStringPassedIn: String?
+    var parametersPassedIn: AnyObject?
+    var completionPassedIn: WordPressOrgRestApi.Completion?
+
+    init() {
+        super.init(apiBase: URL(string: "https://example.com")!)
+    }
+
+    override func GET(_ path: String, parameters: [String : AnyObject]?, completion: @escaping WordPressOrgRestApi.Completion) -> Progress? {
+        getMethodCalled = true
+        URLStringPassedIn = path
+        parametersPassedIn = parameters as AnyObject?
+        completionPassedIn = completion
+
+        return Progress()
+    }
+
+    @objc func methodCalled() -> String {
+
+        var method = "Unknown"
+        if getMethodCalled {
+            method = "GET"
+        }
+
+        return method
+    }
+}

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -269,9 +269,17 @@ class WordPressComRestApiTests: XCTestCase {
     }
 
     // MARK: - WordPressRestApi Interfaces
-    func testRequestPathModifications() {
+    func testRequestPathModificationsWPV2() {
         let orgPath = "/wp/v2/themes?status=active"
         let expectedPath = "/wp/v2/sites/1001/themes?status=active"
+        let api = WordPressComRestApi(oAuthToken: "fakeToken")
+        let result = api.requestPath(fromOrgPath: orgPath, with: 1001)
+        XCTAssertEqual(result, expectedPath)
+    }
+
+    func testRequestPathModificationsWPBlockEditor() {
+        let orgPath = "/wp-block-editor/v1/settings"
+        let expectedPath = "/wp-block-editor/v1/sites/1001/settings"
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
         let result = api.requestPath(fromOrgPath: orgPath, with: 1001)
         XCTAssertEqual(result, expectedPath)


### PR DESCRIPTION
### Description

This updates the Global styles endpoint to use the non-experimental paths for fetching the block editor settings. 

### Testing Details

This can be tested with the same notes in: https://github.com/wordpress-mobile/WordPress-iOS/pull/16823

- [x] Please check here if your pull request includes additional test coverage.
