### PR TITLE
Add `getEmailFollowers` and `deleteEmailFollower` API calls

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.46.0'
+  s.version       = '4.46.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.46.1'
+  s.version       = '4.46.0-beta.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -571,6 +571,7 @@
 		F1B7F4FC272376A8004215CD /* NSCharacterSet+URLEncode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B7F4FB272376A8004215CD /* NSCharacterSet+URLEncode.swift */; };
 		F1BB7806240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BB7805240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift */; };
 		F3FF8A1F279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3FF8A1E279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift */; };
+		F3FF8A21279C8EE200E5C90F /* RemotePersonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3FF8A20279C8EE200E5C90F /* RemotePersonTests.swift */; };
 		F9E56DF624EB11EF00916770 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DF524EB11EF00916770 /* FeatureFlag.swift */; };
 		F9E56DF824EB125600916770 /* FeatureFlagRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */; };
 		F9E56DFB24EB18C300916770 /* FeatureFlagRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */; };
@@ -1211,6 +1212,7 @@
 		F1B7F4FB272376A8004215CD /* NSCharacterSet+URLEncode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSCharacterSet+URLEncode.swift"; sourceTree = "<group>"; };
 		F1BB7805240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicAuthenticationServiceRemote.swift; sourceTree = "<group>"; };
 		F3FF8A1E279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDotComFollowersInsightTests.swift; sourceTree = "<group>"; };
+		F3FF8A20279C8EE200E5C90F /* RemotePersonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePersonTests.swift; sourceTree = "<group>"; };
 		F9E56DF524EB11EF00916770 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemote.swift; sourceTree = "<group>"; };
 		F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemoteTests.swift; sourceTree = "<group>"; };
@@ -2346,6 +2348,7 @@
 			isa = PBXGroup;
 			children = (
 				F3FF8A1B279C86E000E5C90F /* Stats */,
+				F3FF8A20279C8EE200E5C90F /* RemotePersonTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -3178,6 +3181,7 @@
 				FA87FE0724EB39C4003FBEE3 /* ReaderPostServiceRemote+SubscriptionTests.swift in Sources */,
 				7403A2E61EF06F7000DED7DC /* AccountSettingsRemoteTests.swift in Sources */,
 				8B16CE92252502C4007BE5A9 /* RemoteReaderPostTests+V2.swift in Sources */,
+				F3FF8A21279C8EE200E5C90F /* RemotePersonTests.swift in Sources */,
 				73D5930521E5541200E4CF84 /* WordPressComServiceRemoteTests+SiteVerticals.swift in Sources */,
 				17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */,
 				73A2F38D21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -570,6 +570,7 @@
 		F194E1252417EE7E00874408 /* atomic-get-auth-cookie-success.json in Resources */ = {isa = PBXBuildFile; fileRef = F194E1242417EE7E00874408 /* atomic-get-auth-cookie-success.json */; };
 		F1B7F4FC272376A8004215CD /* NSCharacterSet+URLEncode.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B7F4FB272376A8004215CD /* NSCharacterSet+URLEncode.swift */; };
 		F1BB7806240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BB7805240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift */; };
+		F3FF8A1F279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3FF8A1E279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift */; };
 		F9E56DF624EB11EF00916770 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DF524EB11EF00916770 /* FeatureFlag.swift */; };
 		F9E56DF824EB125600916770 /* FeatureFlagRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */; };
 		F9E56DFB24EB18C300916770 /* FeatureFlagRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */; };
@@ -1209,6 +1210,7 @@
 		F194E1242417EE7E00874408 /* atomic-get-auth-cookie-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "atomic-get-auth-cookie-success.json"; sourceTree = "<group>"; };
 		F1B7F4FB272376A8004215CD /* NSCharacterSet+URLEncode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSCharacterSet+URLEncode.swift"; sourceTree = "<group>"; };
 		F1BB7805240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicAuthenticationServiceRemote.swift; sourceTree = "<group>"; };
+		F3FF8A1E279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDotComFollowersInsightTests.swift; sourceTree = "<group>"; };
 		F9E56DF524EB11EF00916770 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemote.swift; sourceTree = "<group>"; };
 		F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemoteTests.swift; sourceTree = "<group>"; };
@@ -1630,6 +1632,7 @@
 				9A2D0B29225E0DF7009E585F /* Jetpack */,
 				74FA25F81F1FDA240044BC54 /* Media */,
 				74D97CB91F1CF6E200AC49B7 /* Menu */,
