### PR TITLE
Dashboard cards: add `fetch` endpoint

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.47.0-beta.4'
+  s.version       = '4.47.0-beta.5'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -344,6 +344,7 @@
 		82FFBF501F45EFD100F4573F /* RemoteBlogJetpackSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF4F1F45EFD100F4573F /* RemoteBlogJetpackSettings.swift */; };
 		82FFBF521F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */; };
 		82FFBF561F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF551F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift */; };
+		8B074A4E27AC2FFD003A2EB8 /* dashboard-400-invalid-card.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B074A4D27AC2FFD003A2EB8 /* dashboard-400-invalid-card.json */; };
 		8B16CE8E25250039007BE5A9 /* RemoteReaderPost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B16CE8D25250039007BE5A9 /* RemoteReaderPost.swift */; };
 		8B16CE92252502C4007BE5A9 /* RemoteReaderPostTests+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B16CE91252502C4007BE5A9 /* RemoteReaderPostTests+V2.swift */; };
 		8B16CE962525045F007BE5A9 /* reader-posts-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B16CE952525045F007BE5A9 /* reader-posts-success.json */; };
@@ -983,6 +984,7 @@
 		82FFBF4F1F45EFD100F4573F /* RemoteBlogJetpackSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteBlogJetpackSettings.swift; sourceTree = "<group>"; };
 		82FFBF511F45F04100F4573F /* RemoteBlogJetpackMonitorSettings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteBlogJetpackMonitorSettings.swift; sourceTree = "<group>"; };
 		82FFBF551F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlogJetpackSettingsServiceRemote.swift; sourceTree = "<group>"; };
+		8B074A4D27AC2FFD003A2EB8 /* dashboard-400-invalid-card.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-400-invalid-card.json"; sourceTree = "<group>"; };
 		8B16CE8D25250039007BE5A9 /* RemoteReaderPost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteReaderPost.swift; sourceTree = "<group>"; };
 		8B16CE91252502C4007BE5A9 /* RemoteReaderPostTests+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteReaderPostTests+V2.swift"; sourceTree = "<group>"; };
 		8B16CE952525045F007BE5A9 /* reader-posts-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-posts-success.json"; sourceTree = "<group>"; };
@@ -1996,6 +1998,7 @@
 				C92EFF6C25E741E900E0308D /* common-starter-site-designs-malformed.json */,
 				C92EFF6825E7403F00E0308D /* common-starter-site-designs-success.json */,
 				8BB5F62727A9B12800B2FFAF /* dashboard-200-with-drafts-and-scheduled-posts.json */,
+				8B074A4D27AC2FFD003A2EB8 /* dashboard-400-invalid-card.json */,
 				436D564B211CCCB900CEAA33 /* domain-contact-information-response-success.json */,
 				74585B931F0D53B800E7E667 /* domain-service-all-domain-types.json */,
 				74585B9E1F0D6E7500E7E667 /* domain-service-bad-json.json */,
@@ -2592,6 +2595,7 @@
 				7403A2FC1EF06FEB00DED7DC /* me-settings-change-lastname-success.json in Resources */,
 				40F88F601F85723500AE3FAF /* auth-send-verification-email-already-verified-failure.json in Resources */,
 				74D67F211F15C3240010C5ED /* people-validate-invitation-success.json in Resources */,
+				8B074A4E27AC2FFD003A2EB8 /* dashboard-400-invalid-card.json in Resources */,
 				3297E28D25647E0300287D21 /* jetpack-scan-enqueue-success.json in Resources */,
 				7403A2F71EF06FEB00DED7DC /* me-settings-change-display-name-bad-json-failure.json in Resources */,
 				74B335E41F06F6B30053A184 /* WordPressComRestApiMultipleErrors.json in Resources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -362,6 +362,7 @@
 		8B9F0CAE2762414F00DBE144 /* WordPressComRestApiTests+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F0CAD2762414F00DBE144 /* WordPressComRestApiTests+AsyncAwait.swift */; };
 		8BB5F62127A99A2000B2FFAF /* DashboardServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB5F62027A99A2000B2FFAF /* DashboardServiceRemote.swift */; };
 		8BB5F62427A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB5F62327A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift */; };
