### PR TITLE
Domains: Add renewal and expiry properties

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.1'
+  s.version       = '4.42.2-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -269,7 +269,20 @@ private func mapDomainsResponse(_ response: AnyObject) throws -> [RemoteDomain] 
                 throw DomainsServiceRemote.ResponseError.decodingFailed
         }
 
-        return RemoteDomain(domainName: domainName, isPrimaryDomain: isPrimary, domainType: domainTypeFromDomainJSON(domainJson))
+        let autoRenewing = domainJson["auto_renewing"] as? Bool
+        let autoRenewalDate = domainJson["auto_renewal_date"] as? String
+        let expirySoon = domainJson["expiry_soon"] as? Bool
+        let expired = domainJson["expired"] as? Bool
+        let expiryDate = domainJson["expiry"] as? String
+
+        return RemoteDomain(domainName: domainName,
+                            isPrimaryDomain: isPrimary,
+                            domainType: domainTypeFromDomainJSON(domainJson),
+                            autoRenewing: autoRenewing,
+                            autoRenewalDate: autoRenewalDate,
+                            expirySoon: expirySoon,
+                            expired: expired,
+                            expiryDate: expiryDate)
     }
 
     return domains

--- a/WordPressKit/RemoteDomain.swift
+++ b/WordPressKit/RemoteDomain.swift
@@ -25,12 +25,29 @@ public struct RemoteDomain {
     public let isPrimaryDomain: Bool
     public let domainType: DomainType
 
+    // Renewals / Expiry
+    public let autoRenewing: Bool
+    public let autoRenewalDate: String
+    public let expirySoon: Bool
+    public let expired: Bool
+    public let expiryDate: String
+
     public init(domainName: String,
                 isPrimaryDomain: Bool,
-                domainType: DomainType) {
+                domainType: DomainType,
+                autoRenewing: Bool? = nil,
+                autoRenewalDate: String? = nil,
+                expirySoon: Bool? = nil,
+                expired: Bool? = nil,
+                expiryDate: String? = nil) {
         self.domainName = domainName
         self.isPrimaryDomain = isPrimaryDomain
         self.domainType = domainType
+        self.autoRenewing = autoRenewing ?? false
+        self.autoRenewalDate = autoRenewalDate ?? ""
+        self.expirySoon = expirySoon ?? false
+        self.expired = expired ?? false
+        self.expiryDate = expiryDate ?? ""
     }
 }
 


### PR DESCRIPTION
This PR adds properties for domain name renewal and expiry that we receive via a domains API request.

To test, please see the associated WPiOS PR.