### PR TITLE
Comments: Parse author dotcom ID

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.44.0-beta.1'
+  s.version       = '4.44.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -451,6 +451,7 @@
 {
     RemoteComment *comment = [RemoteComment new];
 
+    comment.authorID = [jsonDictionary numberForKeyPath:@"author.ID"];
     comment.author = jsonDictionary[@"author"][@"name"];
     // Email might be `false`, turn into `nil`
     comment.authorEmail = [jsonDictionary[@"author"] stringForKey:@"email"];

--- a/WordPressKit/RemoteComment.h
+++ b/WordPressKit/RemoteComment.h
@@ -2,6 +2,7 @@
 
 @interface RemoteComment : NSObject
 @property (nonatomic, strong) NSNumber *commentID;
+@property (nonatomic, strong) NSNumber *authorID;
 @property (nonatomic, strong) NSString *author;
 @property (nonatomic, strong) NSString *authorEmail;
 @property (nonatomic, strong) NSString *authorUrl;

--- a/WordPressKit/RemoteReaderPost.h
+++ b/WordPressKit/RemoteReaderPost.h
@@ -56,6 +56,7 @@
 @property (nonatomic) BOOL receivesCommentNotifications;
 
 // Base Post Model
+@property (nonatomic, strong) NSNumber *authorID;
 @property (nonatomic, strong) NSString *author;
 @property (nonatomic, strong) NSString *content;
 @property (nonatomic, strong) NSString *date_created_gmt;

--- a/WordPressKit/RemoteReaderPost.m
+++ b/WordPressKit/RemoteReaderPost.m
@@ -92,6 +92,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
     NSDictionary *authorDict = [dict dictionaryForKey:PostRESTKeyAuthor];
     NSDictionary *discussionDict = [dict dictionaryForKey:PostRESTKeyDiscussion] ?: dict;
 
+    self.authorID = [authorDict numberForKey:PostRESTKeyID];
     self.author = [self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyNiceName]]; // typically the author's screen name
     self.authorAvatarURL = [self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyAvatarURL]];
     self.authorDisplayName = [[self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyName]] stringByDecodingXMLCharacters]; // Typically the author's given name

--- a/WordPressKitTests/CommentServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/CommentServiceRemoteRESTTests.swift
@@ -39,6 +39,7 @@ final class CommentServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 return
             }
 
+            XCTAssertEqual(comment.authorID, NSNumber(value: 12345))
             XCTAssertEqual(comment.author, "Comment Author")
             XCTAssertEqual(comment.authorEmail, "author@email.com")
             XCTAssertEqual(comment.authorUrl, "author URL")

--- a/WordPressKitTests/Mock Data/site-comments-success.json
+++ b/WordPressKitTests/Mock Data/site-comments-success.json
@@ -11,7 +11,7 @@
 				"link": "post URL"
 			},
 			"author": {
-				"ID": 0,
+				"ID": 12345,
 				"login": "",
 				"email": "author@email.com",
 				"name": "Comment Author",


### PR DESCRIPTION
### Description

This PR adds an `authorID` field for `RemoteComment` and updates `CommentServiceRemoteREST` to properly parse the `authorID` value from the API. Previously, this was not done before due to a bug where the comments endpoint would always return `0` for the author ID, regardless of role. 

### Testing Details

Refer to the testing steps detailed in https://github.com/wordpress-mobile/WordPress-iOS/pull/17566.

- [x] Please check here if your pull request includes additional test coverage.