+				F3FF8A1A279C86AF00E5C90F /* Models */,
 				74A44DD61F13C6F3006CD8F4 /* Notifications */,
 				74D67F0B1F15C2570010C5ED /* People */,
 				7433BC061EFC456B002D9E92 /* Plans */,
@@ -2337,6 +2340,38 @@
 				F194E1222417ED9F00874408 /* AtomicAuthenticationServiceRemoteTests.swift */,
 			);
 			name = Authentication;
+			sourceTree = "<group>";
+		};
+		F3FF8A1A279C86AF00E5C90F /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				F3FF8A1B279C86E000E5C90F /* Stats */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		F3FF8A1B279C86E000E5C90F /* Stats */ = {
+			isa = PBXGroup;
+			children = (
+				F3FF8A1C279C86F600E5C90F /* V2 */,
+			);
+			path = Stats;
+			sourceTree = "<group>";
+		};
+		F3FF8A1C279C86F600E5C90F /* V2 */ = {
+			isa = PBXGroup;
+			children = (
+				F3FF8A1D279C86FE00E5C90F /* Insights */,
+			);
+			path = V2;
+			sourceTree = "<group>";
+		};
+		F3FF8A1D279C86FE00E5C90F /* Insights */ = {
+			isa = PBXGroup;
+			children = (
+				F3FF8A1E279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift */,
+			);
+			path = Insights;
 			sourceTree = "<group>";
 		};
 		F9E56DF924EB18A300916770 /* Utilities */ = {
@@ -3133,6 +3168,7 @@
 				93BD27411EE73311002BB00B /* AccountServiceRemoteRESTTests.swift in Sources */,
 				93F50A441F227CFB00B5BEBA /* UsersServiceRemoteXMLRPCTests.swift in Sources */,
 				7430C9BC1F192C0F0051B8E6 /* ReaderSiteServiceRemoteTests.swift in Sources */,
+				F3FF8A1F279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift in Sources */,
 				73D5930321E552CD00E4CF84 /* SiteVerticalsRequestEncodingTests.swift in Sources */,
 				BAB0E36424AD599700B3D22C /* MockPluginStateProvider.swift in Sources */,
 				98F884D426BC6445009ADF57 /* CommentServiceRemoteRESTTests.swift in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -572,6 +572,10 @@
 		F1BB7806240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1BB7805240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift */; };
 		F3FF8A1F279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3FF8A1E279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift */; };
 		F3FF8A21279C8EE200E5C90F /* RemotePersonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3FF8A20279C8EE200E5C90F /* RemotePersonTests.swift */; };
+		F3FF8A23279C954100E5C90F /* site-email-followers-get-success.json in Resources */ = {isa = PBXBuildFile; fileRef = F3FF8A22279C954100E5C90F /* site-email-followers-get-success.json */; };
+		F3FF8A25279C960F00E5C90F /* site-email-followers-get-auth-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = F3FF8A24279C960F00E5C90F /* site-email-followers-get-auth-failure.json */; };
+		F3FF8A27279C967200E5C90F /* site-email-followers-get-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = F3FF8A26279C967200E5C90F /* site-email-followers-get-failure.json */; };
+		F3FF8A29279C991B00E5C90F /* site-email-followers-get-success-more-pages.json in Resources */ = {isa = PBXBuildFile; fileRef = F3FF8A28279C991B00E5C90F /* site-email-followers-get-success-more-pages.json */; };
 		F9E56DF624EB11EF00916770 /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DF524EB11EF00916770 /* FeatureFlag.swift */; };
 		F9E56DF824EB125600916770 /* FeatureFlagRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */; };
 		F9E56DFB24EB18C300916770 /* FeatureFlagRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */; };
