### PR TITLE
Empty Stats: Fix error when fetching all-time stats for the first time

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.42.3-beta.1'
+  s.version       = '4.42.3-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/Insights/StatsAllTimesInsight.swift
+++ b/WordPressKit/Insights/StatsAllTimesInsight.swift
@@ -24,8 +24,7 @@ extension StatsAllTimesInsight: StatsInsightData {
     public init?(jsonDictionary: [String: AnyObject]) {
         guard
             let statsDict = jsonDictionary["stats"] as? [String: AnyObject],
-            let bestViewsDayString = statsDict["views_best_day"] as? String,
-            let bestViewsDay = StatsAllTimesInsight.dateFormatter.date(from: bestViewsDayString)
+            let bestViewsDayString = statsDict["views_best_day"] as? String
             else {
                 return nil
         }
@@ -34,7 +33,7 @@ extension StatsAllTimesInsight: StatsInsightData {
         self.bestViewsPerDayCount = statsDict["views_best_day_total"] as? Int ?? 0
         self.visitorsCount = statsDict["visitors"] as? Int ?? 0
         self.viewsCount = statsDict["views"] as? Int ?? 0
-        self.bestViewsDay = bestViewsDay
+        self.bestViewsDay = StatsAllTimesInsight.dateFormatter.date(from: bestViewsDayString) ?? Date()
     }
 
     // MARK: -


### PR DESCRIPTION
FIxes [#17367](https://github.com/wordpress-mobile/WordPress-iOS/issues/17367)

### Description

This PR adds a default value `Date()` for `bestViewsDay` property of `StatsAllTimesInsight` when initialized from remote JSON. `bestViewsDayString` can be `""` for a site with zero views, thus leaving `bestViewsDay` uninitialized, and init failing.

### Testing Details

1. Do a fresh install of WPiOS
2. Create a new site
2. Go to **My Site** > **Stats** for that site
3. Notice there is no error message under all time stats, nor any other section.

- [ ] Please check here if your pull request includes additional test coverage.
