### PR TITLE
Merge release 4.37.1 into develop

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "WordPressKit"
-  s.version       = "4.37.0"
+  s.version       = "4.37.1"
 
   s.summary       = "WordPressKit offers a clean and simple WordPress.com and WordPress.org API."
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -462,12 +462,8 @@
     comment.isLiked = [[jsonDictionary numberForKey:@"i_like"] boolValue];
     comment.likeCount = [jsonDictionary numberForKey:@"like_count"];
     comment.canModerate = [[jsonDictionary numberForKey:@"can_moderate"] boolValue];
-
-    // Ref: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/413
-    // The `context:edit` parameter is no longer passed when fetching Comments,
-    // which results in the`content` property containing HTML.
-    // So use the `raw_content` property instead.
-    comment.content = jsonDictionary[@"raw_content"];
+    comment.content = jsonDictionary[@"content"];
+    comment.rawContent = jsonDictionary[@"raw_content"];
 
     return comment;
 }

--- a/WordPressKit/RemoteComment.h
+++ b/WordPressKit/RemoteComment.h
@@ -7,6 +7,7 @@
 @property (nonatomic, strong) NSString *authorUrl;
 @property (nonatomic, strong) NSString *authorAvatarURL;
 @property (nonatomic, strong) NSString *content;
+@property (nonatomic, strong) NSString *rawContent;
 @property (nonatomic, strong) NSDate *date;
 @property (nonatomic, strong) NSString *link;
 @property (nonatomic, strong) NSNumber *parentID;


### PR DESCRIPTION
This also bumps the beta version on `develop` from `4.38.0-beta.1` to `4.38.0-beta.2`.