### PR TITLE
Comments: add XMLRPC test for successful fetching

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.39.0-beta.3'
+  s.version       = '4.39.0-beta.4'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -440,10 +440,12 @@
 		93F50A441F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F50A431F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift */; };
 		93F50A471F227F3600B5BEBA /* xmlrpc-response-getprofile.xml in Resources */ = {isa = PBXBuildFile; fileRef = 93F50A451F227F3600B5BEBA /* xmlrpc-response-getprofile.xml */; };
 		93F50A481F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml in Resources */ = {isa = PBXBuildFile; fileRef = 93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */; };
+		9817D9D426BC8AF000ECBD8C /* CommentServiceRemoteXMLRPCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9817D9D326BC8AF000ECBD8C /* CommentServiceRemoteXMLRPCTests.swift */; };
 		984E34EB22EF7209005C3F92 /* StatsFileDownloadsTimeIntervalData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984E34EA22EF7209005C3F92 /* StatsFileDownloadsTimeIntervalData.swift */; };
 		984E34F422EF9465005C3F92 /* stats-file-downloads.json in Resources */ = {isa = PBXBuildFile; fileRef = 984E34F322EF9464005C3F92 /* stats-file-downloads.json */; };
 		9856BE962630B5C200C12FEB /* RemoteUser+Likes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9856BE952630B5C200C12FEB /* RemoteUser+Likes.swift */; };
 		98DC787522BAEBF200267279 /* StatsAllAnnualInsight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DC787422BAEBF100267279 /* StatsAllAnnualInsight.swift */; };
+		98EA910526BC96B8004098A1 /* xmlrpc-site-comments-success.xml in Resources */ = {isa = PBXBuildFile; fileRef = 98EA910426BC96B8004098A1 /* xmlrpc-site-comments-success.xml */; };
 		98F884D426BC6445009ADF57 /* CommentServiceRemoteRESTTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F884D326BC6445009ADF57 /* CommentServiceRemoteRESTTests.swift */; };
 		98F884D626BC6909009ADF57 /* site-comments-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 98F884D526BC6909009ADF57 /* site-comments-success.json */; };
 		9A2D0B28225E0119009E585F /* JetpackServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A2D0B27225E0119009E585F /* JetpackServiceRemote.swift */; };
@@ -1057,10 +1059,12 @@
 		93F50A431F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UsersServiceRemoteXMLRPCTests.swift; sourceTree = "<group>"; };
 		93F50A451F227F3600B5BEBA /* xmlrpc-response-getprofile.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-response-getprofile.xml"; sourceTree = "<group>"; };
 		93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-response-valid-but-unexpected-dictionary.xml"; sourceTree = "<group>"; };
+		9817D9D326BC8AF000ECBD8C /* CommentServiceRemoteXMLRPCTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommentServiceRemoteXMLRPCTests.swift; sourceTree = "<group>"; };
 		984E34EA22EF7209005C3F92 /* StatsFileDownloadsTimeIntervalData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsFileDownloadsTimeIntervalData.swift; sourceTree = "<group>"; };
 		984E34F322EF9464005C3F92 /* stats-file-downloads.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "stats-file-downloads.json"; sourceTree = "<group>"; };
 		9856BE952630B5C200C12FEB /* RemoteUser+Likes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "RemoteUser+Likes.swift"; sourceTree = "<group>"; };
 		98DC787422BAEBF100267279 /* StatsAllAnnualInsight.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsAllAnnualInsight.swift; sourceTree = "<group>"; };
+		98EA910426BC96B8004098A1 /* xmlrpc-site-comments-success.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = "xmlrpc-site-comments-success.xml"; sourceTree = "<group>"; };
 		98F884D326BC6445009ADF57 /* CommentServiceRemoteRESTTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentServiceRemoteRESTTests.swift; sourceTree = "<group>"; };
 		98F884D526BC6909009ADF57 /* site-comments-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-comments-success.json"; sourceTree = "<group>"; };
 		9A2D0B27225E0119009E585F /* JetpackServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackServiceRemote.swift; sourceTree = "<group>"; };
@@ -2143,6 +2147,7 @@
 				74B335E91F06F76B0053A184 /* xmlrpc-response-getpost.xml */,
 				93F50A451F227F3600B5BEBA /* xmlrpc-response-getprofile.xml */,
 				93F50A461F227F3600B5BEBA /* xmlrpc-response-valid-but-unexpected-dictionary.xml */,
