### PR TITLE
Comments: return total comment count

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.43.0'
+  s.version       = '4.44.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemote.h
+++ b/WordPressKit/CommentServiceRemote.h
@@ -18,7 +18,7 @@ typedef enum {
  Loads all of the comments associated with a blog
  */
 - (void)getCommentsWithMaximumCount:(NSInteger)maximumComments
-                            success:(void (^)(NSArray *comments))success
+                            success:(void (^)(NSArray *comments, NSNumber *found))success
                             failure:(void (^)(NSError *error))failure;
 
 
@@ -28,7 +28,7 @@ typedef enum {
  */
 - (void)getCommentsWithMaximumCount:(NSInteger)maximumComments
                             options:(NSDictionary *)options
-                            success:(void (^)(NSArray *posts))success
+                            success:(void (^)(NSArray *comments, NSNumber *found))success
                             failure:(void (^)(NSError *error))failure;
 
 /**

--- a/WordPressKit/CommentServiceRemoteXMLRPC.m
+++ b/WordPressKit/CommentServiceRemoteXMLRPC.m
@@ -9,7 +9,7 @@
 @implementation CommentServiceRemoteXMLRPC
 
 - (void)getCommentsWithMaximumCount:(NSInteger)maximumComments
-                            success:(void (^)(NSArray *comments))success
+                            success:(void (^)(NSArray *comments, NSNumber *found))success
                             failure:(void (^)(NSError *error))failure
 {
     [self getCommentsWithMaximumCount:maximumComments options:nil success:success failure:failure];
@@ -17,7 +17,7 @@
 
 - (void)getCommentsWithMaximumCount:(NSInteger)maximumComments
                             options:(NSDictionary *)options
-                            success:(void (^)(NSArray *posts))success
+                            success:(void (^)(NSArray *comments, NSNumber *found))success
                             failure:(void (^)(NSError *error))failure
 {
     NSMutableDictionary *extraParameters = [@{ @"number": @(maximumComments) } mutableCopy];
@@ -31,13 +31,12 @@
     extraParameters[@"status"] = [self parameterForCommentStatus:statusFilter];
 
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:extraParameters];
-    
     [self.api callMethod:@"wp.getComments"
               parameters:parameters
                  success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                      NSAssert([responseObject isKindOfClass:[NSArray class]], @"Response should be an array.");
                      if (success) {
-                         success([self remoteCommentsFromXMLRPCArray:responseObject]);
+                         success([self remoteCommentsFromXMLRPCArray:responseObject], nil);
                      }
                  } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
                      if (failure) {

--- a/WordPressKit/ProductServiceRemote.swift
+++ b/WordPressKit/ProductServiceRemote.swift
@@ -43,7 +43,7 @@ open class ProductServiceRemote {
 
         serviceRemote.wordPressComRestApi.GET(
             path,
-            parameters: [:]) { result, response in
+            parameters: [:]) { result, _ in
 
             switch result {
             case .success(let responseProducts):

--- a/WordPressKitTests/CommentServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTTests.swift
@@ -32,7 +32,7 @@ final class CommentServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                            contentType: .ApplicationJSON)
 
         remote.getCommentsWithMaximumCount(1,
-                                           success: { comments in
+                                           success: { comments, totalComments in
 
             guard let comment = comments?.first as? RemoteComment else {
                 XCTFail("Failed to retrieve mock site comment")

--- a/WordPressKitTests/CommentServiceRemoteXMLRPCTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteXMLRPCTests.swift
@@ -30,7 +30,7 @@ class CommentServiceRemoteXMLRPCTests: RemoteTestCase, XMLRPCTestable {
 
         if let remoteInstance = remote as? CommentServiceRemote {
             remoteInstance.getCommentsWithMaximumCount(1,
-                                                       success: { comments in
+                                                       success: { comments, totalComments in
 
                 guard let comment = comments?.first as? RemoteComment else {
                     XCTFail("Failed to retrieve mock site comment")

--- a/WordPressKitTests/ReaderPostServiceRemote+SubscriptionTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+SubscriptionTests.swift
@@ -118,7 +118,7 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
             // the boolean result should match the receiveNotifications property passed in the params.
             expect.fulfill()
         },
-                                                                  failure: { error in
+                                                                  failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -141,7 +141,7 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         },
-                                                                  failure: { error in
+                                                                  failure: { _ in
             expect.fulfill()
         })
 
@@ -159,7 +159,7 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         },
-                                                                  failure: { error in
+                                                                  failure: { _ in
             expect.fulfill()
         })
 


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/17511
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17513

This updates the `getComments` methods to return the total comment count provided by the API.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