+		8BB5F62827A9B12800B2FFAF /* dashboard-200-with-drafts-and-scheduled-posts.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BB5F62727A9B12800B2FFAF /* dashboard-200-with-drafts-and-scheduled-posts.json */; };
 		8BB66DB02523C181000B29DA /* ReaderPostServiceRemote+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB66DAF2523C181000B29DA /* ReaderPostServiceRemote+V2.swift */; };
 		8BE67ED324AD05D3004DB4C9 /* Decodable+DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */; };
 		8BFB4E6625B07905004D026E /* jetpack-capabilities-34197361-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BFB4E6525B07905004D026E /* jetpack-capabilities-34197361-success.json */; };
@@ -1000,6 +1001,7 @@
 		8B9F0CAD2762414F00DBE144 /* WordPressComRestApiTests+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApiTests+AsyncAwait.swift"; sourceTree = "<group>"; };
 		8BB5F62027A99A2000B2FFAF /* DashboardServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardServiceRemote.swift; sourceTree = "<group>"; };
 		8BB5F62327A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardServiceRemoteTests.swift; sourceTree = "<group>"; };
+		8BB5F62727A9B12800B2FFAF /* dashboard-200-with-drafts-and-scheduled-posts.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "dashboard-200-with-drafts-and-scheduled-posts.json"; sourceTree = "<group>"; };
 		8BB66DAF2523C181000B29DA /* ReaderPostServiceRemote+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostServiceRemote+V2.swift"; sourceTree = "<group>"; };
 		8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+DictionaryTests.swift"; sourceTree = "<group>"; };
 		8BFB4E6525B07905004D026E /* jetpack-capabilities-34197361-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "jetpack-capabilities-34197361-success.json"; sourceTree = "<group>"; };
@@ -1993,6 +1995,7 @@
 				C92EFF7225E7444400E0308D /* common-starter-site-designs-empty-designs.json */,
 				C92EFF6C25E741E900E0308D /* common-starter-site-designs-malformed.json */,
 				C92EFF6825E7403F00E0308D /* common-starter-site-designs-success.json */,
+				8BB5F62727A9B12800B2FFAF /* dashboard-200-with-drafts-and-scheduled-posts.json */,
 				436D564B211CCCB900CEAA33 /* domain-contact-information-response-success.json */,
 				74585B931F0D53B800E7E667 /* domain-service-all-domain-types.json */,
 				74585B9E1F0D6E7500E7E667 /* domain-service-bad-json.json */,
@@ -2603,6 +2606,7 @@
 				AB49D09725D1AC0A0084905B /* post-likes-success.json in Resources */,
 				74FC6F401F191C1D00112505 /* notifications-mark-as-read.json in Resources */,
 				74D67F3A1F15C3740010C5ED /* site-viewers-delete-failure.json in Resources */,
+				8BB5F62827A9B12800B2FFAF /* dashboard-200-with-drafts-and-scheduled-posts.json in Resources */,
 				BA3F138E24A09C87006367A3 /* plugin-install-generic-error.json in Resources */,
 				3236F79C24AE413A0088E8F3 /* reader-interests-success.json in Resources */,
 				93BD275C1EE73442002BB00B /* is-available-username-success.json in Resources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -360,6 +360,8 @@
 		8B749E8625AF808600023F03 /* jetpack-capabilities-107159616-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B749E8525AF808600023F03 /* jetpack-capabilities-107159616-success.json */; };
 		8B749E8A25AF819700023F03 /* jetpack-capabilities-malformed.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B749E8925AF819700023F03 /* jetpack-capabilities-malformed.json */; };
 		8B9F0CAE2762414F00DBE144 /* WordPressComRestApiTests+AsyncAwait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F0CAD2762414F00DBE144 /* WordPressComRestApiTests+AsyncAwait.swift */; };
+		8BB5F62127A99A2000B2FFAF /* DashboardServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB5F62027A99A2000B2FFAF /* DashboardServiceRemote.swift */; };
+		8BB5F62427A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB5F62327A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift */; };
 		8BB66DB02523C181000B29DA /* ReaderPostServiceRemote+V2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB66DAF2523C181000B29DA /* ReaderPostServiceRemote+V2.swift */; };
 		8BE67ED324AD05D3004DB4C9 /* Decodable+DictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */; };
 		8BFB4E6625B07905004D026E /* jetpack-capabilities-34197361-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BFB4E6525B07905004D026E /* jetpack-capabilities-34197361-success.json */; };
