### PR TITLE
Remind authors to update podspec version if needed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,3 +9,4 @@ Fixes #
 ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.
 
 - [ ] Please check here if your pull request includes additional test coverage.
+- [ ] I have considered updating the podspec version.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@ Fixes #
 ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.
 
 - [ ] Please check here if your pull request includes additional test coverage.
-- [ ] I have considered updating the podspec version.
+- [ ] I have considered updating the `version` in the `.podspec` file.


### PR DESCRIPTION
### Description

Assuming contributors know how to publish a new version of this library, they may simply forget to update the podspec version and require a second PR to update it.
This PR adds a checklist item to the repo's PR template to remind contributors to consider whether updating the podspec version is necessary.
A scenario where it is necessary is if the PR is being included directly in WPiOS. A scenario where it may not be necessary is if this PR is part of a group of PRs being included in WPiOS, and only the last PR will bump the version.

### Testing Details

Just check if the new template item adds value here.

- [ ] Please check here if your pull request includes additional test coverage.
