### PR TITLE
Add organization support to DomainContactInformation messages struct

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.0'
+  s.version       = '4.42.1-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/DomainContactInformation.swift
+++ b/WordPressKit/DomainContactInformation.swift
@@ -12,10 +12,30 @@ public struct ValidateDomainContactInformationResponse: Codable {
         public var firstName: [String]?
         public var lastName: [String]?
         public var state: [String]?
+        public var organization: [String]?
     }
 
     public var success: Bool = false
     public var messages: Messages?
+
+    /// Returns true if any of the properties within `messages` has a value.
+    ///
+    public var hasMessages: Bool {
+        if let messages = messages {
+            let mirror = Mirror(reflecting: messages)
+
+            for child in mirror.children {
+                let childMirror = Mirror(reflecting: child.value)
+
+                if childMirror.displayStyle == .optional,
+                   let _ = childMirror.children.first {
+                    return true
+                }
+            }
+        }
+
+        return false
+    }
 
     public init() {
     }


### PR DESCRIPTION
### Description

This PR adds support for the organization field in the domain contact information struct, as well as a helper property to determine whether any validation messages are present.

### Testing Details

Test using steps in associated WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17296