+				98EA910426BC96B8004098A1 /* xmlrpc-site-comments-success.xml */,
 				740B23DE1F17FB4200067A2A /* xmlrpc-wp-getpost-bad-xml-failure.xml */,
 				740B23DF1F17FB4200067A2A /* xmlrpc-wp-getpost-invalid-id-failure.xml */,
 				740B23E01F17FB4200067A2A /* xmlrpc-wp-getpost-success.xml */,
@@ -2215,6 +2220,7 @@
 			children = (
 				ABD95B7E25DD6C4B00735BEE /* CommentServiceRemoteRESTLikesTests.swift */,
 				98F884D326BC6445009ADF57 /* CommentServiceRemoteRESTTests.swift */,
+				9817D9D326BC8AF000ECBD8C /* CommentServiceRemoteXMLRPCTests.swift */,
 			);
 			name = Comment;
 			sourceTree = "<group>";
@@ -2650,6 +2656,7 @@
 				74B040721EF8B366002C6258 /* rest-site-settings.json in Resources */,
 				8B749E8625AF808600023F03 /* jetpack-capabilities-107159616-success.json in Resources */,
 				93BD27611EE73442002BB00B /* me-sites-empty-success.json in Resources */,
+				98EA910526BC96B8004098A1 /* xmlrpc-site-comments-success.xml in Resources */,
 				40E4698D2017D2E30030DB5F /* plugin-directory-new.json in Resources */,
 				4081977C221F153B00A298E4 /* stats-visits-day.json in Resources */,
 				9A881750223C01E400A3AB20 /* jetpack-service-error-install-failure.json in Resources */,
@@ -3050,6 +3057,7 @@
 				740B23D31F17F6BB00067A2A /* PostServiceRemoteXMLRPCTests.swift in Sources */,
 				93188D221F2264E60028ED4D /* TaxonomyServiceRemoteRESTTests.m in Sources */,
 				F194E1232417ED9F00874408 /* AtomicAuthenticationServiceRemoteTests.swift in Sources */,
+				9817D9D426BC8AF000ECBD8C /* CommentServiceRemoteXMLRPCTests.swift in Sources */,
 				74FC6F3B1F191BB400112505 /* NotificationSyncServiceRemoteTests.swift in Sources */,
 				731BA83821DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift in Sources */,
 				9A2D0B2B225E0E22009E585F /* JetpackServiceRemoteTests.swift in Sources */,

--- a/WordPressKitTests/CommentServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteXMLRPCTests.swift
@@ -43,7 +43,7 @@ class CommentServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
                 XCTAssertEqual(comment.authorIP, "000.0.00.000")
                 XCTAssertEqual(comment.link, "comment URL")
                 XCTAssertEqual(comment.parentID, NSNumber(value: 1))
-                XCTAssertEqual(comment.postID, NSNumber(value: 1))
+                XCTAssertEqual(comment.postID, NSNumber(value: 2))
                 XCTAssertEqual(comment.postTitle, "Post title")
                 XCTAssertEqual(comment.status, "approve")
                 XCTAssertEqual(comment.type, "comment")

