### PR TITLE
Add new fields to site creation request

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.50.0-beta.1'
+  s.version       = '4.50.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
@@ -82,15 +82,15 @@ public struct SiteCreationRequest: Encodable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case clientIdentifier   = "client_id"
-        case clientSecret       = "client_secret"
+        case clientIdentifier = "client_id"
+        case clientSecret = "client_secret"
         case languageIdentifier = "lang_id"
-        case isPublic           = "public"
-        case shouldValidate     = "validate"
-        case siteURLString      = "blog_name"
-        case title              = "blog_title"
-        case options            = "options"
-        case findAvailableUrl  = "find_available_url"
+        case isPublic = "public"
+        case shouldValidate = "validate"
+        case siteURLString = "blog_name"
+        case title = "blog_title"
+        case options = "options"
+        case findAvailableURL = "find_available_url"
     }
 }
 
@@ -103,12 +103,12 @@ private struct SiteCreationOptions: Encodable {
     let siteCreationFlow: String?
 
     enum CodingKeys: String, CodingKey {
-        case segmentIdentifier  = "site_segment"
+        case segmentIdentifier = "site_segment"
         case verticalIdentifier = "site_vertical"
-        case siteInformation    = "site_information"
-        case siteDesign         = "template"
+        case siteInformation = "site_information"
+        case siteDesign = "template"
         case timezoneIdentifier = "timezone_string"
-        case siteCreationFlow  = "site_creation_flow"
+        case siteCreationFlow = "site_creation_flow"
     }
 }
 
@@ -143,10 +143,10 @@ public struct CreatedSite: Decodable {
     public let xmlrpcString: String
 
     enum CodingKeys: String, CodingKey {
-        case identifier     = "blogid"
-        case title          = "blogname"
-        case urlString      = "url"
-        case xmlrpcString   = "xmlrpc"
+        case identifier = "blogid"
+        case title = "blogname"
+        case urlString = "url"
+        case xmlrpcString = "xmlrpc"
     }
 }
 

