### PR TITLE
Add the option to create a persistent cart for domains

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.0-beta'
+  s.version       = '4.42.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/TransactionsServiceRemote.swift
+++ b/WordPressKit/TransactionsServiceRemote.swift
@@ -37,11 +37,17 @@ import CocoaLumberjack
         })
     }
 
-    public func createShoppingCart(siteID: Int,
-                                   domainSuggestion: DomainSuggestion,
-                                   privacyProtectionEnabled: Bool,
-                                   success: @escaping (CartResponse) -> Void,
-                                   failure: @escaping (Error) -> Void) {
+    /// Creates a shopping cart for a domain purchase
+    /// - Parameters:
+    ///   - siteID: id of the current site
+    ///   - domainSuggestion: suggested new domain to purchase
+    ///   - temporary: true if the card is temporary, false otherwise
+    private func createDomainShoppingCart(siteID: Int,
+                                          domainSuggestion: DomainSuggestion,
+                                          privacyProtectionEnabled: Bool,
+                                          temporary: Bool,
+                                          success: @escaping (CartResponse) -> Void,
+                                          failure: @escaping (Error) -> Void) {
 
         let endPoint = "me/shopping-cart/\(siteID)"
         let urlPath = path(forEndpoint: endPoint, withVersion: ._1_1)
@@ -53,7 +59,7 @@ import CocoaLumberjack
             productDictionary["extra"] = ["privacy": true] as AnyObject
         }
 
-        let parameters: [String: AnyObject] = ["temporary": "true" as AnyObject,
+        let parameters: [String: AnyObject] = ["temporary": (temporary ? "true" : "false") as AnyObject,
                                                "products": [productDictionary] as AnyObject]
 
         wordPressComRestApi.POST(urlPath,
@@ -72,7 +78,34 @@ import CocoaLumberjack
         }) { (error, _) in
             failure(error)
         }
+    }
 
+    /// Creates a temporary shopping cart for a domain purchase
+    public func createTemporaryDomainShoppingCart(siteID: Int,
+                                                  domainSuggestion: DomainSuggestion,
+                                                  privacyProtectionEnabled: Bool,
+                                                  success: @escaping (CartResponse) -> Void,
+                                                  failure: @escaping (Error) -> Void) {
+        createDomainShoppingCart(siteID: siteID,
+                                 domainSuggestion: domainSuggestion,
+                                 privacyProtectionEnabled: privacyProtectionEnabled,
+                                 temporary: true,
+                                 success: success,
+                                 failure: failure)
+    }
+
+    /// Creates a persistent shopping  cart for a domain purchase
+    public func createPersistentDomainShoppingCart(siteID: Int,
+                                                   domainSuggestion: DomainSuggestion,
+                                                   privacyProtectionEnabled: Bool,
+                                                   success: @escaping (CartResponse) -> Void,
+                                                   failure: @escaping (Error) -> Void) {
+        createDomainShoppingCart(siteID: siteID,
+                                 domainSuggestion: domainSuggestion,
+                                 privacyProtectionEnabled: privacyProtectionEnabled,
+                                 temporary: false,
+                                 success: success,
+                                 failure: failure)
     }
 
     public func redeemCartUsingCredits(cart: CartResponse,

--- a/WordPressKit/TransactionsServiceRemote.swift
+++ b/WordPressKit/TransactionsServiceRemote.swift
@@ -42,6 +42,7 @@ import CocoaLumberjack
     ///   - siteID: id of the current site
     ///   - domainSuggestion: suggested new domain to purchase
     ///   - temporary: true if the card is temporary, false otherwise
+    ///   - privacyProtectionEnabled: true if privacy protection on the given domain is enabled
     private func createDomainShoppingCart(siteID: Int,
                                           domainSuggestion: DomainSuggestion,
                                           privacyProtectionEnabled: Bool,


### PR DESCRIPTION
This PR adds the option to create a persistent cart for domains, along with the existing temporary cart, to support the new domain purchase flow

can be tested on this [WordPress-iOS PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17151)

Fixes #NA



### Testing Details


- [ ] Please check here if your pull request includes additional test coverage.
