### PR TITLE
[Gutenberg] RemoteBlockEditorSettings - Add Quote block V2 flag

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.49.0'
+  s.version       = '4.50.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -4,6 +4,7 @@ public class RemoteBlockEditorSettings: Codable {
     enum CodingKeys: String, CodingKey {
         case isFSETheme = "__unstableEnableFullSiteEditingBlocks"
         case galleryWithImageBlocks = "__unstableGalleryWithImageBlocks"
+        case quoteBlockV2 = "__experimentalEnableQuoteBlockV2"
         case rawStyles = "__experimentalStyles"
         case rawFeatures = "__experimentalFeatures"
         case colors
@@ -12,6 +13,7 @@ public class RemoteBlockEditorSettings: Codable {
 
     public let isFSETheme: Bool
     public let galleryWithImageBlocks: Bool
+    public let quoteBlockV2: Bool
     public let rawStyles: String?
     public let rawFeatures: String?
     public let colors: [[String: String]]?
@@ -37,6 +39,7 @@ public class RemoteBlockEditorSettings: Codable {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
         self.galleryWithImageBlocks = (try? map.decode(Bool.self, forKey: .galleryWithImageBlocks)) ?? false
+        self.quoteBlockV2 = (try? map.decode(Bool.self, forKey: .quoteBlockV2)) ?? false
         self.rawStyles = RemoteBlockEditorSettings.parseToString(map, .rawStyles)
         self.rawFeatures = RemoteBlockEditorSettings.parseToString(map, .rawFeatures)
         self.colors = try? map.decode([[String: String]].self, forKey: .colors)


### PR DESCRIPTION
- **Gutenberg PR**: https://github.com/WordPress/gutenberg/pull/40133
- **WordPress iOS PR**: https://github.com/wordpress-mobile/WordPress-iOS/pull/18326

### Description

Adds a Gutenberg feature flag for the Quote V2 block, for more information check the Gutenberg PR description.

### Testing Details

Check the Gutenberg PR for testing instructions.

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
