### PR TITLE
Adds organization IDs to blogs.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.0-beta.2'
+  s.version       = '4.42.0-beta.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/RemoteBlog.h
+++ b/WordPressKit/RemoteBlog.h
@@ -14,6 +14,11 @@
 @property (nonatomic, copy) NSNumber *blogID;
 
 /**
+ *  @details The organization ID of the Blog entity.
+ */
+@property (nonatomic, copy) NSNumber *organizationID;
+
+/**
  *  @details Represents the Blog Name.
  */
 @property (nonatomic, copy) NSString *name;

--- a/WordPressKit/RemoteBlog.m
+++ b/WordPressKit/RemoteBlog.m
@@ -8,6 +8,7 @@
 {
     if (self = [super init]) {
         _blogID =  [json numberForKey:@"ID"];
+        _organizationID = [json numberForKey:@"organization_id"];
         _name = [json stringForKey:@"name"];
         _tagline = [json stringForKey:@"description"];
         _url = [json stringForKey:@"URL"];
@@ -32,6 +33,7 @@
 {
     NSDictionary *properties = @{
         @"blogID"    : self.blogID,
+        @"organizationID": self.organizationID,
         @"name"     : self.name,
         @"url"      : self.url,
         @"xmlrpc"   : self.xmlrpc,


### PR DESCRIPTION
### Description

Adds the organization ID data field from remote endpoints to blogs.

### Associated PRs:

WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/17154

### Testing Details

Use the testing steps from the associated WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
