### PR TITLE
Update UIDeviceIdentifier dependency to version 2.0.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -14,7 +14,7 @@ def wordpresskit_pods
   pod 'NSObject-SafeExpectations', '~> 0.0.4'
   pod 'wpxmlrpc', '~> 0.9.0'
   # pod 'wpxmlrpc', :git => 'https://github.com/wordpress-mobile/wpxmlrpc.git', :branch => 'feature/update-xcode-settings'
-  pod 'UIDeviceIdentifier', '~> 1.4'
+  pod 'UIDeviceIdentifier', '~> 2.0'
 end
 
 ## WordPress Kit

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
-  - UIDeviceIdentifier (1.4.0)
+  - UIDeviceIdentifier (2.0.0)
   - WordPressShared (1.16.1):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
@@ -36,7 +36,7 @@ DEPENDENCIES:
   - OCMock (~> 3.4)
   - OHHTTPStubs (~> 9.0)
   - OHHTTPStubs/Swift (~> 9.0)
-  - UIDeviceIdentifier (~> 1.4)
+  - UIDeviceIdentifier (~> 2.0)
   - WordPressShared (~> 1.15-beta)
   - wpxmlrpc (~> 0.9.0)
 
@@ -59,10 +59,10 @@ SPEC CHECKSUMS:
   NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
   OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  UIDeviceIdentifier: 44f805037d21b94394821828f4fcaba34b38c2d0
+  UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 
-PODFILE CHECKSUM: 41e0ac544d2de6e9267760f9f501e765675b1fa4
+PODFILE CHECKSUM: 16cc178a9361ce125accbf66bdbfd2a3604e1009
 
 COCOAPODS: 1.10.2

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.dependency 'CocoaLumberjack', '~> 3.4'
   s.dependency 'NSObject-SafeExpectations', '0.0.4'
   s.dependency 'wpxmlrpc', '~> 0.9'
-  s.dependency 'UIDeviceIdentifier', '~> 1.4'
+  s.dependency 'UIDeviceIdentifier', '~> 2.0'
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.
   # If you want to update which of these is used, specify it in the host app.


### PR DESCRIPTION
The major version breaking change is due to the library explicitly supporting iOS 9.0 and above, thus dropping support for all prior versions. That doesn't affect us, of course, because we are targeting way above 9.0 already.

See https://github.com/squarefrog/UIDeviceIdentifier/issues/47#issuecomment-998592243

I think we ought to upgrade to 2.0.0 to avoid `pod update` not fetching newest versions because it would stop to the latest 1.x release of the library.

### Testing Details

There are no functionality changes between 2.0.0 and the previous version, 1.4.0, only new models added to the list: https://github.com/squarefrog/UIDeviceIdentifier/compare/1.4.0...2.0.0 If CI is green, we can merge this.