### PR TITLE
Hierarchical Comments: return total comment count

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.43.0'
+  s.version       = '4.44.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.h
+++ b/WordPressKit/CommentServiceRemoteREST.h
@@ -16,13 +16,13 @@
  @param postID The ID of the post.
  @param page The page number to fetch.
  @param number The number to fetch per page.
- @param success block called on a successful fetch.
+ @param success block called on a successful fetch. Returns the comments array and total comments count.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)syncHierarchicalCommentsForPost:(NSNumber * _Nonnull)postID
                                    page:(NSUInteger)page
                                  number:(NSUInteger)number
-                                success:(void (^ _Nullable)(NSArray * _Nullable comments))success
+                                success:(void (^ _Nullable)(NSArray * _Nullable comments, NSNumber * _Nonnull found))success
                                 failure:(void (^ _Nullable)(NSError * _Nullable error))failure;
 
 /**

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -194,7 +194,7 @@
 - (void)syncHierarchicalCommentsForPost:(NSNumber *)postID
                                    page:(NSUInteger)page
                                  number:(NSUInteger)number
-                                success:(void (^)(NSArray *comments))success
+                                success:(void (^)(NSArray *comments, NSNumber *found))success
                                 failure:(void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies?order=ASC&hierarchical=1&page=%lu&number=%lu", self.siteID, postID, (unsigned long)page, (unsigned long)number];
@@ -210,7 +210,8 @@
         if (success) {
             NSDictionary *dict = (NSDictionary *)responseObject;
             NSArray *comments = [self remoteCommentsFromJSONArray:[dict arrayForKey:@"comments"]];
-            success(comments);
+            NSNumber *found = [responseObject numberForKey:@"found"] ?: @0;
+            success(comments, found);
         }
     } failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         if (failure) {

--- a/WordPressKit/ProductServiceRemote.swift
+++ b/WordPressKit/ProductServiceRemote.swift
@@ -43,7 +43,7 @@ open class ProductServiceRemote {
 
         serviceRemote.wordPressComRestApi.GET(
             path,
-            parameters: [:]) { result, response in
+            parameters: [:]) { result, _ in
 
             switch result {
             case .success(let responseProducts):

--- a/WordPressKitTests/ReaderPostServiceRemote+SubscriptionTests.swift
+++ b/WordPressKitTests/ReaderPostServiceRemote+SubscriptionTests.swift
@@ -118,7 +118,7 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
             // the boolean result should match the receiveNotifications property passed in the params.
             expect.fulfill()
         },
-                                                                  failure: { error in
+                                                                  failure: { _ in
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         })
@@ -141,7 +141,7 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         },
-                                                                  failure: { error in
+                                                                  failure: { _ in
             expect.fulfill()
         })
 
@@ -159,7 +159,7 @@ class ReaderPostServiceRemoteSubscriptionTests: RemoteTestCase, RESTTestable {
             XCTFail("This callback shouldn't get called")
             expect.fulfill()
         },
-                                                                  failure: { error in
+                                                                  failure: { _ in
             expect.fulfill()
         })
 


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/17511
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17515

This updates the `syncHierarchicalCommentsForPost` method to return the total comment count provided by the API.

### Testing Details

Can be tested with referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