@@ -1213,6 +1217,10 @@
 		F1BB7805240FB90B0030ADDC /* AtomicAuthenticationServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicAuthenticationServiceRemote.swift; sourceTree = "<group>"; };
 		F3FF8A1E279C871A00E5C90F /* StatsDotComFollowersInsightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDotComFollowersInsightTests.swift; sourceTree = "<group>"; };
 		F3FF8A20279C8EE200E5C90F /* RemotePersonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePersonTests.swift; sourceTree = "<group>"; };
+		F3FF8A22279C954100E5C90F /* site-email-followers-get-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-email-followers-get-success.json"; sourceTree = "<group>"; };
+		F3FF8A24279C960F00E5C90F /* site-email-followers-get-auth-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-email-followers-get-auth-failure.json"; sourceTree = "<group>"; };
+		F3FF8A26279C967200E5C90F /* site-email-followers-get-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-email-followers-get-failure.json"; sourceTree = "<group>"; };
+		F3FF8A28279C991B00E5C90F /* site-email-followers-get-success-more-pages.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-email-followers-get-success-more-pages.json"; sourceTree = "<group>"; };
 		F9E56DF524EB11EF00916770 /* FeatureFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlag.swift; sourceTree = "<group>"; };
 		F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemote.swift; sourceTree = "<group>"; };
 		F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagRemoteTests.swift; sourceTree = "<group>"; };
@@ -2101,6 +2109,10 @@
 				74C473B81EF325F6009918F2 /* site-delete-missing-status-failure.json */,
 				74C473B01EF31A19009918F2 /* site-delete-success.json */,
 				74C473B61EF3229B009918F2 /* site-delete-unexpected-json-failure.json */,
+				F3FF8A24279C960F00E5C90F /* site-email-followers-get-auth-failure.json */,
+				F3FF8A26279C967200E5C90F /* site-email-followers-get-failure.json */,
+				F3FF8A22279C954100E5C90F /* site-email-followers-get-success.json */,
+				F3FF8A28279C991B00E5C90F /* site-email-followers-get-success-more-pages.json */,
 				74C473BC1EF329CA009918F2 /* site-export-auth-failure.json */,
 				74C473BE1EF32B64009918F2 /* site-export-bad-json-failure.json */,
 				74C473C21EF32DD7009918F2 /* site-export-failure.json */,
@@ -2634,6 +2646,7 @@
 				436D564C211CCCB900CEAA33 /* domain-contact-information-response-success.json in Resources */,
 				FFA4D4AD2423B1FE00BF5180 /* wp-admin-post-new.html in Resources */,
 				937250EC267A15060086075F /* stats-referrer-mark-as-spam.json in Resources */,
+				F3FF8A23279C954100E5C90F /* site-email-followers-get-success.json in Resources */,
 				465F889A263B09BF00F4C950 /* wp-block-editor-v1-settings-success-ThemeJSON.json in Resources */,
 				BA9A7F7F24C6895600925E81 /* plugin-directory-jetpack-beta.json in Resources */,
 				E6B0461425E5B6F500DF6F4F /* sites-invites-links-generate.json in Resources */,
@@ -2674,6 +2687,7 @@
 				74C473C71EF334D4009918F2 /* site-active-purchases-none-active-success.json in Resources */,
 				FA87FE0D24EB4450003FBEE3 /* reader-post-comments-unsubscribe-success.json in Resources */,
 				829BA4321FACF187003ADEEA /* activity-rewind-status-restore-finished.json in Resources */,
+				F3FF8A29279C991B00E5C90F /* site-email-followers-get-success-more-pages.json in Resources */,
 				74D67F181F15C2D70010C5ED /* site-users-update-role-unknown-site-failure.json in Resources */,
 				404057D8221C986A0060250C /* stats-clicks-data.json in Resources */,
 				436D56532121F60500CEAA33 /* supported-states-empty.json in Resources */,
@@ -2694,6 +2708,7 @@
 				E13EE1491F332B8500C15787 /* site-plugins-success.json in Resources */,
 				93BD27581EE73442002BB00B /* auth-send-login-email-success.json in Resources */,
 				74B335E01F06F6290053A184 /* WordPressComRestApiFailInvalidInput.json in Resources */,
+				F3FF8A27279C967200E5C90F /* site-email-followers-get-failure.json in Resources */,
 				FFE247C320C9D749002DF3A2 /* reader-site-search-blog-id-fallback.json in Resources */,
 				93BD27651EE73442002BB00B /* me-sites-visibility-success.json in Resources */,
 				404057D0221C46790060250C /* stats-videos-data.json in Resources */,
@@ -2808,6 +2823,7 @@
 				FFE247B120C891E6002DF3A2 /* WordPressComSocial2FACodeSuccess.json in Resources */,
 				9AEAA774215E774A00876E62 /* site-quick-start-success.json in Resources */,
 				93BD275D1EE73442002BB00B /* me-auth-failure.json in Resources */,