@@ -996,6 +998,8 @@
 		8B749E8525AF808600023F03 /* jetpack-capabilities-107159616-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "jetpack-capabilities-107159616-success.json"; sourceTree = "<group>"; };
 		8B749E8925AF819700023F03 /* jetpack-capabilities-malformed.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "jetpack-capabilities-malformed.json"; sourceTree = "<group>"; };
 		8B9F0CAD2762414F00DBE144 /* WordPressComRestApiTests+AsyncAwait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApiTests+AsyncAwait.swift"; sourceTree = "<group>"; };
+		8BB5F62027A99A2000B2FFAF /* DashboardServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardServiceRemote.swift; sourceTree = "<group>"; };
+		8BB5F62327A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardServiceRemoteTests.swift; sourceTree = "<group>"; };
 		8BB66DAF2523C181000B29DA /* ReaderPostServiceRemote+V2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostServiceRemote+V2.swift"; sourceTree = "<group>"; };
 		8BE67ED224AD05D3004DB4C9 /* Decodable+DictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decodable+DictionaryTests.swift"; sourceTree = "<group>"; };
 		8BFB4E6525B07905004D026E /* jetpack-capabilities-34197361-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "jetpack-capabilities-34197361-success.json"; sourceTree = "<group>"; };
@@ -1585,6 +1589,14 @@
 			name = Activity;
 			sourceTree = "<group>";
 		};
+		8BB5F62227A9A5AF00B2FFAF /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				8BB5F62327A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift */,
+			);
+			name = Dashboard;
+			sourceTree = "<group>";
+		};
 		8BE67ED124AD05B5004DB4C9 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -1636,6 +1648,7 @@
 				74B5F0DF1EF82AAB00B411E7 /* Blog */,
 				465F88A5263B370300F4C950 /* BlockEditorSettings */,
 				ABD95B7D25DD6C2400735BEE /* Comment */,
+				8BB5F62227A9A5AF00B2FFAF /* Dashboard */,
 				74585B911F0D520700E7E667 /* Domains */,
 				7EC60EBC22DC4F5A00FB0336 /* Editor */,
 				8BE67ED124AD05B5004DB4C9 /* Extensions */,
@@ -1756,6 +1769,7 @@
 				FEE4EF58272FF78C003CDA3C /* CommentServiceRemoteREST+ApiV2.swift */,
 				74BA04F01F06DC0A00ED5CD8 /* CommentServiceRemoteXMLRPC.h */,
 				74BA04F11F06DC0A00ED5CD8 /* CommentServiceRemoteXMLRPC.m */,
+				8BB5F62027A99A2000B2FFAF /* DashboardServiceRemote.swift */,
 				74585B8D1F0D51A100E7E667 /* DomainsServiceRemote.swift */,
 				74650F711F0EA1A700188EDB /* GravatarServiceRemote.swift */,
 				1769DEA924729AFF00F42EFC /* HomepageSettingsServiceRemote.swift */,
@@ -2997,6 +3011,7 @@
 				B5A4822920AC6BA9009D95F6 /* WPKitLoggingPrivate.m in Sources */,
 				E6D0EE621F7EF9CE0064D3FC /* AccountServiceRemoteREST+SocialService.swift in Sources */,
 				7430C9B61F1927C50051B8E6 /* RemoteReaderSiteInfo.m in Sources */,
+				8BB5F62127A99A2000B2FFAF /* DashboardServiceRemote.swift in Sources */,
 				74DA56351F06EAF000FE9BF4 /* MediaServiceRemoteXMLRPC.m in Sources */,
 				C797196C2679007B0072F984 /* PluginManagementClient.swift in Sources */,
 				C785325625B5F46C006CEAFB /* JetpackThreatFixStatus.swift in Sources */,
