### PR TITLE
Reader cross post parsing: fix post url format

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.0-beta.2'
+  s.version       = '4.42.0-beta.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.0-beta.3'
+  s.version       = '4.42.0-beta.4'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -192,14 +192,12 @@ static const NSUInteger ReaderPostTitleLength = 30;
 
             NSString *path = [obj stringForKey:CrossPostMetaValue];
             NSURL *url = [NSURL URLWithString:path];
-            if (!url) {
-                NSLog(@"break");
-            }
-
-            meta.siteURL = [NSString stringWithFormat:@"%@://%@", url.scheme, url.host];
-            meta.postURL = [NSString stringWithFormat:@"%@%@", meta.siteURL, url.path];
-            if ([url.fragment hasPrefix:CrossPostMetaCommentPrefix]) {
-                meta.commentURL = [url absoluteString];
+            if (url) {
+                meta.siteURL = [NSString stringWithFormat:@"%@://%@", url.scheme, url.host];
+                meta.postURL = [NSString stringWithFormat:@"%@%@", meta.siteURL, url.path];
+                if ([url.fragment hasPrefix:CrossPostMetaCommentPrefix]) {
+                    meta.commentURL = [url absoluteString];
+                }
             }
         } else if ([[obj stringForKey:CrossPostMetaKey] isEqualToString:CrossPostMetaXPostOrigin]) {
             NSString *value = [obj stringForKey:CrossPostMetaValue];

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -197,7 +197,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
             }
 
             meta.siteURL = [NSString stringWithFormat:@"%@://%@", url.scheme, url.host];
-            meta.postURL = [NSString stringWithFormat:@"%@/%@", meta.siteURL, url.path];
+            meta.postURL = [NSString stringWithFormat:@"%@%@", meta.siteURL, url.path];
             if ([url.fragment hasPrefix:CrossPostMetaCommentPrefix]) {
                 meta.commentURL = [url absoluteString];
             }


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/17158
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17159

When a cross post's `postURL` is created, there was an unnecessary "/" in the string format, causing the URL to have "//". This removes that extra "/". 

In addition, the check for `url` didn't actually do anything, so it was possible for cross post `siteURL` and `postURL` to be junk. Now, if there is no `url`, the cross post URLs will not be populated.

### Testing Details

Can be tested with the referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
