### PR TITLE
Improve XML-RPC error messaging

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.45.0'
+  s.version       = '4.46.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -275,7 +275,8 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
         if (400..<600).contains(httpResponse.statusCode) {
             if let decoder = WPXMLRPCDecoder(data: data), decoder.isFault(), let decoderError = decoder.error() {
-                // sometimes a decodable fault is provided for non-200 HTTP responses, against the XML-RPC spec
+                // when XML-RPC is disabled for authenticated calls (e.g. xmlrpc_enabled is false on WP.org),
+                // it will return a valid fault payload with a non-200
                 throw decoderError
             } else {
                 throw convertError(WordPressOrgXMLRPCApiError.httpErrorStatusCode as NSError, data: originalData, statusCode: httpResponse.statusCode)

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -315,7 +315,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
             userInfo[NSLocalizedFailureErrorKey] = error.localizedDescription
 
             if let statusCode = statusCode, (400..<600).contains(statusCode) {
-                let formatString = NSLocalizedString("An HTTP error code %i was returned.", comment: "Description of a specific error status code returned from an HTTP server")
+                let formatString = NSLocalizedString("An HTTP error code %i was returned.", comment: "A failure reason for when an error HTTP status code was returned from the site, with the specific error code.")
                 userInfo[NSLocalizedFailureReasonErrorKey] = String(format: formatString, statusCode)
             } else {
                 userInfo[NSLocalizedFailureReasonErrorKey] = error.localizedFailureReason
@@ -404,19 +404,19 @@ extension WordPressOrgXMLRPCApi {
 
 extension WordPressOrgXMLRPCApiError: LocalizedError {
     public var errorDescription: String? {
-        return "There was a problem communicating with the site."
+        return NSLocalizedString("There was a problem communicating with the site.", comment: "A general error message shown to the user when there was an API communication failure.")
     }
 
     public var failureReason: String? {
         switch self {
         case .httpErrorStatusCode:
-            return NSLocalizedString("An HTTP error code was returned.", comment: "Description of an error where an error HTTP status code was returned from a site")
+            return NSLocalizedString("An HTTP error code was returned.", comment: "A failure reason for when an error HTTP status code was returned from the site.")
         case .requestSerializationFailed:
-            return NSLocalizedString("The serialization of the request failed.", comment: "Description of an error where a request couldn't be serialized")
+            return NSLocalizedString("The serialization of the request failed.", comment: "A failure reason for when the request couldn't be serialized.")
         case .responseSerializationFailed:
-            return NSLocalizedString("The serialization of the response failed.", comment: "Description of an error where a response couldn't be serialized")
+            return NSLocalizedString("The serialization of the response failed.", comment: "A failure reason for when the response couldn't be serialized.")
         case .unknown:
-            return NSLocalizedString("An unknown error occurred.", comment: "Description of an unknown error")
+            return NSLocalizedString("An unknown error occurred.", comment: "A failure reason for when the error that occured wasn't able to be determined.")
         }
     }
 }

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -306,6 +306,14 @@ open class WordPressOrgXMLRPCApi: NSObject {
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyDataString] = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyStatusCode] = statusCode
+
+            if let statusCode = statusCode, (400..<600).contains(statusCode) {
+                let formatString = NSLocalizedString("An HTTP error code %i was returned from the site.", comment: "An error status code returned from a HTTP server")
+                userInfo[NSLocalizedDescriptionKey] = String(format: formatString, statusCode)
+            } else {
+                userInfo[NSLocalizedDescriptionKey] = error.localizedDescription
+            }
+
             return NSError(domain: error.domain, code: responseCode, userInfo: userInfo as? [String: Any])
         }
         return error
@@ -376,13 +384,28 @@ extension WordPressOrgXMLRPCApi {
 }
 
 /// Error constants for the WordPress XMLRPC API
-///     - RequestSerializationFailed:     The serialization of the request failed
-///     - ResponseSerializationFailed:     The serialization of the response failed
-///     - Unknown:                        Unknow error happen
-///
 @objc public enum WordPressOrgXMLRPCApiError: Int, Error {
+    /// An error HTTP status code was returned.
     case httpErrorStatusCode
+    /// The serialization of the request failed.
     case requestSerializationFailed
+    /// The serialization of the response failed.
     case responseSerializationFailed
+    /// An unknown error occurred.
     case unknown
+}
+
+extension WordPressOrgXMLRPCApiError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .httpErrorStatusCode:
+            return NSLocalizedString("An HTTP error code was returned from the site.", comment: "Description of an error where an error HTTP status code was returned from a site")
+        case .requestSerializationFailed:
+            return NSLocalizedString("The serialization of the request failed.", comment: "Description of an error where a request couldn't be serialized")
+        case .responseSerializationFailed:
+            return NSLocalizedString("The serialization of the response failed.", comment: "Description of an error where a response couldn't be serialized")
+        case .unknown:
+            return NSLocalizedString("An unknown error occurred.", comment: "Description of an unknown error")
+        }
+    }
 }

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -311,12 +311,13 @@ open class WordPressOrgXMLRPCApi: NSObject {
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyData] = data
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyDataString] = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
             userInfo[type(of: self).WordPressOrgXMLRPCApiErrorKeyStatusCode] = statusCode
+            userInfo[NSLocalizedFailureErrorKey] = error.localizedDescription
 
             if let statusCode = statusCode, (400..<600).contains(statusCode) {
-                let formatString = NSLocalizedString("An HTTP error code %i was returned from the site.", comment: "An error status code returned from an HTTP server")
-                userInfo[NSLocalizedDescriptionKey] = String(format: formatString, statusCode)
+                let formatString = NSLocalizedString("An HTTP error code %i was returned.", comment: "Description of a specific error status code returned from an HTTP server")
+                userInfo[NSLocalizedFailureReasonErrorKey] = String(format: formatString, statusCode)
             } else {
-                userInfo[NSLocalizedDescriptionKey] = error.localizedDescription
+                userInfo[NSLocalizedFailureReasonErrorKey] = error.localizedFailureReason
             }
 
             return NSError(domain: error.domain, code: responseCode, userInfo: userInfo as? [String: Any])
@@ -402,9 +403,13 @@ extension WordPressOrgXMLRPCApi {
 
 extension WordPressOrgXMLRPCApiError: LocalizedError {
     public var errorDescription: String? {
+        return "There was a problem communicating with the site."
+    }
+
+    public var failureReason: String? {
         switch self {
         case .httpErrorStatusCode:
-            return NSLocalizedString("An HTTP error code was returned from the site.", comment: "Description of an error where an error HTTP status code was returned from a site")
+            return NSLocalizedString("An HTTP error code was returned.", comment: "Description of an error where an error HTTP status code was returned from a site")
         case .requestSerializationFailed:
             return NSLocalizedString("The serialization of the request failed.", comment: "Description of an error where a request couldn't be serialized")
         case .responseSerializationFailed:


### PR DESCRIPTION
### Description

Fixes:
- https://github.com/wordpress-mobile/WordPress-iOS/issues/17119

### Testing Details

The tests in the WordPress-iOS PR should be executed:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/17724

- [ ] Please check here if your pull request includes additional test coverage.
