### PR TITLE
Feature Announcement: add icons property to Feature struct.

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.46.0-beta.1'
+  s.version       = '4.46.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/AnnouncementServiceRemote.swift
+++ b/WordPressKit/AnnouncementServiceRemote.swift
@@ -104,6 +104,7 @@ public struct Announcement: Codable {
 public struct Feature: Codable {
     public let title: String
     public let subtitle: String
+    public let icons: [[String:String]]?
     public let iconUrl: String
     public let iconBase64: String?
 }

--- a/WordPressKit/AnnouncementServiceRemote.swift
+++ b/WordPressKit/AnnouncementServiceRemote.swift
@@ -104,7 +104,13 @@ public struct Announcement: Codable {
 public struct Feature: Codable {
     public let title: String
     public let subtitle: String
-    public let icons: [[String: String]]?
+    public let icons: [FeatureIcon]?
     public let iconUrl: String
     public let iconBase64: String?
+}
+
+public struct FeatureIcon: Codable {
+    public let iconUrl: String
+    public let iconBase64: String
+    public let iconType: String
 }

--- a/WordPressKit/AnnouncementServiceRemote.swift
+++ b/WordPressKit/AnnouncementServiceRemote.swift
@@ -104,7 +104,7 @@ public struct Announcement: Codable {
 public struct Feature: Codable {
     public let title: String
     public let subtitle: String
-    public let icons: [[String:String]]?
+    public let icons: [[String: String]]?
     public let iconUrl: String
     public let iconBase64: String?
 }


### PR DESCRIPTION
Fixes #n/a

An `icons` property will be added to the Feature Announcement json to accommodate Woo's need for multiple icons. This adds an optional `icons` property to the `Feature` struct so decoding doesn't crash if it is present.

Example of new json with `icons` property:
```
{
	"announcements": [{
		"appVersionName": "79.0",
		"minimumAppVersion": "79.0",
		"maximumAppVersion": "79.0",
		"detailsUrl": "zzz",
		"appVersionTargets": ["79.0 (DEV)"],
		"features": [{
			"title": "Some new feature",
			"subtitle": "We added this cool thing!",
			"icons": [{
				"iconUrl": "xxx",
				"iconBase64": "",
				"iconType": ""
			}],
			"iconUrl": "yyy",
			"iconBase64": ""
		}],
		"announcementVersion": "666",
		"isLocalized": false,
		"responseLocale": "en"
	}]
}
```


### Testing Details

Can be tested with the WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/17797.

- [ ] Please check here if your pull request includes additional test coverage.
