### PR TITLE
Comment update: add additional fields to update

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.40.0'
+  s.version       = '4.41.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.41.0-beta.1'
+  s.version       = '4.41.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/AccountSettingsRemote.swift
+++ b/WordPressKit/AccountSettingsRemote.swift
@@ -152,7 +152,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
 
         wordPressComRestApi.POST(path, parameters: nil) { _, _ in
             success()
-        } failure: { error, response in
+        } failure: { error, _ in
             failure(error)
         }
     }

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -118,9 +118,13 @@
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
     NSDictionary *parameters = @{
-                                 @"content": comment.content,
-                                 @"context": @"edit",
-                                 };
+        @"content": comment.content,
+        @"author": comment.author,
+        @"author_email": comment.authorEmail,
+        @"author_url": comment.authorUrl,
+        @"context": @"edit",
+    };
+
     [self.wordPressComRestApi POST:requestUrl
                         parameters:parameters
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -119,11 +119,20 @@
 {
     NSParameterAssert(comment.commentID != nil);
     NSNumber *commentID = comment.commentID;
-    NSArray *extraParameters = @[
-                                 comment.commentID,
-                                 @{@"content": comment.content},
-                                 ];
+    
+    NSDictionary *commentDictionary = @{
+        @"content": comment.content,
+        @"author": comment.author,
+        @"author_email": comment.authorEmail,
+        @"author_url": comment.authorUrl,
+    };
+    
+    NSArray *extraParameters = @[comment.commentID,
+                                 commentDictionary,
+    ];
+
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
+
     [self.api callMethod:@"wp.editComment"
               parameters:parameters
                  success:^(id responseObject, NSHTTPURLResponse *httpResponse) {

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -127,9 +127,10 @@
         @"author_url": comment.authorUrl,
     };
     
-    NSArray *extraParameters = @[comment.commentID,
+    NSArray *extraParameters = @[
+                                 comment.commentID,
                                  commentDictionary,
-    ];
+                                 ];
 
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
 

--- a/WordPressKitTests/AccountSettingsRemoteTests.swift
+++ b/WordPressKitTests/AccountSettingsRemoteTests.swift
@@ -321,7 +321,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
         remote.closeAccount {
             XCTFail("Closing account unexpectedly succeded")
             expectation.fulfill()
-        } failure: { error in
+        } failure: { _ in
             expectation.fulfill()
         }
 


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/17000
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17096

This adds more fields when updating a Comment. This is to support editing a Comment author's name, email, and url.

### Testing Details

Can be tested with references WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
