### PR TITLE
Comment: parse author ip address from endpoint responses.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
   - label: "🧹 Lint"
     command: .buildkite/lint.sh
     plugins:
-      - automattic/bash-cache#add/cocoapods-support: ~
+      - automattic/bash-cache#v1.1.0: ~
       - docker#v3.8.0:
           image: "public.ecr.aws/automattic/multilint:latest"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.1.0: ~
+    - automattic/bash-cache#add/cocoapods-support: ~
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-12.5.1
@@ -33,7 +33,7 @@ steps:
   - label: "🧹 Lint"
     command: .buildkite/lint.sh
     plugins:
-      - automattic/bash-cache#v1.1.0: ~
+      - automattic/bash-cache#add/cocoapods-support: ~
       - docker#v3.8.0:
           image: "public.ecr.aws/automattic/multilint:latest"
     agents:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#add/cocoapods-support: ~
+    - automattic/bash-cache#v1.1.0: ~
   # Common environment values to use with the `env` key.
   - &common_env
     IMAGE_ID: xcode-12.5.1

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.39.0-beta.1'
+  s.version       = '4.39.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -451,6 +451,7 @@
     comment.authorEmail = [jsonDictionary[@"author"] stringForKey:@"email"];
     comment.authorUrl = jsonDictionary[@"author"][@"URL"];
     comment.authorAvatarURL = [jsonDictionary stringForKeyPath:@"author.avatar_URL"];
+    comment.authorIP = [jsonDictionary stringForKeyPath:@"author.ip_address"];
     comment.commentID = jsonDictionary[@"ID"];
     comment.date = [NSDate dateWithWordPressComJSONString:jsonDictionary[@"date"]];
     comment.link = jsonDictionary[@"URL"];

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -205,6 +205,7 @@
     comment.author = xmlrpcDictionary[@"author"];
     comment.authorEmail = xmlrpcDictionary[@"author_email"];
     comment.authorUrl = xmlrpcDictionary[@"author_url"];
+    comment.authorIP = xmlrpcDictionary[@"author_ip"];
     comment.commentID = [xmlrpcDictionary numberForKey:@"comment_id"];
     comment.content = xmlrpcDictionary[@"content"];
     comment.date = xmlrpcDictionary[@"date_created_gmt"];

--- a/WordPressKit/RemoteComment.h
+++ b/WordPressKit/RemoteComment.h
@@ -6,6 +6,7 @@
 @property (nonatomic, strong) NSString *authorEmail;
 @property (nonatomic, strong) NSString *authorUrl;
 @property (nonatomic, strong) NSString *authorAvatarURL;
+@property (nonatomic, strong) NSString *authorIP;
 @property (nonatomic, strong) NSString *content;
 @property (nonatomic, strong) NSString *rawContent;
 @property (nonatomic, strong) NSDate *date;

--- a/WordPressKit/ZendeskMetadata.swift
+++ b/WordPressKit/ZendeskMetadata.swift
@@ -1,8 +1,6 @@
-
 public struct ZendeskSiteContainer: Decodable {
     public let sites: [ZendeskSite]
 }
-
 
 public struct ZendeskSite: Decodable {
     public let ID: Int
@@ -13,7 +11,6 @@ public struct ZendeskSite: Decodable {
         case zendeskMetadata = "zendesk_site_meta"
     }
 }
-
 
 public struct ZendeskMetadata: Decodable {
     public let plan: String

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -205,7 +205,7 @@ extension BlockEditorSettingsServiceRemoteTests {
         let mockOrgRemoteApi = MockWordPressOrgRestApi()
         service = BlockEditorSettingsServiceRemote(remoteAPI: mockOrgRemoteApi)
 
-        service.fetchBlockEditorSettings(forSiteID: siteID) { (response) in
+        service.fetchBlockEditorSettings(forSiteID: siteID) { (_) in
             waitExpectation.fulfill()
         }
         mockOrgRemoteApi.completionPassedIn!(.success(mockedResponse), HTTPURLResponse())


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/16876
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/16982

This parses the Comment author ip address from both REST and XMLRPC endpoint responses, and stores it in `RemoteComment`.

### Testing Details

Can be tested in referenced WPiOS PR.