--- a/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
@@ -17,6 +17,8 @@ public struct SiteCreationRequest: Encodable {
     public let clientSecret: String
     public let siteDesign: String?
     public let timezoneIdentifier: String?
+    public let siteCreationFlow: String?
+    public let findAvailableUrl: Bool
 
     public init(segmentIdentifier: Int64?,
                 siteDesign: String?,
@@ -29,7 +31,9 @@ public struct SiteCreationRequest: Encodable {
                 shouldValidate: Bool,
                 clientIdentifier: String,
                 clientSecret: String,
-                timezoneIdentifier: String?) {
+                timezoneIdentifier: String?,
+                siteCreationFlow: String?,
+                findAvailableUrl: Bool) {
 
         self.segmentIdentifier = segmentIdentifier
         self.siteDesign = siteDesign
@@ -43,6 +47,8 @@ public struct SiteCreationRequest: Encodable {
         self.clientIdentifier = clientIdentifier
         self.clientSecret = clientSecret
         self.timezoneIdentifier = timezoneIdentifier
+        self.siteCreationFlow = siteCreationFlow
+        self.findAvailableUrl = findAvailableUrl
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -54,6 +60,7 @@ public struct SiteCreationRequest: Encodable {
         try container.encode(shouldValidate, forKey: .shouldValidate)
         try container.encode(siteURLString, forKey: .siteURLString)
         try container.encode(title, forKey: .title)
+        try container.encode(findAvailableUrl, forKey: .findAvailableUrl)
 
         let publicValue = isPublic ? 1 : 0
         try container.encode(publicValue, forKey: .isPublic)
@@ -64,7 +71,12 @@ public struct SiteCreationRequest: Encodable {
         } else {
             siteInfo = nil
         }
-        let options = SiteCreationOptions(segmentIdentifier: segmentIdentifier, verticalIdentifier: verticalIdentifier, siteInformation: siteInfo, siteDesign: siteDesign, timezoneIdentifier: timezoneIdentifier)
+        let options = SiteCreationOptions(segmentIdentifier: segmentIdentifier,
+                                          verticalIdentifier: verticalIdentifier,
+                                          siteInformation: siteInfo,
+                                          siteDesign: siteDesign,
+                                          timezoneIdentifier: timezoneIdentifier,
+                                          siteCreationFlow: siteCreationFlow)
 
         try container.encode(options, forKey: .options)
     }
@@ -78,6 +90,7 @@ public struct SiteCreationRequest: Encodable {
         case siteURLString      = "blog_name"
         case title              = "blog_title"
         case options            = "options"
+        case findAvailableUrl  = "find_available_url"
     }
 }
 
@@ -87,6 +100,7 @@ private struct SiteCreationOptions: Encodable {
     let siteInformation: SiteInformation?
     let siteDesign: String?
     let timezoneIdentifier: String?
+    let siteCreationFlow: String?
 
     enum CodingKeys: String, CodingKey {
         case segmentIdentifier  = "site_segment"
@@ -94,6 +108,7 @@ private struct SiteCreationOptions: Encodable {
         case siteInformation    = "site_information"
         case siteDesign         = "template"
         case timezoneIdentifier = "timezone_string"
+        case siteCreationFlow  = "site_creation_flow"
     }
 }
 

--- a/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
+++ b/WordPressKit/WordPressComServiceRemote+SiteCreation.swift
@@ -18,7 +18,7 @@ public struct SiteCreationRequest: Encodable {
     public let siteDesign: String?
     public let timezoneIdentifier: String?
     public let siteCreationFlow: String?
-    public let findAvailableUrl: Bool
+    public let findAvailableURL: Bool
 
     public init(segmentIdentifier: Int64?,
                 siteDesign: String?,
@@ -33,7 +33,7 @@ public struct SiteCreationRequest: Encodable {
                 clientSecret: String,
                 timezoneIdentifier: String?,
                 siteCreationFlow: String?,
-                findAvailableUrl: Bool) {
+                findAvailableURL: Bool) {
 
         self.segmentIdentifier = segmentIdentifier
         self.siteDesign = siteDesign
@@ -48,7 +48,7 @@ public struct SiteCreationRequest: Encodable {
         self.clientSecret = clientSecret
         self.timezoneIdentifier = timezoneIdentifier
         self.siteCreationFlow = siteCreationFlow
-        self.findAvailableUrl = findAvailableUrl
+        self.findAvailableURL = findAvailableURL
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -60,7 +60,7 @@ public struct SiteCreationRequest: Encodable {
         try container.encode(shouldValidate, forKey: .shouldValidate)
         try container.encode(siteURLString, forKey: .siteURLString)
         try container.encode(title, forKey: .title)
-        try container.encode(findAvailableUrl, forKey: .findAvailableUrl)
+        try container.encode(findAvailableURL, forKey: .findAvailableURL)
 
         let publicValue = isPublic ? 1 : 0
         try container.encode(publicValue, forKey: .isPublic)

--- a/WordPressKitTests/SiteCreationRequestEncodingTests.swift
+++ b/WordPressKitTests/SiteCreationRequestEncodingTests.swift
@@ -14,6 +14,8 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
     static let expectedClientId = "TEST-ID"
     static let expectedClientSecret = "TEST-SECRET"
     static let expectedTimezoneIdentifier = "Pacific/Samoa"
+    static let siteCreationFlow: String? = nil
+    static let findAvailableUrl = false
 
     func testSiteCreationRequestEncoding_WithAllParameters_IsSuccessful() {
         // Given
@@ -29,7 +31,9 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
-            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
+            siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
+            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -53,7 +57,9 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
-            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
+            siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
+            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -77,7 +83,9 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             shouldValidate: false,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
-            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
+            siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
+            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -103,7 +111,9 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
-            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
+            siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
+            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -127,7 +137,9 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
-            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
+            siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
+            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -151,7 +163,9 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
-            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
+            siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
+            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -175,7 +189,9 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             shouldValidate: SiteCreationRequestEncodingTests.expectedValidateValue,
             clientIdentifier: SiteCreationRequestEncodingTests.expectedClientId,
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
-            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier
+            timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
+            siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
+            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When

--- a/WordPressKitTests/SiteCreationRequestEncodingTests.swift
+++ b/WordPressKitTests/SiteCreationRequestEncodingTests.swift
@@ -33,7 +33,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
             timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
             siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
-            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
+            findAvailableURL: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -59,7 +59,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
             timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
             siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
-            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
+            findAvailableURL: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -85,7 +85,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
             timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
             siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
-            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
+            findAvailableURL: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -113,7 +113,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
             timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
             siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
-            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
+            findAvailableURL: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -139,7 +139,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
             timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
             siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
-            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
+            findAvailableURL: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -165,7 +165,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
             timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
             siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
-            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
+            findAvailableURL: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When
@@ -191,7 +191,7 @@ final class SiteCreationRequestEncodingTests: XCTestCase {
             clientSecret: SiteCreationRequestEncodingTests.expectedClientSecret,
             timezoneIdentifier: SiteCreationRequestEncodingTests.expectedTimezoneIdentifier,
             siteCreationFlow: SiteCreationRequestEncodingTests.siteCreationFlow,
-            findAvailableUrl: SiteCreationRequestEncodingTests.findAvailableUrl
+            findAvailableURL: SiteCreationRequestEncodingTests.findAvailableUrl
         )
 
         // When

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
@@ -26,7 +26,7 @@ final class SiteCreationServiceTests: RemoteTestCase, RESTTestable {
             clientSecret: "TEST-SECRET",
             timezoneIdentifier: TimeZone.current.identifier,
             siteCreationFlow: nil,
-            findAvailableUrl: false
+            findAvailableURL: false
         )
 
         // When, Then

--- a/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteTests+SiteCreation.swift
@@ -24,7 +24,9 @@ final class SiteCreationServiceTests: RemoteTestCase, RESTTestable {
             shouldValidate: true,
             clientIdentifier: "TEST-ID",
             clientSecret: "TEST-SECRET",
-            timezoneIdentifier: TimeZone.current.identifier
+            timezoneIdentifier: TimeZone.current.identifier,
+            siteCreationFlow: nil,
+            findAvailableUrl: false
         )
 
         // When, Then


### PR DESCRIPTION
### This PR adds two new fields to the site creation request, to handle site creation without an existing domain suggestions: `findAvailableUrl` and `siteCreationFlow`.


Fixes #NA


### Testing Details

Can be tested on the related WordPRess-iOS [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/18378)

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
