### PR TITLE
Adds support for marking multiple notifications as read/unread

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Alamofire (4.8.2)
-  - CocoaLumberjack (3.7.4):
-    - CocoaLumberjack/Core (= 3.7.4)
-  - CocoaLumberjack/Core (3.7.4)
+  - CocoaLumberjack (3.7.2):
+    - CocoaLumberjack/Core (= 3.7.2)
+  - CocoaLumberjack/Core (3.7.2)
   - FormatterKit/Resources (1.9.0)
   - FormatterKit/TimeIntervalFormatter (1.9.0):
     - FormatterKit/Resources
   - NSObject-SafeExpectations (0.0.4)
-  - OCMock (3.9.1)
+  - OCMock (3.8.1)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -23,8 +23,8 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
-  - UIDeviceIdentifier (1.7.1)
-  - WordPressShared (1.17.0):
+  - UIDeviceIdentifier (1.4.0)
+  - WordPressShared (1.16.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
   - wpxmlrpc (0.9.0)
@@ -54,15 +54,15 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
+  CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
-  OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
+  OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  UIDeviceIdentifier: d0fee204f467dacf8808b7ac14ce43affeb271a5
-  WordPressShared: a4b0308a6345d4dda20c8f7ad9317df4246b4a00
+  UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
+  WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
 PODFILE CHECKSUM: 41e0ac544d2de6e9267760f9f501e765675b1fa4
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.10.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - Alamofire (4.8.2)
-  - CocoaLumberjack (3.7.2):
-    - CocoaLumberjack/Core (= 3.7.2)
-  - CocoaLumberjack/Core (3.7.2)
+  - CocoaLumberjack (3.7.4):
+    - CocoaLumberjack/Core (= 3.7.4)
+  - CocoaLumberjack/Core (3.7.4)
   - FormatterKit/Resources (1.9.0)
   - FormatterKit/TimeIntervalFormatter (1.9.0):
     - FormatterKit/Resources
   - NSObject-SafeExpectations (0.0.4)
-  - OCMock (3.8.1)
+  - OCMock (3.9.1)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -23,8 +23,8 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
-  - UIDeviceIdentifier (1.4.0)
-  - WordPressShared (1.16.1):
+  - UIDeviceIdentifier (1.7.1)
+  - WordPressShared (1.17.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
   - wpxmlrpc (0.9.0)
@@ -54,15 +54,15 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
+  CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
-  OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
+  OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
-  WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
+  UIDeviceIdentifier: d0fee204f467dacf8808b7ac14ce43affeb271a5
+  WordPressShared: a4b0308a6345d4dda20c8f7ad9317df4246b4a00
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
 PODFILE CHECKSUM: 41e0ac544d2de6e9267760f9f501e765675b1fa4
 
-COCOAPODS: 1.10.2
+COCOAPODS: 1.11.2

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.45.0'
+  s.version       = '4.46.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/NotificationSyncServiceRemote.swift
+++ b/WordPressKit/NotificationSyncServiceRemote.swift
@@ -58,7 +58,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     ///     - completion: Closure to be executed on completion, indicating whether the OP was successful or not.
     ///
     @objc public func updateReadStatus(_ notificationID: String, read: Bool, completion: @escaping ((Error?) -> Void)) {
-        updateReadStatusOfNotifications([notificationID], read: read, completion: completion)
+        updateReadStatusForNotifications([notificationID], read: read, completion: completion)
     }
 
     /// Updates an array of Notifications' Read Status as specified.
@@ -68,7 +68,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     ///     - read: The new Read Status to set.
     ///     - completion: Closure to be executed on completion, indicating whether the OP was successful or not.
     ///
-    @objc public func updateReadStatusOfNotifications(_ notificationIDs: [String], read: Bool, completion: @escaping ((Error?) -> Void)) {
+    @objc public func updateReadStatusForNotifications(_ notificationIDs: [String], read: Bool, completion: @escaping ((Error?) -> Void)) {
         guard !notificationIDs.isEmpty else {
             completion(InputError.arrayEmpty)
             return

--- a/WordPressKit/NotificationSyncServiceRemote.swift
+++ b/WordPressKit/NotificationSyncServiceRemote.swift
@@ -12,6 +12,10 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     public enum SyncError: Error {
         case failed
     }
+    
+    public enum InputError: Int, Error {
+        case arrayEmpty
+    }
 
     /// Retrieves latest Notifications (OR collection of Notifications, whenever noteIds is present)
     ///
@@ -60,11 +64,16 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     /// Updates an array of Notifications' Read Status as specified.
     ///
     /// - Parameters:
-    ///     - notificationIDs: The NotificationIDs to Mark as Read.
+    ///     - notificationIDs: ID's of Notifications to Mark as Read.
     ///     - read: The new Read Status to set.
     ///     - completion: Closure to be executed on completion, indicating whether the OP was successful or not.
     ///
     @objc public func updateReadStatusOfNotifications(_ notificationIDs: [String], read: Bool, completion: @escaping ((Error?) -> Void)) {
+        guard !notificationIDs.isEmpty else {
+            completion(InputError.arrayEmpty)
+            return
+        }
+        
         let path = "notifications/read"
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 

--- a/WordPressKit/NotificationSyncServiceRemote.swift
+++ b/WordPressKit/NotificationSyncServiceRemote.swift
@@ -12,7 +12,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     public enum SyncError: Error {
         case failed
     }
-    
+
     public enum InputError: Int, Error {
         case arrayEmpty
     }
@@ -73,7 +73,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
             completion(InputError.arrayEmpty)
             return
         }
-        
+
         let path = "notifications/read"
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 

--- a/WordPressKit/NotificationSyncServiceRemote.swift
+++ b/WordPressKit/NotificationSyncServiceRemote.swift
@@ -54,15 +54,30 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
     ///     - completion: Closure to be executed on completion, indicating whether the OP was successful or not.
     ///
     @objc public func updateReadStatus(_ notificationID: String, read: Bool, completion: @escaping ((Error?) -> Void)) {
+        updateReadStatusOfNotifications([notificationID], read: read, completion: completion)
+    }
+
+    /// Updates an array of Notifications' Read Status as specified.
+    ///
+    /// - Parameters:
+    ///     - notificationIDs: The NotificationIDs to Mark as Read.
+    ///     - read: The new Read Status to set.
+    ///     - completion: Closure to be executed on completion, indicating whether the OP was successful or not.
+    ///
+    @objc public func updateReadStatusOfNotifications(_ notificationIDs: [String], read: Bool, completion: @escaping ((Error?) -> Void)) {
         let path = "notifications/read"
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 
         // Note: Isn't the API wonderful?
         let value = read ? 9999 : -9999
 
-        let parameters = [
-            "counts": ["\(notificationID)": value]
-        ]
+        var notifications: [String: Int] = [:]
+
+        for notificationID in notificationIDs {
+            notifications[notificationID] = value
+        }
+
+        let parameters = ["counts": notifications]
 
         wordPressComRestApi.POST(requestUrl, parameters: parameters as [String: AnyObject]?, success: { (response, _)  in
             let error = self.errorFromResponse(response)

--- a/WordPressKitTests/NotificationSyncServiceRemoteTests.swift
+++ b/WordPressKitTests/NotificationSyncServiceRemoteTests.swift
@@ -130,10 +130,10 @@ class NotificationSyncServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     /// Verifies that Mark as Read Notifications successfully parses the backend's response
     ///
-    func testUpdateReadStatusOfNotifications() {
+    func testUpdateReadStatusForNotifications() {
         let expect = expectation(description: "Mark notifications as read success")
         stubRemoteResponse(notificationsReadEndpoint, filename: notificationServiceMarkReadMockFilename, contentType: .ApplicationJSON)
-        remote.updateReadStatusOfNotifications(["1234", "4567", "8901"], read: true) { error in
+        remote.updateReadStatusForNotifications(["1234", "4567", "8901"], read: true) { error in
             XCTAssertNil(error)
             expect.fulfill()
         }
@@ -143,10 +143,10 @@ class NotificationSyncServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     /// Verifies that Mark as Read Notifications returns `emptyArray` error when Notification IDs array is empty
     ///
-    func testUpdateReadStatusOfNotificationsReturnsErrorWhenInputArrayIsEmpty() {
+    func testUpdateReadStatusForNotificationsReturnsErrorWhenInputArrayIsEmpty() {
         let expect = expectation(description: "Returns `arrayEmpty` error when input array has no elements")
         stubRemoteResponse(notificationsReadEndpoint, filename: notificationServiceMarkReadMockFilename, contentType: .ApplicationJSON)
-        remote.updateReadStatusOfNotifications([], read: true) { error in
+        remote.updateReadStatusForNotifications([], read: true) { error in
             if let error = error as NSError? {
                 XCTAssertEqual(error.domain, String(reflecting: NotificationSyncServiceRemote.InputError.self))
                 XCTAssertEqual(

--- a/WordPressKitTests/NotificationSyncServiceRemoteTests.swift
+++ b/WordPressKitTests/NotificationSyncServiceRemoteTests.swift
@@ -128,6 +128,39 @@ class NotificationSyncServiceRemoteTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
+    /// Verifies that Mark as Read Notifications successfully parses the backend's response
+    ///
+    func testUpdateReadStatusOfNotifications() {
+        let expect = expectation(description: "Mark notifications as read success")
+        stubRemoteResponse(notificationsReadEndpoint, filename: notificationServiceMarkReadMockFilename, contentType: .ApplicationJSON)
+        remote.updateReadStatusOfNotifications(["1234", "4567", "8901"], read: true) { error in
+            XCTAssertNil(error)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    /// Verifies that Mark as Read Notifications returns `emptyArray` error when Notification IDs array is empty
+    ///
+    func testUpdateReadStatusOfNotificationsReturnsErrorWhenInputArrayIsEmpty() {
+        let expect = expectation(description: "Returns `arrayEmpty` error when input array has no elements")
+        stubRemoteResponse(notificationsReadEndpoint, filename: notificationServiceMarkReadMockFilename, contentType: .ApplicationJSON)
+        remote.updateReadStatusOfNotifications([], read: true) { error in
+            if let error = error as NSError? {
+                XCTAssertEqual(error.domain, String(reflecting: NotificationSyncServiceRemote.InputError.self))
+                XCTAssertEqual(
+                    error.code,
+                    NotificationSyncServiceRemote.InputError.arrayEmpty.rawValue,
+                    "The error code should be 0 - emptyArray"
+                )
+                expect.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
     /// Verifies that Update Last Seen successfully parses the backend's response
     ///
     func testUpdateLastSeen() {


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/17135

This PR adds support for marking multiple notifications as read or unread. Instead of providing a single NotificationID,
we can now also provide an array of IDs. And Bumps the version to `4.46.0-beta.1`.

### Testing Details
* As the already existing `updateReadStatus` function now utilizes the newly added function to avoid code duplication, marking a single notification as read/unread needs to be validated.

* The proper way to test it will be to interact with the Checkmark button that is added with [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17772#issuecomment-1013704458). **This will only be possible with the follow up PR's** that make use of this WPKit change. Though, unit tests are already in place.

- [x] Please check here if your pull request includes additional test coverage.