--- a/WordPressKitTests/CommentServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteXMLRPCTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+import wpxmlrpc
+
+@testable import WordPressKit
+
+class CommentServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
+    private var remote: Any?
+    private let getSiteCommentsSuccessMockFilename = "xmlrpc-site-comments-success.xml"
+
+    override func setUp() {
+        super.setUp()
+        remote = CommentServiceRemoteXMLRPC(api: getXmlRpcApi(),
+                                            username: XMLRPCTestableConstants.xmlRpcUserName,
+                                            password: XMLRPCTestableConstants.xmlRpcPassword)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        remote = nil
+    }
+
+    // MARK: - Tests
+
+    func testGetCommentsSucceeds() {
+        let expect = expectation(description: "Fetching site comments should succeed")
+
+        stubRemoteResponse(XMLRPCTestableConstants.xmlRpcUrl,
+                           filename: getSiteCommentsSuccessMockFilename,
+                           contentType: .XML)
+
+        if let remoteInstance = remote as? CommentServiceRemote {
+            remoteInstance.getCommentsWithMaximumCount(1,
+                                                       success: { comments in
+
+                guard let comment = comments?.first as? RemoteComment else {
+                    XCTFail("Failed to retrieve mock site comment")
+                    return
+                }
+
+                XCTAssertEqual(comment.author, "Comment Author")
+                XCTAssertEqual(comment.authorEmail, "author@email.com")
+                XCTAssertEqual(comment.authorUrl, "author URL")
+                XCTAssertEqual(comment.authorIP, "000.0.00.000")
+                XCTAssertEqual(comment.link, "comment URL")
+                XCTAssertEqual(comment.parentID, NSNumber(value: 1))
+                XCTAssertEqual(comment.postID, NSNumber(value: 1))
+                XCTAssertEqual(comment.postTitle, "Post title")
+                XCTAssertEqual(comment.status, "approve")
+                XCTAssertEqual(comment.type, "comment")
+                XCTAssertEqual(comment.content, "I am comment content")
+                XCTAssertEqual(comment.rawContent, nil)
+                XCTAssertEqual(comments?.count, 1)
+                expect.fulfill()
+               }, failure: { _ in
+                XCTFail("This callback shouldn't get called")
+               })
+
+            waitForExpectations(timeout: timeout, handler: nil)
+        }
+    }
+
+}

--- a/WordPressKitTests/Mock Data/xmlrpc-site-comments-success.xml
+++ b/WordPressKitTests/Mock Data/xmlrpc-site-comments-success.xml
@@ -14,7 +14,7 @@
                                 <member><name>status</name><value><string>approve</string></value></member>
                                 <member><name>content</name><value><string>I am comment content</string></value></member>
                                 <member><name>link</name><value><string>comment URL</string></value></member>
-                                <member><name>post_id</name><value><string>1</string></value></member>
+                                <member><name>post_id</name><value><string>2</string></value></member>
                                 <member><name>post_title</name><value><string>Post title</string></value></member>
                                 <member><name>author</name><value><string>Comment Author</string></value></member>
                                 <member><name>author_url</name><value><string>author URL</string></value></member>

--- a/WordPressKitTests/Mock Data/xmlrpc-site-comments-success.xml
+++ b/WordPressKitTests/Mock Data/xmlrpc-site-comments-success.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<methodResponse>
+    <params>
+        <param>
+            <value>
+                <array>
+                    <data>
+                        <value>
+                            <struct>
+                                <member><name>date_created_gmt</name><value><dateTime.iso8601>20210804T21:01:08</dateTime.iso8601></value></member>
+                                <member><name>user_id</name><value><string>1</string></value></member>
+                                <member><name>comment_id</name><value><string>1</string></value></member>
+                                <member><name>parent</name><value><string>1</string></value></member>
+                                <member><name>status</name><value><string>approve</string></value></member>
+                                <member><name>content</name><value><string>I am comment content</string></value></member>
+                                <member><name>link</name><value><string>comment URL</string></value></member>
+                                <member><name>post_id</name><value><string>1</string></value></member>
+                                <member><name>post_title</name><value><string>Post title</string></value></member>
+                                <member><name>author</name><value><string>Comment Author</string></value></member>
+                                <member><name>author_url</name><value><string>author URL</string></value></member>
+                                <member><name>author_email</name><value><string>author@email.com</string></value></member>
+                                <member><name>author_ip</name><value><string>000.0.00.000</string></value></member>
+                                <member><name>type</name><value><string>comment</string></value></member>
+                            </struct>
+                        </value>
+                    </data>
+                </array>
+            </value>
+        </param>
+    </params>
+</methodResponse>


### PR DESCRIPTION
Depends on: #428

### Testing Details

- Run `CommentServiceRemoteXMLRPCTests`. Verify it passes.
- Change any of the assert values. Verify the test fails.

- [x] Please check here if your pull request includes additional test coverage.
