### PR TITLE
Reader Post: add endpoint to update notification settings for subscriptions

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.1-beta.2'
+  s.version       = '4.42.1-beta.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -588,6 +588,7 @@
 		FAD1344525908F5F00A8FEB1 /* JetpackBackupServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD1344425908F5F00A8FEB1 /* JetpackBackupServiceRemote.swift */; };
 		FAD1344B259094C300A8FEB1 /* JetpackBackup.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD1344A259094C300A8FEB1 /* JetpackBackup.swift */; };
 		FAD1345125909DEA00A8FEB1 /* JetpackBackupServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD1345025909DEA00A8FEB1 /* JetpackBackupServiceRemoteTests.swift */; };
+		FEB7A88F271873BD00A8CF85 /* reader-post-comments-update-notification-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEB7A88E271873BD00A8CF85 /* reader-post-comments-update-notification-success.json */; };
 		FEFFD99126C1347D00F34231 /* ShareAppContentServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFD99026C1347D00F34231 /* ShareAppContentServiceRemote.swift */; };
 		FEFFD99326C141A800F34231 /* RemoteShareAppContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFD99226C141A800F34231 /* RemoteShareAppContent.swift */; };
 		FEFFD99726C158F400F34231 /* share-app-content-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEFFD99626C158F400F34231 /* share-app-content-success.json */; };
