### PR TITLE
Add timezone parameter to site creation request

### DIFF
--- a/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
@@ -16,6 +16,7 @@ public struct SiteCreationRequest: Encodable {
     public let clientIdentifier: String
     public let clientSecret: String
     public let siteDesign: String?
+    public let timezoneIdentifier: String?
 
     public init(segmentIdentifier: Int64?,
                 siteDesign: String?,
@@ -27,7 +28,8 @@ public struct SiteCreationRequest: Encodable {
                 languageIdentifier: String,
                 shouldValidate: Bool,
                 clientIdentifier: String,
-                clientSecret: String) {
+                clientSecret: String,
+                timezoneIdentifier: String?) {
 
         self.segmentIdentifier = segmentIdentifier
         self.siteDesign = siteDesign
@@ -40,6 +42,7 @@ public struct SiteCreationRequest: Encodable {
         self.shouldValidate = shouldValidate
         self.clientIdentifier = clientIdentifier
         self.clientSecret = clientSecret
+        self.timezoneIdentifier = timezoneIdentifier
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -61,7 +64,7 @@ public struct SiteCreationRequest: Encodable {
         } else {
             siteInfo = nil
         }
-        let options = SiteCreationOptions(segmentIdentifier: segmentIdentifier, verticalIdentifier: verticalIdentifier, siteInformation: siteInfo, siteDesign: siteDesign)
+        let options = SiteCreationOptions(segmentIdentifier: segmentIdentifier, verticalIdentifier: verticalIdentifier, siteInformation: siteInfo, siteDesign: siteDesign, timezoneIdentifier: timezoneIdentifier)
 
         try container.encode(options, forKey: .options)
     }
@@ -83,12 +86,14 @@ private struct SiteCreationOptions: Encodable {
     let verticalIdentifier: String?
     let siteInformation: SiteInformation?
     let siteDesign: String?
+    let timezoneIdentifier: String?
 
     enum CodingKeys: String, CodingKey {
         case segmentIdentifier  = "site_segment"
         case verticalIdentifier = "site_vertical"
         case siteInformation    = "site_information"
         case siteDesign         = "template"
+        case timezoneIdentifier = "timezone_string"
     }
 }
 

--- a/WordPressKitTests/SiteCreationRequestEncodingTests.swift
+++ b/WordPressKitTests/SiteCreationRequestEncodingTests.swift
@@ -13,6 +13,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
     static let expectedValidateValue = true
     static let expectedClientId = "TEST-ID"
     static let expectedClientSecret = "TEST-SECRET"
+    static let expectedTimezoneIdentifier = "Pacific/Samoa"
 
     func testSiteCreationRequestEncoding_WithAllParameters_IsSuccessful() {
         // Given
@@ -27,7 +28,8 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             languageIdentifier: SiteCreationRequestEncodingTests.expectedLanguageId,
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
-            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret
+            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
         )
 
         // When
@@ -50,7 +52,8 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             languageIdentifier: SiteCreationRequestEncodingTests.expectedLanguageId,
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
-            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret
+            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
         )
 
         // When
@@ -73,7 +76,8 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             languageIdentifier: SiteCreationRequestEncodingTests.expectedLanguageId,
             shouldValidate: false,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
-            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret
+            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
         )
 
         // When
@@ -98,7 +102,8 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             languageIdentifier: SiteCreationRequestEncodingTests.expectedLanguageId,
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
-            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret
+            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
         )
 
         // When
@@ -121,7 +126,8 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             languageIdentifier: SiteCreationRequestEncodingTests.expectedLanguageId,
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
-            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret
+            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
         )
 
         // When
@@ -144,7 +150,8 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             languageIdentifier: SiteCreationRequestEncodingTests.expectedLanguageId,
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
-            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret
+            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
         )
 
         // When
@@ -167,7 +174,8 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             languageIdentifier: SiteCreationRequestEncodingTests.expectedLanguageId,
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
-            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret
+            clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
         )
 
         // When
@@ -243,5 +251,8 @@ extension SiteCreationRequestEncodingTests {
 
         let actualDesign = actualOptions!["template"] as? String
         XCTAssertEqual(expectedSiteDesign, actualDesign)
+
+        let actualTimezoneIdentifier = actualOptions!["timezone_string"] as? String
+        XCTAssertNotNil(actualTimezoneIdentifier)
     }
 }

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
@@ -23,7 +23,8 @@ final class SiteCreationServiceTests: RemoteTestCase, RESTTestable {
             languageIdentifier: "TEST-ENGLISH",
             shouldValidate: true,
             clientIdentifier: "TEST-ID",
-            clientSecret: "TEST-SECRET"
+            clientSecret: "TEST-SECRET",
+            timezoneIdentifier: TimeZone.current.identifier
         )
 
         // When, Then


### PR DESCRIPTION
### Description

This PR adds the device time zone to site creation requests. The benefit of this change is that sites created on WPiOS will no longer use UTC time, which causes issues in post scheduling.

Related:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/17821

### Testing Details

I've modified existing automated tests to also check for `timezone_string` in outgoing site creation requests. See `testSiteCreationRequestEncoding_WithAllParameters_IsSuccessful` (specifically in the call to `func validate`).

- [x] Please check here if your pull request includes additional test coverage.
