### PR TITLE
Feature/16941 - Close account

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.40.0-beta.2'
+  s.version       = '4.40.0-beta.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 		931924241F1662FA0069CBCC /* JSONLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931924231F1662FA0069CBCC /* JSONLoader.swift */; };
 		9368C7851EC5EF1B0092CE8E /* WordPressKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9368C77B1EC5EF1B0092CE8E /* WordPressKit.framework */; };
 		9368C78C1EC5EF1B0092CE8E /* WordPressKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9368C77E1EC5EF1B0092CE8E /* WordPressKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		93A4232326CBC845004CCA31 /* me-settings-close-account-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 93A4232226CBC845004CCA31 /* me-settings-close-account-success.json */; };
 		93AB06041EE8838400EF8764 /* RemoteTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AB06031EE8838400EF8764 /* RemoteTestCase.swift */; };
 		93BD273B1EE73282002BB00B /* AccountServiceRemote.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BD27381EE73282002BB00B /* AccountServiceRemote.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93BD273C1EE73282002BB00B /* AccountServiceRemoteREST.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BD27391EE73282002BB00B /* AccountServiceRemoteREST.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1009,6 +1010,7 @@
 		9368C77F1EC5EF1B0092CE8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9368C7841EC5EF1B0092CE8E /* WordPressKitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WordPressKitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9368C78B1EC5EF1B0092CE8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		93A4232226CBC845004CCA31 /* me-settings-close-account-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings-close-account-success.json"; sourceTree = "<group>"; };
 		93AB06031EE8838400EF8764 /* RemoteTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteTestCase.swift; sourceTree = "<group>"; };
 		93BD27381EE73282002BB00B /* AccountServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountServiceRemote.h; sourceTree = "<group>"; };
 		93BD27391EE73282002BB00B /* AccountServiceRemoteREST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountServiceRemoteREST.h; sourceTree = "<group>"; };
@@ -1990,6 +1992,7 @@
 				7403A2EF1EF06FEB00DED7DC /* me-settings-change-lastname-success.json */,
 				7403A2F01EF06FEB00DED7DC /* me-settings-change-primary-site-success.json */,
 				7403A2F11EF06FEB00DED7DC /* me-settings-change-web-address-success.json */,
+				93A4232226CBC845004CCA31 /* me-settings-close-account-success.json */,
 				7403A2F21EF06FEB00DED7DC /* me-settings-revert-email-success.json */,
 				7403A2F31EF06FEB00DED7DC /* me-settings-success.json */,
 				93BD274D1EE73442002BB00B /* me-sites-auth-failure.json */,
@@ -2702,6 +2705,7 @@
 				BA4BFC582498C04D005C83E7 /* plugin-update-jetpack-already-updated.json in Resources */,
 				740B23E51F17FB4200067A2A /* xmlrpc-metaweblog-newpost-bad-xml-failure.xml in Resources */,
 				74C473C91EF335B8009918F2 /* site-active-purchases-empty-response.json in Resources */,
+				93A4232326CBC845004CCA31 /* me-settings-close-account-success.json in Resources */,
 				740B23EA1F17FB4200067A2A /* xmlrpc-wp-getpost-success.xml in Resources */,
 				829BA4331FACF187003ADEEA /* activity-rewind-status-restore-queued.json in Resources */,
 				74C473B31EF3204B009918F2 /* site-delete-auth-failure.json in Resources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		9368C78C1EC5EF1B0092CE8E /* WordPressKit.h in Headers */ = {isa = PBXBuildFile; fileRef = 9368C77E1EC5EF1B0092CE8E /* WordPressKit.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93A4232326CBC845004CCA31 /* me-settings-close-account-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 93A4232226CBC845004CCA31 /* me-settings-close-account-success.json */; };
 		93AB06041EE8838400EF8764 /* RemoteTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AB06031EE8838400EF8764 /* RemoteTestCase.swift */; };
