### PR TITLE
Reads the cost from the domains suggestions endpoint.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.1-beta.1'
+  s.version       = '4.42.1-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -5,6 +5,7 @@ public struct DomainSuggestion: Codable {
     public let domainName: String
     public let productID: Int?
     public let supportsPrivacy: Bool?
+    public let costString: String
 
     public var domainNameStrippingSubdomain: String {
         return domainName.components(separatedBy: ".").first ?? domainName
@@ -18,6 +19,7 @@ public struct DomainSuggestion: Codable {
         self.domainName = domain
         self.productID = json["product_id"] as? Int ?? nil
         self.supportsPrivacy = json["supports_privacy"] as? Bool ?? nil
+        self.costString = json["cost"] as? String ?? ""
     }
 }
 


### PR DESCRIPTION
## Description

This PR makes it possible for client apps to read the cost for a domain suggestion.

## Associated PRs:

WPiOS: https://github.com/wordpress-mobile/WordPress-iOS/pull/17299

## Testing Details

Follow the testing instructions in the associated WPiOS PR.