### PR TITLE
Add release build publishing

### DIFF
--- a/.buildkite/build-and-test.sh
+++ b/.buildkite/build-and-test.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -eu
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/lint.sh
+++ b/.buildkite/lint.sh
@@ -1,30 +1,15 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -eu
 
 echo "--- :rubygems: Setting up Gems"
 bundle install
 
 echo "--- :rubygems: Checking Gemfile.lock"
-# This will only work if it goes after `bundle install` – don't try to run it first
-if [ -n "$(git status | grep modified | grep Gemfile.lock)" ]; then 
-	echo "Error: Gemfile.lock is not in sync – please run \`bundle install\` and commit your changes"
-	exit 1
-fi 
+validate_gemfile_lock
 
 echo "--- :rubocop: Running Rubocop"
 bundle exec rubocop
 
-echo "Gemfile.lock is in sync"
-
 echo "--- :cocoapods: Checking Podfile.lock"
-PODFILE_SHA1=$(ruby -e "require 'yaml';puts YAML.load_file('Podfile.lock')['PODFILE CHECKSUM']")
-RESULT=$(echo "$PODFILE_SHA1 *Podfile" | shasum -c)
-
-# This will only work if it goes after `pod install` – don't try to run it first
-if [[ $RESULT != "Podfile: OK" ]]; then 
-	echo "Error: Podfile.lock is not in sync – please run \`bundle exec pod install\` and commit your changes"
-	exit 1
-fi 
+validate_podfile_lock
 
 # TODO: Add swiftlint

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#add/cocoapods-support: ~
+    - automattic/bash-cache#add/pod-publishing: ~
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-12.5.1
@@ -31,9 +31,10 @@ steps:
   # Lint
   #################
   - label: "🧹 Lint"
+    key: "lint"
     command: .buildkite/lint.sh
     plugins:
-      - automattic/bash-cache#add/cocoapods-support: ~
+      - automattic/bash-cache#v1.1.0: ~
       - docker#v3.8.0:
           image: "public.ecr.aws/automattic/multilint:latest"
     agents:
@@ -42,14 +43,15 @@ steps:
   #################
   # Publish the Podspec (if we're building a tag)
   #################
-  #- label: "⬆️ Publish Podspec"
-  #  key: "publish"
-  #  command: |
-  #    echo "Publishing"
-  #  env: *common_env
-  #  plugins: *common_plugins
-  #  depends_on:
-  #    - "test"
-  #    - "validate"
-  #    - "lint"
-  #  if: build.tag != null
+  - label: "⬆️ Publish Podspec"
+    key: "publish"
+    command: .buildkite/publish-pod.sh
+    env: *common_env
+    plugins: *common_plugins
+    depends_on:
+      - "test"
+      - "validate"
+      - "lint"
+    if: build.tag != null
+    agents:
+      queue: "mac"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#add/pod-publishing: ~
+    - automattic/bash-cache#v1.2.1: ~
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-12.5.1

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,9 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/bash-cache#v1.2.1: ~
+  plugins: &common_plugins
+  - &bash_cache automattic/bash-cache#v1.2.1: ~
   # Common environment values to use with the `env` key.
-  - &common_env
+  env: &common_env
     IMAGE_ID: xcode-12.5.1
 
 # This is the default pipeline – it will build and test the app
@@ -34,7 +33,7 @@ steps:
     key: "lint"
     command: .buildkite/lint.sh
     plugins:
-      - automattic/bash-cache#v1.1.0: ~
+      - *bash_cache
       - docker#v3.8.0:
           image: "public.ecr.aws/automattic/multilint:latest"
     agents:

--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+
+PODSPEC_PATH="WordPressKit.podspec"
+SPECS_REPO="git@github.com:wordpress-mobile/cocoapods-specs.git"
+SLACK_WEBHOOK=$PODS_SLACK_WEBHOOK
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :cocoapods: Publishing Pod to CocoaPods CDN"
+publish_pod $PODSPEC_PATH
+
+echo "--- :cocoapods: Publishing Pod to WP Specs Repo"
+publish_private_pod $PODSPEC_PATH $SPECS_REPO "$SPEC_REPO_PUBLIC_DEPLOY_KEY"
+
+echo "--- :slack: Notifying Slack"
+slack_notify_pod_published $PODSPEC_PATH $SLACK_WEBHOOK

--- a/.buildkite/validate-podspec.sh
+++ b/.buildkite/validate-podspec.sh
@@ -1,6 +1,4 @@
-#!/bin/bash
-
-set -e
+#!/bin/bash -eu
 
 echo "--- :rubygems: Setting up Gems"
 install_gems
@@ -12,4 +10,5 @@ echo "--- :microscope: Validate Podspec"
 # For some reason this fixes a failure in `lib lint`
 # https://github.com/Automattic/buildkite-ci/issues/7
 xcrun simctl list >> /dev/null
+
 bundle exec pod lib lint --verbose --fail-fast

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,18 +32,3 @@ workflows:
           podspec-path: *podspec
           bundle-install: true
           additional-parameters: "--allow-warnings"
-      - ios/publish-podspec:
-          name: Publish to a8c Spec Repo
-          xcode-version: *xcode-version
-          podspec-path: *podspec
-          spec-repo: https://github.com/wordpress-mobile/cocoapods-specs.git
-          bundle-install: true
-          post-to-slack: false
-          filters: *on-tags-only
-      - ios/publish-podspec:
-          name: Publish to Trunk
-          xcode-version: *xcode-version
-          podspec-path: *podspec
-          bundle-install: true
-          post-to-slack: true
-          filters: *on-tags-only


### PR DESCRIPTION
### Description

Adds release build support to Buildkite (removing it from CircleCI).

### Testing Details

- Note that CI passes
- Note that [the production release succeeds ](https://buildkite.com/wordpress-mobile/wordpresskit-ios/builds/68#_)