@@ -1217,6 +1218,7 @@
 		FAD1344425908F5F00A8FEB1 /* JetpackBackupServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupServiceRemote.swift; sourceTree = "<group>"; };
 		FAD1344A259094C300A8FEB1 /* JetpackBackup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackup.swift; sourceTree = "<group>"; };
 		FAD1345025909DEA00A8FEB1 /* JetpackBackupServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupServiceRemoteTests.swift; sourceTree = "<group>"; };
+		FEB7A88E271873BD00A8CF85 /* reader-post-comments-update-notification-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-update-notification-success.json"; sourceTree = "<group>"; };
 		FEFFD99026C1347D00F34231 /* ShareAppContentServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppContentServiceRemote.swift; sourceTree = "<group>"; };
 		FEFFD99226C141A800F34231 /* RemoteShareAppContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteShareAppContent.swift; sourceTree = "<group>"; };
 		FEFFD99626C158F400F34231 /* share-app-content-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "share-app-content-success.json"; sourceTree = "<group>"; };
@@ -1910,28 +1912,7 @@
 		93BD27421EE73384002BB00B /* Mock Data */ = {
 			isa = PBXGroup;
 			children = (
-				C92EFF7225E7444400E0308D /* common-starter-site-designs-empty-designs.json */,
-				C92EFF6C25E741E900E0308D /* common-starter-site-designs-malformed.json */,
-				C92EFF6825E7403F00E0308D /* common-starter-site-designs-success.json */,
-				FFA4D4AE2423B33800BF5180 /* wp-forbidden.json */,
-				FFA4D4AF2423B33800BF5180 /* wp-pages.json */,
-				FFA4D4AC2423B1FE00BF5180 /* wp-admin-post-new.html */,
-				F194E1242417EE7E00874408 /* atomic-get-auth-cookie-success.json */,
-				40819784221F74B200A298E4 /* stats-post-details.json */,
-				4081977A221F153A00A298E4 /* stats-visits-day.json */,
-				4081977D221F269A00A298E4 /* stats-visits-month.json */,
-				40819779221F153A00A298E4 /* stats-visits-week.json */,
-				40819770221DFDB600A298E4 /* stats-posts-data.json */,
-				40819774221E497C00A298E4 /* stats-published-posts.json */,
-				404057DB221C9FD70060250C /* stats-referrer-data.json */,
 				937250EB267A15060086075F /* stats-referrer-mark-as-spam.json */,
-				404057D7221C98690060250C /* stats-clicks-data.json */,
-				404057D3221C5FC30060250C /* stats-countries-data.json */,
-				404057CF221C46780060250C /* stats-videos-data.json */,
-				404057CA221B80BC0060250C /* stats-top-authors.json */,
-				40F9880D221ACFB400B7B369 /* stats-streak-result.json */,
-				404057C6221B36070060250C /* stats-search-term-result.json */,
-				984E34F322EF9464005C3F92 /* stats-file-downloads.json */,
 				465F8892263B094900F4C950 /* BlockEditorSettings */,
 				FA4261712570CC91003A01E2 /* activity-groups-bad-json-failure.json */,
 				FA42615D2570C712003A01E2 /* activity-groups-success.json */,
@@ -2066,6 +2047,7 @@
 				FA87FE0A24EB4419003FBEE3 /* reader-post-comments-subscribe-success.json */,
 				FA87FE0824EB3FEF003FBEE3 /* reader-post-comments-subscription-status-success.json */,
 				FA87FE0C24EB4450003FBEE3 /* reader-post-comments-unsubscribe-success.json */,
+				FEB7A88E271873BD00A8CF85 /* reader-post-comments-update-notification-success.json */,
 				FACBDD4B25ECB76C0026705B /* reader-post-related-posts-success.json */,
 				8B16CE952525045F007BE5A9 /* reader-posts-success.json */,
 				FFE247C120C9D749002DF3A2 /* reader-site-search-blog-id-fallback.json */,
@@ -2739,6 +2721,7 @@
 				74D67F371F15C3740010C5ED /* site-users-delete-success.json in Resources */,
 				74D67F341F15C3740010C5ED /* site-users-delete-bad-json-failure.json in Resources */,
 				7403A2FF1EF06FEB00DED7DC /* me-settings-revert-email-success.json in Resources */,
+				FEB7A88F271873BD00A8CF85 /* reader-post-comments-update-notification-success.json in Resources */,
 				74B335E21F06F6730053A184 /* WordPressComRestApiFailRequestInvalidToken.json in Resources */,
 				74C473BB1EF328D8009918F2 /* site-export-success.json in Resources */,
 				7403A2FE1EF06FEB00DED7DC /* me-settings-change-web-address-success.json in Resources */,

--- a/WordPressKit/RemoteReaderPost.h
+++ b/WordPressKit/RemoteReaderPost.h
@@ -53,6 +53,7 @@
 
 @property (nonatomic) BOOL canSubscribeComments;
 @property (nonatomic) BOOL isSubscribedComments;
+@property (nonatomic) BOOL receivesCommentNotifications;
 
 // Base Post Model
 @property (nonatomic, strong) NSString *author;

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -58,6 +58,7 @@ NSString * const PostRESTKeyRailcar = @"railcar";
 NSString * const PostRESTKeyOrganizationID = @"meta.data.site.organization_id";
 NSString * const PostRESTKeyCanSubscribeComments = @"can_subscribe_comments";
 NSString * const PostRESTKeyIsSubscribedComments = @"is_subscribed_comments";
+NSString * const POSTRESTKeyReceivesCommentNotifications = @"subscribed_comments_notifications";
 
 // Tag dictionary keys
 NSString * const TagKeyPrimary = @"primaryTag";
@@ -130,6 +131,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     self.organizationID = [dict numberForKeyPath:PostRESTKeyOrganizationID] ?: @0;
     self.canSubscribeComments = [[dict numberForKey:PostRESTKeyCanSubscribeComments] boolValue];
     self.isSubscribedComments = [[dict numberForKey:PostRESTKeyIsSubscribedComments] boolValue];
+    self.receivesCommentNotifications = [[dict numberForKey:POSTRESTKeyReceivesCommentNotifications] boolValue];
 
     if ([dict numberForKey:PostRESTKeyIsSeen]) {
         self.isSeen = [[dict numberForKey:PostRESTKeyIsSeen] boolValue];

--- a/WordPressKitTests/Mock Data/reader-post-comments-update-notification-success.json
+++ b/WordPressKitTests/Mock Data/reader-post-comments-update-notification-success.json
@@ -1,0 +1,4 @@
+{
+  "i_subscribe": true,
+  "receives_notifications": true
+}


### PR DESCRIPTION
### Description

Refs: https://github.com/wordpress-mobile/WordPress-iOS/pull/17322

- Added `receivesCommentNotifications` property to `RemoteReaderPost`.
- Added method in `ReaderPostServiceRemote+Subscriptions` to update notification settings for a post subscription.

### Testing Details

Ensure that all the tests are 🆗 . Manual testing instructions can be done following the instructions described in https://github.com/wordpress-mobile/WordPress-iOS/pull/17322.


- [x] Please check here if your pull request includes additional test coverage.
