### PR TITLE
Merge 4.43.0 stable release into `develop`

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.43.0-beta.1'
+  s.version       = '4.43.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze process for WordPress iOS 18.7 and is here to leave a breadcrumb in the release process. I will be admin-merge it and deploy the new version as soon as CI is green. I'll submit a merge PR against `trunk` for review later on.