@@ -3199,6 +3214,7 @@
 				8B16CE92252502C4007BE5A9 /* RemoteReaderPostTests+V2.swift in Sources */,
 				F3FF8A21279C8EE200E5C90F /* RemotePersonTests.swift in Sources */,
 				73D5930521E5541200E4CF84 /* WordPressComServiceRemoteTests+SiteVerticals.swift in Sources */,
+				8BB5F62427A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift in Sources */,
 				17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */,
 				73A2F38D21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift in Sources */,
 				74C473AF1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
-    open func fetch(cards: [String], forBlogID blogID: Int, completion: @escaping (NSDictionary) -> Void) {
+    open func fetch(cards: [String], forBlogID blogID: Int, success: @escaping (NSDictionary) -> Void, failure: @escaping (Error) -> Void) {
         guard let requestUrl = endpoint(for: cards, blogID: blogID) else {
             return
         }
@@ -14,8 +14,9 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
                 return
             }
 
-            completion(cards)
+            success(cards)
         }, failure: { error, _ in
+            failure(error)
             DDLogError("Error fetching dashboard cards: \(error)")
         })
     }

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -10,7 +10,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
                                 parameters: nil,
                                 success: { response, _ in
             guard let cards = response["body"] as? NSDictionary else {
-                // failure
+                failure(ResponseError.decodingFailure)
                 return
             }
 
@@ -32,5 +32,9 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
         }
 
         return self.path(forEndpoint: endpoint, withVersion: ._2_0)
+    }
+
+    enum ResponseError: Error {
+        case decodingFailure
     }
 }

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
-    open func fetch(cards: [String], forBlogID blogID: Int, completion: @escaping () -> Void) {
+    open func fetch(cards: [String], forBlogID blogID: Int, completion: @escaping (NSDictionary) -> Void) {
         guard let requestUrl = endpoint(for: cards, blogID: blogID) else {
             return
         }
@@ -9,8 +9,12 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.GET(requestUrl,
                                 parameters: nil,
                                 success: { response, _ in
+            guard let cards = response["body"] as? NSDictionary else {
+                // failure
+                return
+            }
 
-                                    completion()
+            completion(cards)
         }, failure: { error, _ in
             DDLogError("Error fetching dashboard cards: \(error)")
         })

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -9,7 +9,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
         wordPressComRestApi.GET(requestUrl,
                                 parameters: nil,
                                 success: { response, _ in
-            guard let cards = response["body"] as? NSDictionary else {
+            guard let cards = response as? NSDictionary else {
                 failure(ResponseError.decodingFailure)
                 return
             }

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
+    
+}

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -1,5 +1,31 @@
 import Foundation
 
 open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
-    
+    open func fetch(cards: [String], forBlogID blogID: Int, completion: @escaping () -> Void) {
+        guard let requestUrl = endpoint(for: cards, blogID: blogID) else {
+            return
+        }
+
+        wordPressComRestApi.GET(requestUrl,
+                                parameters: nil,
+                                success: { response, _ in
+
+                                    completion()
+        }, failure: { error, _ in
+            DDLogError("Error fetching dashboard cards: \(error)")
+        })
+    }
+
+    private func endpoint(for cards: [String], blogID: Int) -> String? {
+        var path = URLComponents(string: "sites/\(blogID)/dashboard/cards/v1_1/")
+
+        let cardsEncoded = cards.joined(separator: ",")
+        path?.queryItems = [URLQueryItem(name: "cards", value: cardsEncoded)]
+
+        guard let endpoint = path?.string else {
+            return nil
+        }
+
+        return self.path(forEndpoint: endpoint, withVersion: ._2_0)
+    }
 }

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -10,13 +10,28 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         dashboardServiceRemote = DashboardServiceRemote(wordPressComRestApi: getRestApi())
     }
 
-    // Request the correct set of cards
+    // Requests the correct set of cards
+    //
+    func testRequestCardsParam() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,today_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
+
+        dashboardServiceRemote.fetch(cards: ["posts", "today_stats"], forBlogID: 165243437) { _ in
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    // Return the cards when the request succeeds
     //
     func testRequestCards() {
         let expect = expectation(description: "Get cards successfully")
         stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,today_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
 
-        dashboardServiceRemote.fetch(cards: ["posts", "today_stats"], forBlogID: 165243437) {
+        dashboardServiceRemote.fetch(cards: ["posts", "today_stats"], forBlogID: 165243437) { cards in
+            XCTAssertTrue((cards["posts"] as! NSDictionary)["has_published"] as! Bool)
+            XCTAssertEqual((cards["todays_stats"] as! NSDictionary)["views"] as! Int, 0)
             expect.fulfill()
         }
 

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -18,7 +18,7 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
             expect.fulfill()
-        }
+        } failure: { _ in }
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
@@ -32,6 +32,21 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { cards in
             XCTAssertTrue((cards["posts"] as! NSDictionary)["has_published"] as! Bool)
             XCTAssertEqual((cards["todays_stats"] as! NSDictionary)["views"] as! Int, 0)
+            expect.fulfill()
+        } failure: { _ in }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    // Calls the failure block when request fails
+    //
+    func testRequestFails() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,todays_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON, status: 503)
+
+        dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
+            XCTFail("This call should not suceed")
+        } failure: { error in
             expect.fulfill()
         }
 

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+
+@testable import WordPressKit
+
+class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
+    let mockRemoteApi = MockWordPressComRestApi()
+    var dashboardServiceRemote: DashboardServiceRemote!
+}

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -5,4 +5,21 @@ import XCTest
 class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
     let mockRemoteApi = MockWordPressComRestApi()
     var dashboardServiceRemote: DashboardServiceRemote!