+				F3FF8A25279C960F00E5C90F /* site-email-followers-get-auth-failure.json in Resources */,
 				74D67F361F15C3740010C5ED /* site-users-delete-site-owner-failure.json in Resources */,
 				BA3F139424A0B783006367A3 /* plugin-modify-malformed-response.json in Resources */,
 				74C473CB1EF33696009918F2 /* site-active-purchases-auth-failure.json in Resources */,

--- a/WordPressKit/Insights/StatsDotComFollowersInsight.swift
+++ b/WordPressKit/Insights/StatsDotComFollowersInsight.swift
@@ -40,16 +40,19 @@ extension StatsDotComFollowersInsight: StatsInsightData {
 }
 
 public struct StatsFollower {
+    public let id: String?
     public let name: String
     public let subscribedDate: Date
     public let avatarURL: URL?
 
     public init(name: String,
                 subscribedDate: Date,
-                avatarURL: URL?) {
+                avatarURL: URL?,
+                id: String? = nil) {
         self.name = name
         self.subscribedDate = subscribedDate
         self.avatarURL = avatarURL
+        self.id = id
     }
 }
 
@@ -63,11 +66,11 @@ extension StatsFollower {
             else {
                 return nil
         }
-
-        self.init(name: name, avatar: avatar, date: dateString)
+        let id = jsonDictionary["ID"] as? String
+        self.init(name: name, avatar: avatar, date: dateString, id: id)
     }
 
-    init?(name: String, avatar: String, date: String) {
+    init?(name: String, avatar: String, date: String, id: String? = nil) {
         guard let date = StatsDotComFollowersInsight.dateFormatter.date(from: date) else {
             return nil
         }
@@ -84,5 +87,6 @@ extension StatsFollower {
         self.name = name
         self.subscribedDate = date
         self.avatarURL = url
+        self.id = id
     }
 }

--- a/WordPressKit/PeopleServiceRemote.swift
+++ b/WordPressKit/PeopleServiceRemote.swift
@@ -103,10 +103,8 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
     ///     - siteID: The target site's ID.
     ///     - page: The page to fetch.
     ///     - max: The max number of followers to fetch.
-    ///     - success: Closure to be executed on success.
+    ///     - success: Closure to be executed on success with an array of EmailFollower and a bool indicating if more pages are available.
     ///     - failure: Closure to be executed on error.
-    ///
-    /// - Returns: An array of EmailFollower.
     ///
     public func getEmailFollowers(_ siteID: Int,
                                   page: Int = 1,

--- a/WordPressKit/PeopleServiceRemote.swift
+++ b/WordPressKit/PeopleServiceRemote.swift
@@ -119,7 +119,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "type": "email" as AnyObject
         ]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, _) in
+        wordPressComRestApi.GET(path, parameters: parameters, success: { responseObject, _ in
             guard let response = responseObject as? [String: AnyObject],
                   let subscribers = response["subscribers"] as? [[String: AnyObject]],
                   let totalPages = response["pages"] as? Int else {
@@ -129,7 +129,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             let followers = subscribers.compactMap { EmailFollower(siteID: siteID, statsFollower: StatsFollower(jsonDictionary: $0)) }
             let hasMore = totalPages > page
             success(followers, hasMore)
-        }, failure: { (error, _) in
+        }, failure: { error, _ in
             failure(error)
         })
     }
@@ -277,9 +277,9 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/email-followers/\(userID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (_, _) in
+        wordPressComRestApi.POST(path, parameters: nil, success: { _, _ in
             success?()
-        }, failure: { (error, _) in
+        }, failure: { error, _ in
             failure?(error)
         })
     }

--- a/WordPressKit/RemotePerson.swift
+++ b/WordPressKit/RemotePerson.swift
@@ -56,9 +56,10 @@ extension RemoteRole {
 // MARK: - Specifies all of the possible Person Types that might exist.
 //
 public enum PersonKind: Int {
-    case user       = 0
-    case follower   = 1
-    case viewer     = 2
+    case user
+    case follower
+    case viewer
+    case emailFollower
 }
 
 // MARK: - Defines a Blog's User
@@ -175,6 +176,62 @@ public struct Viewer: RemotePerson {
     }
 }
 
