### PR TITLE
Update podspec version for new changes on trunk

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.47.0-beta.1'
+  s.version       = '4.47.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

In https://github.com/wordpress-mobile/WordPressKit-iOS/pull/481, I overlooked updating the podspec version so this PR bumps it to the next beta version.

### Testing Details

Make sure CI is green.

- [x] Please check here if your pull request includes additional test coverage.