+
+    override func setUp() {
+        dashboardServiceRemote = DashboardServiceRemote(wordPressComRestApi: getRestApi())
+    }
+
+    // Request the correct set of cards
+    //
+    func testRequestCards() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,today_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
+
+        dashboardServiceRemote.fetch(cards: ["posts", "today_stats"], forBlogID: 165243437) {
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
 }

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -52,4 +52,19 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
+
+    // Calls the failure block when an invalid card is given
+    //
+    func testRequestInvalidCard() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=invalid_card", filename: "dashboard-400-invalid-card.json", contentType: .ApplicationJSON, status: 400)
+
+        dashboardServiceRemote.fetch(cards: ["invalid_card"], forBlogID: 165243437) { _ in
+            XCTFail("This call should not suceed")
+        } failure: { error in
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
 }

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -67,4 +67,19 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
 
         waitForExpectations(timeout: timeout, handler: nil)
     }
+
+    // Calls the failure block when request fails
+    //
+    func testRequestInvalidJSON() {
+        let expect = expectation(description: "Get cards successfully")
+        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,todays_stats", data: "{}".data(using: .utf8)!, contentType: .ApplicationJSON)
+
+        dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
+            XCTFail("This call should not suceed")
+        } failure: { error in
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
 }

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -72,7 +72,7 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
     //
     func testRequestInvalidJSON() {
         let expect = expectation(description: "Get cards successfully")
-        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,todays_stats", data: "{}".data(using: .utf8)!, contentType: .ApplicationJSON)
+        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,todays_stats", data: "foo".data(using: .utf8)!, contentType: .ApplicationJSON)
 
         dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
             XCTFail("This call should not suceed")

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -14,9 +14,9 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
     //
     func testRequestCardsParam() {
         let expect = expectation(description: "Get cards successfully")
-        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,today_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
+        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,todays_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
 
-        dashboardServiceRemote.fetch(cards: ["posts", "today_stats"], forBlogID: 165243437) { _ in
+        dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
             expect.fulfill()
         }
 
@@ -27,9 +27,9 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
     //
     func testRequestCards() {
         let expect = expectation(description: "Get cards successfully")
-        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,today_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
+        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards/v1_1/?cards=posts,todays_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
 
-        dashboardServiceRemote.fetch(cards: ["posts", "today_stats"], forBlogID: 165243437) { cards in
+        dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { cards in
             XCTAssertTrue((cards["posts"] as! NSDictionary)["has_published"] as! Bool)
             XCTAssertEqual((cards["todays_stats"] as! NSDictionary)["views"] as! Int, 0)
             expect.fulfill()

--- a/WordPressKitTests/Mock Data/dashboard-200-with-drafts-and-scheduled-posts.json
+++ b/WordPressKitTests/Mock Data/dashboard-200-with-drafts-and-scheduled-posts.json
@@ -1,49 +1,31 @@
 {
-    "body": {
-        "posts": {
-            "has_published": true,
-            "draft": [
-                {
-                    "id": 1949,
-                    "title": "Howdy 🤷🏻‍♂️",
-                    "content": "Howdy",
-                    "featured_image": null,
-                    "date": "2022-01-19 12:46:04"
-                },
-                {
-                    "id": 1688,
-                    "title": "Test",
-                    "content": "Test",
-                    "featured_image": null,
-                    "date": "2020-06-05 15:02:55"
-                },
-                {
-                    "id": 1679,
-                    "title": "Edged",
-                    "content": "Dfgdfgdg",
-                    "featured_image": null,
-                    "date": "0000-00-00 00:00:00"
-                }
-            ],
-            "scheduled": [
-                {
-                    "id": 1954,
-                    "title": "Scheduled",
-                    "content": "Scheduled",
-                    "featured_image": null,
-                    "date": "2023-01-08 17:46:00"
-                }
-            ]
-        },
-        "todays_stats": {
-            "views": 0,
-            "visitors": 0,
-            "likes": 0,
-            "comments": 0
-        }
+    "posts": {
+        "has_published": true,
+        "draft": [{
+            "id": 3246,
+            "title": "Whatever",
+            "content": "",
+            "featured_image": null,
+            "date": "2022-01-13 00:30:56"
+        }, {
+            "id": 3120,
+            "title": "Dfhhffg :)",
+            "content": "",
+            "featured_image": null,
+            "date": "2021-03-05 21:04:44"
+        }, {
+            "id": 3109,
+            "title": "Title!",
+            "content": "",
+            "featured_image": null,
+            "date": "0000-00-00 00:00:00"
+        }],
+        "scheduled": []
     },
-    "status": 200,
-    "headers": {
-        "Allow": "GET"
+    "todays_stats": {
+        "views": 0,
+        "visitors": 0,
+        "likes": 0,
+        "comments": 0
     }
 }

--- a/WordPressKitTests/Mock Data/dashboard-200-with-drafts-and-scheduled-posts.json
+++ b/WordPressKitTests/Mock Data/dashboard-200-with-drafts-and-scheduled-posts.json
@@ -1,0 +1,49 @@
+{
+    "body": {
+        "posts": {
+            "has_published": true,
+            "draft": [
+                {
+                    "id": 1949,
+                    "title": "Howdy 🤷🏻‍♂️",
+                    "content": "Howdy",
+                    "featured_image": null,
+                    "date": "2022-01-19 12:46:04"
+                },
+                {
+                    "id": 1688,
+                    "title": "Test",
+                    "content": "Test",
+                    "featured_image": null,
+                    "date": "2020-06-05 15:02:55"
+                },
+                {
+                    "id": 1679,
+                    "title": "Edged",
+                    "content": "Dfgdfgdg",
+                    "featured_image": null,
+                    "date": "0000-00-00 00:00:00"
+                }
+            ],
+            "scheduled": [
+                {
+                    "id": 1954,
+                    "title": "Scheduled",
+                    "content": "Scheduled",
+                    "featured_image": null,
+                    "date": "2023-01-08 17:46:00"
+                }
+            ]
+        },
+        "todays_stats": {
+            "views": 0,
+            "visitors": 0,
+            "likes": 0,
+            "comments": 0
+        }
+    },
+    "status": 200,
+    "headers": {
+        "Allow": "GET"
+    }
+}

--- a/WordPressKitTests/Mock Data/dashboard-400-invalid-card.json
+++ b/WordPressKitTests/Mock Data/dashboard-400-invalid-card.json
@@ -1,0 +1,17 @@
+{
+    "code": "rest_invalid_param",
+    "message": "Invalid parameter(s): cards",
+    "data": {
+        "status": 400,
+        "params": {
+            "cards": "Invalid request: Empty Params."
+        },
+        "details": {
+            "cards": {
+                "code": "sites_dashboard_validate_cards",
+                "message": "Invalid request: Empty Params.",
+                "data": 400
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

Add the Dashboard v1.1 endpoint.

### Testing Details

Please, use instructions on the WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/17889

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file. (will do before merging)