+		93AEA69326CE4EED009502D2 /* me-settings-close-account-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = 93AEA69226CE4EED009502D2 /* me-settings-close-account-failure.json */; };
 		93BD273B1EE73282002BB00B /* AccountServiceRemote.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BD27381EE73282002BB00B /* AccountServiceRemote.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93BD273C1EE73282002BB00B /* AccountServiceRemoteREST.h in Headers */ = {isa = PBXBuildFile; fileRef = 93BD27391EE73282002BB00B /* AccountServiceRemoteREST.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		93BD273D1EE73282002BB00B /* AccountServiceRemoteREST.m in Sources */ = {isa = PBXBuildFile; fileRef = 93BD273A1EE73282002BB00B /* AccountServiceRemoteREST.m */; };
@@ -1012,6 +1013,7 @@
 		9368C78B1EC5EF1B0092CE8E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		93A4232226CBC845004CCA31 /* me-settings-close-account-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings-close-account-success.json"; sourceTree = "<group>"; };
 		93AB06031EE8838400EF8764 /* RemoteTestCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteTestCase.swift; sourceTree = "<group>"; };
+		93AEA69226CE4EED009502D2 /* me-settings-close-account-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "me-settings-close-account-failure.json"; sourceTree = "<group>"; };
 		93BD27381EE73282002BB00B /* AccountServiceRemote.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountServiceRemote.h; sourceTree = "<group>"; };
 		93BD27391EE73282002BB00B /* AccountServiceRemoteREST.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccountServiceRemoteREST.h; sourceTree = "<group>"; };
 		93BD273A1EE73282002BB00B /* AccountServiceRemoteREST.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AccountServiceRemoteREST.m; sourceTree = "<group>"; };
@@ -1992,6 +1994,7 @@
 				7403A2EF1EF06FEB00DED7DC /* me-settings-change-lastname-success.json */,
 				7403A2F01EF06FEB00DED7DC /* me-settings-change-primary-site-success.json */,
 				7403A2F11EF06FEB00DED7DC /* me-settings-change-web-address-success.json */,
+				93AEA69226CE4EED009502D2 /* me-settings-close-account-failure.json */,
 				93A4232226CBC845004CCA31 /* me-settings-close-account-success.json */,
 				7403A2F21EF06FEB00DED7DC /* me-settings-revert-email-success.json */,
 				7403A2F31EF06FEB00DED7DC /* me-settings-success.json */,
@@ -2530,6 +2533,7 @@
 				74D67F171F15C2D70010C5ED /* site-users-update-role-success.json in Resources */,
 				74C473B11EF31A19009918F2 /* site-delete-success.json in Resources */,
 				465F8894263B09AE00F4C950 /* wp-block-editor-v1-settings-success-NotThemeJSON.json in Resources */,
+				93AEA69326CE4EED009502D2 /* me-settings-close-account-failure.json in Resources */,
 				E14694031F344F71004052C8 /* site-plugins-error.json in Resources */,
 				829BA4311FACF187003ADEEA /* activity-rewind-status-success.json in Resources */,
 				93BD27571EE73442002BB00B /* auth-send-login-email-no-user-failure.json in Resources */,

--- a/WordPressKit/AccountSettingsRemote.swift
+++ b/WordPressKit/AccountSettingsRemote.swift
@@ -146,6 +146,17 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         })
     }
 
