### PR TITLE
Update podspec to fix version tag mismatch

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.47.0-beta.2'
+  s.version       = '4.47.0-beta.4'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

1. I merged https://github.com/wordpress-mobile/WordPressKit-iOS/pull/481 without first updating the podspec version
2. I created the `4.47.0-beta.2` release but overlooked the fact that it pointed to a podspec with version `4.47.0-beta.1`
3. I then created another PR to update the podspec version to `4.47.0-beta.2` and merged it, but the release (and tag) still pointed to the merge commit from the previous PR (doh 🤦 )
4. The Publishing Pod to WP Specs Repo job on build kite failed because the tag (4.47.0-beta.2) didn't match the version (4.47.0-beta.1) found in the podspec that that tag pointed to (see build on https://buildkite.com/automattic/wordpresskit-ios)
5. ⏩ Fast forward a couple of days... 
6. I then created a new release (4.47.0-beta.3) with the latest merge commit from trunk, but again overlooked the fact that podspec version was still 4.47.0-beta.2 🙈 

This aims to resolve this situation by updating the podspec version first. Then I will merge this PR and create a new release pointing to the merge commit on `trunk`.

### Testing Details

Verify CI is green.

~~- [ ] Please check here if your pull request includes additional test coverage.~~ [not applicable since this is a version bump]
