### PR TITLE
Fix/store both comment content fields

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.37.0"
+  s.version       = "4.37.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -462,12 +462,8 @@
     comment.isLiked = [[jsonDictionary numberForKey:@"i_like"] boolValue];
     comment.likeCount = [jsonDictionary numberForKey:@"like_count"];
     comment.canModerate = [[jsonDictionary numberForKey:@"can_moderate"] boolValue];
-
-    // Ref: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/413
-    // The `context:edit` parameter is no longer passed when fetching Comments,
-    // which results in the`content` property containing HTML.
-    // So use the `raw_content` property instead.
-    comment.content = jsonDictionary[@"raw_content"];
+    comment.content = jsonDictionary[@"content"];
+    comment.rawContent = jsonDictionary[@"raw_content"];
 
     return comment;
 }

--- a/WordPressKit/RemoteComment.h
+++ b/WordPressKit/RemoteComment.h
@@ -7,6 +7,7 @@
 @property (nonatomic, strong) NSString *authorUrl;
 @property (nonatomic, strong) NSString *authorAvatarURL;
 @property (nonatomic, strong) NSString *content;
+@property (nonatomic, strong) NSString *rawContent;
 @property (nonatomic, strong) NSDate *date;
 @property (nonatomic, strong) NSString *link;
 @property (nonatomic, strong) NSNumber *parentID;


### PR DESCRIPTION
This PR is part of a bug fix for WPiOS `release/17.8`. 
More in p1626841091202200-slack-hummingbird

In https://github.com/wordpress-mobile/WordPressKit-iOS/pull/413 we made a change to consume `raw_content` rather than `content` field from the Comments endpoints.  This [resolved](https://github.com/wordpress-mobile/WordPress-iOS/pull/16768) an [issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/16685) with Authors and Contributors not being able to view Comment content.  However, we missed that it created a new issue with comments in the Reader being incorrectly rendered in many cases as the `raw_comment` field does not include html mark up for non-P2 WordPress sites.  P2s that use the block editor for comments were rendered correctly.  We were unaware of this difference between P2 and non-P2 comments.  The reader's caching behavior likely contributed to missing the regression. 

Example of the badness. Note the cropped lines of text:
![Simulator Screen Shot - iPhone 11 - 2021-07-20 at 23 12 22](https://user-images.githubusercontent.com/1435271/126558810-7ee0e22d-6513-4a28-879a-1cba628e4407.png)


This PR makes a change to consume both content and raw_content fields from the comments endpoint.  A companion WPiOS PR will wrangle the values as needed based on the context where they are used. 

### Testing Details
Run the companion WPiOS PR. (tbd)
- Confirm that reader comments are correctly rendered.  
- Confirm that comments in My Sites are correctly rendered.
- Confirm that authors and contributors can still view comments under My Sites.
- Confirm that comments under Notifications are correctly rendered.
- Confirm that replying to a reader comment works as expected and there are no layout issues. 
- Confirm that editing a my sites or notifications comment works as expected.

- [x] Please check here if your pull request includes additional test coverage.