+    public func closeAccount(success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+        let endpoint = "me/account/close"
+        let path = path(forEndpoint: endpoint, withVersion: ._1_1)
+
+        wordPressComRestApi.POST(path, parameters: nil) { _, _ in
+            success()
+        } failure: { error, response in
+            failure(error)
+        }
+    }
+
     private func settingsFromResponse(_ responseObject: AnyObject) throws -> AccountSettings {
         guard let
             response = responseObject as? [String: AnyObject],

--- a/WordPressKitTests/AccountSettingsRemoteTests.swift
+++ b/WordPressKitTests/AccountSettingsRemoteTests.swift
@@ -38,6 +38,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
     let updateSettingsInvalidInputFailureMockFilename              = "me-settings-change-invalid-input-failure.json"
 
     let closeAccountSuccessFilename = "me-settings-close-account-success.json"
+    let closeAccountFailureFilename = "me-settings-close-account-failure.json"
 
     // MARK: - Properties
 
@@ -316,7 +317,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
     func testCloseAccountFails() {
         let expectation = expectation(description: "Closing account should fail")
 
-        stubRemoteResponse(meAccountCloseEndpoint, filename: closeAccountSuccessFilename, contentType: .ApplicationJSON, status: 400)
+        stubRemoteResponse(meAccountCloseEndpoint, filename: closeAccountFailureFilename, contentType: .ApplicationJSON, status: 403)
         remote.closeAccount {
             XCTFail("Closing account unexpectedly succeded")
             expectation.fulfill()

--- a/WordPressKitTests/AccountSettingsRemoteTests.swift
+++ b/WordPressKitTests/AccountSettingsRemoteTests.swift
@@ -20,6 +20,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
     let changedAboutMe      = "I like the color blue and paperclips!"
 
     let meSettingsEndpoint  = "me/settings"
+    let meAccountCloseEndpoint = "me/account/close"
 
     let getAccountSettingsSuccessMockFilename        = "me-settings-success.json"
     let getAccountSettingsAuthFailureMockFilename    = "me-settings-auth-failure.json"
@@ -35,6 +36,8 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
     let updateSettingsChangeDisplayNameSuccessMockFilename         = "me-settings-change-display-name-success.json"
     let updateSettingsChangeDisplayNameBadJsonFailureMockFilename  = "me-settings-change-display-name-bad-json-failure.json"
     let updateSettingsInvalidInputFailureMockFilename              = "me-settings-change-invalid-input-failure.json"
+
+    let closeAccountSuccessFilename = "me-settings-close-account-success.json"
 
     // MARK: - Properties
 
@@ -292,6 +295,34 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(error.code, WordPressComRestApiError.invalidInput.rawValue, "The error code should be 0 - invalid input")
             expect.fulfill()
         })
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testCloseAccountSucceeds() {
+        let expectation = expectation(description: "Closing account should succeed")
+
+        stubRemoteResponse(meAccountCloseEndpoint, filename: closeAccountSuccessFilename, contentType: .ApplicationJSON, status: 200)
+        remote.closeAccount {
+            expectation.fulfill()
+        } failure: { error in
+            XCTFail("Closing account unexpectedly failed with reason: \(error.localizedDescription)")
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testCloseAccountFails() {
+        let expectation = expectation(description: "Closing account should fail")
+
+        stubRemoteResponse(meAccountCloseEndpoint, filename: closeAccountSuccessFilename, contentType: .ApplicationJSON, status: 400)
+        remote.closeAccount {
+            XCTFail("Closing account unexpectedly succeded")
+            expectation.fulfill()
+        } failure: { error in
+            expectation.fulfill()
+        }
 
         waitForExpectations(timeout: timeout, handler: nil)
     }

--- a/WordPressKitTests/Mock Data/me-settings-close-account-failure.json
+++ b/WordPressKitTests/Mock Data/me-settings-close-account-failure.json
@@ -1,0 +1,4 @@
+{
+    "error": "active-subscriptions"
+    "message": "This user account cannot be closed while it has active subscriptions."
+}

--- a/WordPressKitTests/Mock Data/me-settings-close-account-success.json
+++ b/WordPressKitTests/Mock Data/me-settings-close-account-success.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}


### PR DESCRIPTION
Part of [#17029](https://github.com/wordpress-mobile/WordPress-iOS/pull/17029)

### Description
This PR adds close account functionality to the `AccountSettingsRemote`.

- [x] Please check here if your pull request includes additional test coverage.