+// MARK: - Defines a Blog's Email Follower
+//
+public struct EmailFollower: RemotePerson {
+    public let ID: Int
+    public let username: String
+    public let firstName: String?
+    public let lastName: String?
+    public let displayName: String
+    public let role: String
+    public let siteID: Int
+    public let linkedUserID: Int
+    public let avatarURL: URL?
+    public let isSuperAdmin: Bool
+    public static let kind = PersonKind.emailFollower
+
+    public init(ID: Int,
+                username: String,
+                firstName: String?,
+                lastName: String?,
+                displayName: String,
+                role: String,
+                siteID: Int,
+                linkedUserID: Int,
+                avatarURL: URL?,
+                isSuperAdmin: Bool) {
+        self.ID = ID
+        self.username = username
+        self.firstName = firstName
+        self.lastName = lastName
+        self.displayName = displayName
+        self.role = role
+        self.siteID = siteID
+        self.linkedUserID = linkedUserID
+        self.avatarURL = avatarURL
+        self.isSuperAdmin = isSuperAdmin
+    }
+
+    public init?(siteID: Int, statsFollower: StatsFollower?) {
+        guard let statsFollower = statsFollower,
+        let stringId = statsFollower.id,
+        let id = Int(stringId) else {
+            return nil
+        }
+
+        self.ID = id
+        self.username = ""
+        self.firstName = nil
+        self.lastName = nil
+        self.displayName = statsFollower.name
+        self.role = ""
+        self.siteID = siteID
+        self.linkedUserID = id
+        self.avatarURL = statsFollower.avatarURL
+        self.isSuperAdmin = false
+    }
+}
 // MARK: - Extensions
 //
 public extension RemotePerson {

--- a/WordPressKitTests/Mock Data/site-email-followers-get-auth-failure.json
+++ b/WordPressKitTests/Mock Data/site-email-followers-get-auth-failure.json
@@ -1,0 +1,4 @@
+{
+  "error": "unauthorized",
+  "message": "user cannot view stats"
+}

--- a/WordPressKitTests/Mock Data/site-email-followers-get-failure.json
+++ b/WordPressKitTests/Mock Data/site-email-followers-get-failure.json
@@ -1,0 +1,4 @@
+{
+  "error": "invalid_blog",
+  "message": "This blog does not have the Stats module enabled"
+}

--- a/WordPressKitTests/Mock Data/site-email-followers-get-success-more-pages.json
+++ b/WordPressKitTests/Mock Data/site-email-followers-get-success-more-pages.json
@@ -1,0 +1,17 @@
+{
+  "page": 1,
+  "pages": 10,
+  "total": 1,
+  "total_email": 1,
+  "total_wpcom": 1,
+  "subscribers": [
+    {
+      "avatar": "https://localhost/image",
+      "label": "test@test.com",
+      "ID": "123456",
+      "url": null,
+      "follow_data": null,
+      "date_subscribed": "2022-01-01T00:00:00+00:00"
+    }
+  ]
+}

--- a/WordPressKitTests/Mock Data/site-email-followers-get-success.json
+++ b/WordPressKitTests/Mock Data/site-email-followers-get-success.json
@@ -1,0 +1,17 @@
+{
+  "page": 1,
+  "pages": 1,
+  "total": 1,
+  "total_email": 1,
+  "total_wpcom": 1,
+  "subscribers": [
+    {
+      "avatar": "https://localhost/image",
+      "label": "test@test.com",
+      "ID": "123456",
+      "url": null,
+      "follow_data": null,
+      "date_subscribed": "2022-01-01T00:00:00+00:00"
+    }
+  ]
+}

--- a/WordPressKitTests/Models/RemotePersonTests.swift
+++ b/WordPressKitTests/Models/RemotePersonTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import WordPressKit
+
+class RemotePersonTests: XCTestCase {
+
+    // MARK: - EmailFollower tests
+
+    func testEmailFollowerKind() {
+        XCTAssertEqual(EmailFollower.kind, .emailFollower)
+    }
+
+    func testConvertingFromStatsFollower() {
+        // Given
+        let date = Date(timeIntervalSince1970: 0)
+        let url = URL(string: "https://localhost/image")
+        let id = "1234567890"
+        let name = "test@test.com"
+        let statsFollower = StatsFollower(name: name, subscribedDate: date, avatarURL: url, id: id)
+        let siteId = 5
+
+        // When
+        let follower = EmailFollower(siteID: siteId, statsFollower: statsFollower)
+
+        // Then
+        let expectedId = Int(id)
+        XCTAssertEqual(follower?.ID, expectedId)
+        XCTAssertEqual(follower?.username, "")
+        XCTAssertNil(follower?.firstName)
+        XCTAssertNil(follower?.lastName)
+        XCTAssertEqual(follower?.displayName, name)
+        XCTAssertEqual(follower?.role, "")
+        XCTAssertEqual(follower?.siteID, siteId)
+        XCTAssertEqual(follower?.linkedUserID, expectedId)
+        XCTAssertEqual(follower?.avatarURL, url)
+        XCTAssertFalse(follower?.isSuperAdmin ?? true)
+    }
+
+    func testConvertingWithNilStatsFollower() {
+        // Given
+        let siteId = 5
+
+        // When
+        let follower = EmailFollower(siteID: siteId, statsFollower: nil)
+
+        // Then
+        XCTAssertNil(follower)
+    }
+
+    func testConvertingWithInvalidId() {
+        // Given
+        let date = Date(timeIntervalSince1970: 0)
+        let url = URL(string: "https://localhost/image")
+        let id = "Not an int"
+        let name = "test@test.com"
+        let statsFollower = StatsFollower(name: name, subscribedDate: date, avatarURL: url, id: id)
+        let siteId = 5
+
+        // When
+        let follower = EmailFollower(siteID: siteId, statsFollower: statsFollower)
+
+        // Then
+        XCTAssertNil(follower)
+    }
+
+}

--- a/WordPressKitTests/Models/Stats/V2/Insights/StatsDotComFollowersInsightTests.swift
+++ b/WordPressKitTests/Models/Stats/V2/Insights/StatsDotComFollowersInsightTests.swift
@@ -3,10 +3,6 @@ import XCTest
 
 class StatsDotComFollowersInsightTests: XCTestCase {
 
-    private enum Constants {
-        static let imageQueryParams = "d=mm&s=60"
-    }
-
     func testInitializingWithNoData() {
         // Given
         let jsonDictionary = getFollowerDictionary()
@@ -42,7 +38,6 @@ class StatsDotComFollowersInsightTests: XCTestCase {
         let date = Date(timeIntervalSince1970: 0)
         let name = "Test"
         let avatarUrl = "https://localhost/image"
-        let expectedUrl = getUrl(from: avatarUrl)
         let jsonDictionary = getFollowerDictionary(id: id, name: name, subscribedDate: date, avatarUrl: avatarUrl)
 
         // When
@@ -50,9 +45,6 @@ class StatsDotComFollowersInsightTests: XCTestCase {
 
         // Then
         XCTAssertEqual(follower?.id, id)
-        XCTAssertEqual(follower?.name, name)
-        XCTAssertEqual(follower?.subscribedDate, date)
-        XCTAssertEqual(follower?.avatarURL, expectedUrl)
     }
 
     func testInitializingWithMissingName() {
@@ -121,7 +113,7 @@ private extension StatsDotComFollowersInsightTests {
 
     func getUrl(from urlString: String) -> URL? {
         guard var components = URLComponents(string: urlString) else { return nil }
-        components.query = Constants.imageQueryParams
+        components.query = "d=mm&s=60"
 
         return try? components.asURL()
     }

--- a/WordPressKitTests/Models/Stats/V2/Insights/StatsDotComFollowersInsightTests.swift
+++ b/WordPressKitTests/Models/Stats/V2/Insights/StatsDotComFollowersInsightTests.swift
@@ -1,0 +1,129 @@
+import XCTest
+@testable import WordPressKit
+
+class StatsDotComFollowersInsightTests: XCTestCase {
+
+    private enum Constants {
+        static let imageQueryParams = "d=mm&s=60"
+    }
+
+    func testInitializingWithNoData() {
+        // Given
+        let jsonDictionary = getFollowerDictionary()
+
+        // When
+        let follower = StatsFollower(jsonDictionary: jsonDictionary)
+
+        // Then
+        XCTAssertNil(follower)
+    }
+
+    func testInitializingWithNoId() {
+        // Given
+        let date = Date(timeIntervalSince1970: 0)
+        let name = "Test"
+        let avatarUrl = "https://localhost/image"
+        let expectedUrl = getUrl(from: avatarUrl)
+        let jsonDictionary = getFollowerDictionary(name: name, subscribedDate: date, avatarUrl: avatarUrl)
+
+        // When
+        let follower = StatsFollower(jsonDictionary: jsonDictionary)
+
+        // Then
+        XCTAssertNil(follower?.id)
+        XCTAssertEqual(follower?.name, name)
+        XCTAssertEqual(follower?.subscribedDate, date)
+        XCTAssertEqual(follower?.avatarURL, expectedUrl)
+    }
+
+    func testInitializingWithId() {
+        // Given
+        let id = "1234567890"
+        let date = Date(timeIntervalSince1970: 0)
+        let name = "Test"
+        let avatarUrl = "https://localhost/image"
+        let expectedUrl = getUrl(from: avatarUrl)
+        let jsonDictionary = getFollowerDictionary(id: id, name: name, subscribedDate: date, avatarUrl: avatarUrl)
+
+        // When
+        let follower = StatsFollower(jsonDictionary: jsonDictionary)
+
+        // Then
+        XCTAssertEqual(follower?.id, id)
+        XCTAssertEqual(follower?.name, name)
+        XCTAssertEqual(follower?.subscribedDate, date)
+        XCTAssertEqual(follower?.avatarURL, expectedUrl)
+    }
+
+    func testInitializingWithMissingName() {
+        // Given
+        let id = "1234567890"
+        let date = Date(timeIntervalSince1970: 0)
+        let avatarUrl = "https://localhost/image"
+        let jsonDictionary = getFollowerDictionary(id: id, subscribedDate: date, avatarUrl: avatarUrl)
+
+        // When
+        let follower = StatsFollower(jsonDictionary: jsonDictionary)
+
+        // Then
+        XCTAssertNil(follower)
+    }
+
+    func testInitializingWithMissingDate() {
+        // Given
+        let id = "1234567890"
+        let name = "Test"
+        let avatarUrl = "https://localhost/image"
+        let jsonDictionary = getFollowerDictionary(id: id, name: name, avatarUrl: avatarUrl)
+
+        // When
+        let follower = StatsFollower(jsonDictionary: jsonDictionary)
+
+        // Then
+        XCTAssertNil(follower)
+    }
+
+    func testInitializingWithMissingAvatar() {
+        // Given
+        let id = "1234567890"
+        let name = "Test"
+        let date = Date(timeIntervalSince1970: 0)
+        let jsonDictionary = getFollowerDictionary(id: id, name: name, subscribedDate: date)
+
+        // When
+        let follower = StatsFollower(jsonDictionary: jsonDictionary)
+
+        // Then
+        XCTAssertNil(follower)
+    }
+
+}
+
+// MARK: - Test functions
+
+private extension StatsDotComFollowersInsightTests {
+
+    func getFollowerDictionary(id: String? = nil, name: String? = nil, subscribedDate: Date? = nil, avatarUrl: String? = nil) -> [String: AnyObject] {
+        var dateString: String?
+
+        if let subscribedDate = subscribedDate {
+            let dateFormatter = ISO8601DateFormatter()
+            dateString = dateFormatter.string(from: subscribedDate)
+        }
+
+        return [
+            "ID": id,
+            "label": name,
+            "date_subscribed": dateString,
+            "avatar": avatarUrl
+        ].compactMapValues { $0 as AnyObject }
+    }
+
+    func getUrl(from urlString: String) -> URL? {
+        guard var components = URLComponents(string: urlString) else { return nil }
+        components.query = Constants.imageQueryParams
+
+        return try? components.asURL()
+    }
+
+}


### PR DESCRIPTION
## Description

See wordpress-mobile/WordPress-iOS#6969

Adds the following API calls:
- [`/sites/$site/stats/followers`](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/stats/followers/)
- `/sites/$site/email-followers/$user_id/delete` (No API documentation)

These are done in the same manner as [`/sites/$site/follows`](https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/follows/) and `/sites/$site/followers/$user_id/delete` to allow for better compatibility. It reuses `StatsFollower` from the insights screen and converts it to a `RemotePerson` to allow for easier use.

## Testing Details

Unit tests were added for every change. Additionally, I verified integration with [WordPress-iOS](https://github.com/wordpress-mobile/WordPress-iOS) after making my changes for the email UI filter.

- [x] Please check here if your pull request includes additional test coverage.
