### PR TITLE
Add remote service for Blogging Prompts

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.50.0'
+  s.version       = '4.51.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -611,6 +611,8 @@
 		FEE4EF5D2730315C003CDA3C /* empty-array.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE4EF5C2730315C003CDA3C /* empty-array.json */; };
 		FEE4EF5F2730334D003CDA3C /* comments-v2-view-context-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE4EF5E2730334D003CDA3C /* comments-v2-view-context-success.json */; };
 		FEE4EF6127303361003CDA3C /* comments-v2-edit-context-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE4EF6027303361003CDA3C /* comments-v2-edit-context-success.json */; };
+		FEEFD8B4280DD60200A3E261 /* blogging-prompts-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEEFD8B3280DD60200A3E261 /* blogging-prompts-success.json */; };
+		FEEFD8B7280EC91B00A3E261 /* BloggingPromptsServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEFD8B6280EC91B00A3E261 /* BloggingPromptsServiceRemoteTests.swift */; };
 		FEF7419B2808591C002C4203 /* BloggingPromptsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF7419A2808591C002C4203 /* BloggingPromptsServiceRemote.swift */; };
 		FEF7419D28085D89002C4203 /* RemoteBloggingPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF7419C28085D89002C4203 /* RemoteBloggingPrompt.swift */; };
 		FEFFD99126C1347D00F34231 /* ShareAppContentServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFD99026C1347D00F34231 /* ShareAppContentServiceRemote.swift */; };
@@ -1265,6 +1267,8 @@
 		FEE4EF5C2730315C003CDA3C /* empty-array.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "empty-array.json"; sourceTree = "<group>"; };
 		FEE4EF5E2730334D003CDA3C /* comments-v2-view-context-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "comments-v2-view-context-success.json"; sourceTree = "<group>"; };
 		FEE4EF6027303361003CDA3C /* comments-v2-edit-context-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "comments-v2-edit-context-success.json"; sourceTree = "<group>"; };
+		FEEFD8B3280DD60200A3E261 /* blogging-prompts-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "blogging-prompts-success.json"; sourceTree = "<group>"; };
+		FEEFD8B6280EC91B00A3E261 /* BloggingPromptsServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsServiceRemoteTests.swift; sourceTree = "<group>"; };
 		FEF7419A2808591C002C4203 /* BloggingPromptsServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsServiceRemote.swift; sourceTree = "<group>"; };
 		FEF7419C28085D89002C4203 /* RemoteBloggingPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBloggingPrompt.swift; sourceTree = "<group>"; };
 		FEFFD99026C1347D00F34231 /* ShareAppContentServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppContentServiceRemote.swift; sourceTree = "<group>"; };
@@ -1660,6 +1664,7 @@
 				826016FE1F9FD59400533B6C /* Activity */,
 				FAD1345425909DF500A8FEB1 /* Backup */,
 				74B5F0DF1EF82AAB00B411E7 /* Blog */,
+				FEEFD8B5280EC8C800A3E261 /* BloggingPrompts */,
 				465F88A5263B370300F4C950 /* BlockEditorSettings */,
 				ABD95B7D25DD6C2400735BEE /* Comment */,
 				8BB5F62227A9A5AF00B2FFAF /* Dashboard */,
@@ -2003,6 +2008,7 @@
 				8BFD71FD25CACCBF0094534E /* backup-get-backup-status-complete-without-download-id-success.json */,
 				FA79F1952591809C00D235A9 /* backup-get-backup-status-in-progress-success.json */,
 				FA79F1862591730D00D235A9 /* backup-prepare-backup-success.json */,
+				FEEFD8B3280DD60200A3E261 /* blogging-prompts-success.json */,
 				ABD95B8425DD6DA200735BEE /* comment-likes-success.json */,
 				FEE4EF5E2730334D003CDA3C /* comments-v2-view-context-success.json */,
 				FEE4EF6027303361003CDA3C /* comments-v2-edit-context-success.json */,
@@ -2130,6 +2136,7 @@
 				17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */,
 				74A44DD71F13C7AC006CD8F4 /* remote-notification.json */,
 				74B040711EF8B366002C6258 /* rest-site-settings.json */,
+				FEFFD99626C158F400F34231 /* share-app-content-success.json */,
 				74C473CA1EF33696009918F2 /* site-active-purchases-auth-failure.json */,
 				74C473CC1EF336BD009918F2 /* site-active-purchases-bad-json-failure.json */,
 				74C473C81EF335B8009918F2 /* site-active-purchases-empty-response.json */,
@@ -2245,7 +2252,6 @@
 				740B23DE1F17FB4200067A2A /* xmlrpc-wp-getpost-bad-xml-failure.xml */,
 				740B23DF1F17FB4200067A2A /* xmlrpc-wp-getpost-invalid-id-failure.xml */,
 				740B23E01F17FB4200067A2A /* xmlrpc-wp-getpost-success.xml */,
-				FEFFD99626C158F400F34231 /* share-app-content-success.json */,
 			);
 			path = "Mock Data";
 			sourceTree = "<group>";
@@ -2441,6 +2447,14 @@
 				FAD1345025909DEA00A8FEB1 /* JetpackBackupServiceRemoteTests.swift */,
 			);
 			name = Backup;
+			sourceTree = "<group>";
+		};
+		FEEFD8B5280EC8C800A3E261 /* BloggingPrompts */ = {
+			isa = PBXGroup;
+			children = (
+				FEEFD8B6280EC91B00A3E261 /* BloggingPromptsServiceRemoteTests.swift */,
+			);
+			name = BloggingPrompts;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2716,6 +2730,7 @@
 				74D67F351F15C3740010C5ED /* site-users-delete-not-member-failure.json in Resources */,
 				E1E89C681FD6B2E9006E7A33 /* plugin-directory-jetpack.json in Resources */,
 				74D67F201F15C3240010C5ED /* people-validate-invitation-failure.json in Resources */,
+				FEEFD8B4280DD60200A3E261 /* blogging-prompts-success.json in Resources */,
 				74D67F161F15C2D70010C5ED /* site-users-update-role-bad-json-failure.json in Resources */,
 				93BD27661EE73442002BB00B /* me-success.json in Resources */,
 				404057DC221C9FD80060250C /* stats-referrer-data.json in Resources */,
@@ -3206,6 +3221,7 @@
 				8B749E8225AF7DDA00023F03 /* JetpackCapabilitiesServiceRemoteTests.swift in Sources */,
 				74E2294B1F1E73340085F7F2 /* SharingServiceRemoteTests.m in Sources */,
 				FEFFD99B26C1598F00F34231 /* ShareAppContentServiceRemoteTests.swift in Sources */,
+				FEEFD8B7280EC91B00A3E261 /* BloggingPromptsServiceRemoteTests.swift in Sources */,
 				73B3DAD621FBB20D00B2CF18 /* WordPressComRestApiTests+Locale.swift in Sources */,
 				3297E1DE2564653A00287D21 /* JetpackScanServiceRemoteTests.swift in Sources */,
 				9F3E0BAC20873785009CB5BA /* ServiceRequestTest.swift in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -611,6 +611,8 @@
 		FEE4EF5D2730315C003CDA3C /* empty-array.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE4EF5C2730315C003CDA3C /* empty-array.json */; };
 		FEE4EF5F2730334D003CDA3C /* comments-v2-view-context-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE4EF5E2730334D003CDA3C /* comments-v2-view-context-success.json */; };
 		FEE4EF6127303361003CDA3C /* comments-v2-edit-context-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE4EF6027303361003CDA3C /* comments-v2-edit-context-success.json */; };
+		FEF7419B2808591C002C4203 /* BloggingPromptsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF7419A2808591C002C4203 /* BloggingPromptsServiceRemote.swift */; };
+		FEF7419D28085D89002C4203 /* RemoteBloggingPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF7419C28085D89002C4203 /* RemoteBloggingPrompt.swift */; };
 		FEFFD99126C1347D00F34231 /* ShareAppContentServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFD99026C1347D00F34231 /* ShareAppContentServiceRemote.swift */; };
 		FEFFD99326C141A800F34231 /* RemoteShareAppContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEFFD99226C141A800F34231 /* RemoteShareAppContent.swift */; };
 		FEFFD99726C158F400F34231 /* share-app-content-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEFFD99626C158F400F34231 /* share-app-content-success.json */; };
@@ -1263,6 +1265,8 @@
 		FEE4EF5C2730315C003CDA3C /* empty-array.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "empty-array.json"; sourceTree = "<group>"; };
 		FEE4EF5E2730334D003CDA3C /* comments-v2-view-context-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "comments-v2-view-context-success.json"; sourceTree = "<group>"; };
 		FEE4EF6027303361003CDA3C /* comments-v2-edit-context-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "comments-v2-edit-context-success.json"; sourceTree = "<group>"; };
+		FEF7419A2808591C002C4203 /* BloggingPromptsServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsServiceRemote.swift; sourceTree = "<group>"; };
+		FEF7419C28085D89002C4203 /* RemoteBloggingPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBloggingPrompt.swift; sourceTree = "<group>"; };
 		FEFFD99026C1347D00F34231 /* ShareAppContentServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppContentServiceRemote.swift; sourceTree = "<group>"; };
 		FEFFD99226C141A800F34231 /* RemoteShareAppContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteShareAppContent.swift; sourceTree = "<group>"; };
 		FEFFD99626C158F400F34231 /* share-app-content-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "share-app-content-success.json"; sourceTree = "<group>"; };
@@ -1857,6 +1861,7 @@
 				462422282548B98A002B8A12 /* SiteDesignServiceRemote.swift */,
 				465F889D263B0C5500F4C950 /* BlockEditorSettingsServiceRemote.swift */,
 				FEFFD99026C1347D00F34231 /* ShareAppContentServiceRemote.swift */,
+				FEF7419A2808591C002C4203 /* BloggingPromptsServiceRemote.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -1952,6 +1957,7 @@
 				464BAB0A262F6736006AEED5 /* RemoteBlockEditorSettings.swift */,
 				FEFFD99226C141A800F34231 /* RemoteShareAppContent.swift */,
 				FEE4EF56272FDD4B003CDA3C /* RemoteCommentV2.swift */,
+				FEF7419C28085D89002C4203 /* RemoteBloggingPrompt.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -2962,6 +2968,7 @@
 				FEFFD99126C1347D00F34231 /* ShareAppContentServiceRemote.swift in Sources */,
 				74585B8E1F0D51A100E7E667 /* DomainsServiceRemote.swift in Sources */,
 				4625B965253A343900C04AAD /* RemotePageLayouts.swift in Sources */,
+				FEF7419B2808591C002C4203 /* BloggingPromptsServiceRemote.swift in Sources */,
 				7430C9A41F1927180051B8E6 /* ReaderPostServiceRemote.m in Sources */,
 				C797196D2679007B0072F984 /* JetpackPluginManagementClient.swift in Sources */,
 				408197882220A35000A298E4 /* StatsLastPostInsight.swift in Sources */,
@@ -3123,6 +3130,7 @@
 				74B5F0D81EF8299B00B411E7 /* BlogServiceRemoteREST.m in Sources */,
 				9FCDD09720A5EF75004F0BF7 /* ReaderTopicServiceError.swift in Sources */,
 				74A44DD11F13C64B006CD8F4 /* RemoteNotificationSettings.swift in Sources */,
+				FEF7419D28085D89002C4203 /* RemoteBloggingPrompt.swift in Sources */,
 				74DA56331F06EAF000FE9BF4 /* MediaServiceRemoteREST.m in Sources */,
 				17CD0CC320C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift in Sources */,
 				74DA563B1F06EB3000FE9BF4 /* RemoteMedia.m in Sources */,

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -19,7 +19,7 @@ public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
     ///   - number: The number of prompts to query. When not specified, this will default to remote implementation.
     ///   - fromDate: When specified, this will fetch prompts from the given date. When not specified, this will default to remote implementation.
     ///   - completion: A closure that will be called when the fetch request completes.
-    func fetchPrompts(for siteID: NSNumber,
+    public func fetchPrompts(for siteID: NSNumber,
                       number: Int? = nil,
                       fromDate: Date? = nil,
                       completion: @escaping (Result<[RemoteBloggingPrompt], Error>) -> Void) {

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -2,8 +2,14 @@ import Foundation
 
 public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
 
-    /// Used to format dates so the time & timezone information is omitted.
-    private static var calendar: Calendar = .autoupdatingCurrent
+    /// Used to format dates so the time information is omitted.
+    private static var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        return formatter
+    }()
 
     /// Fetches a number of blogging prompts for the specified site.
     /// Note that this method hits wpcom/v2, which means the `WordPressComRestAPI` needs to be initialized with `LocaleKeyV2`.
@@ -28,10 +34,7 @@ public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
             if let fromDate = fromDate {
                 // convert to yyyy-MM-dd format, excluding the timezone information.
                 // the date parameter doesn't need to be timezone-accurate since prompts are grouped by date.
-                params["from"] = String(format: "%d-%02d-%02d",
-                                        Self.calendar.component(.year, from: fromDate),
-                                        Self.calendar.component(.month, from: fromDate),
-                                        Self.calendar.component(.day, from: fromDate))
+                params["from"] = Self.dateFormatter.string(from: fromDate)
             }
 
             return params

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -21,11 +21,11 @@ public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
     /// - Parameters:
     ///   - siteID: Used to check which prompts have been answered for the site with given `siteID`.
     ///   - number: The number of prompts to query. When not specified, this will default to remote implementation.
-    ///   - after: When specified, this will fetch prompts after the given date. When not specified, this will default to remote implementation.
+    ///   - fromDate: When specified, this will fetch prompts from the given date. When not specified, this will default to remote implementation.
     ///   - completion: A closure that will be called when the fetch request completes.
     func fetchPrompts(for siteID: NSNumber,
                       number: Int? = nil,
-                      after: Date? = nil,
+                      fromDate: Date? = nil,
                       completion: @escaping (Result<[RemoteBloggingPrompt], Error>) -> Void) {
         let path = path(forEndpoint: "blogging-prompts", withVersion: ._2_0)
         let requestParameter: [String: AnyHashable] = {
@@ -35,10 +35,10 @@ public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
                 params["number"] = number
             }
 
-            if let dateAfter = after {
+            if let fromDate = fromDate {
                 // convert to yyyy-MM-dd format.
                 // this parameter doesn't need to be timezone-accurate since prompts are grouped by date.
-                params["after"] = Self.dateFormatter.string(from: dateAfter)
+                params["from"] = Self.dateFormatter.string(from: fromDate)
             }
 
             return params

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -53,7 +53,7 @@ public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
                     // our API decoder assumes that we're converting from snake case.
                     // revert it to default so the CodingKeys match the actual response keys.
                     decoder.keyDecodingStrategy = .useDefaultKeys
-                    let response = try decoder.decode([String:[RemoteBloggingPrompt]].self, from: data)
+                    let response = try decoder.decode([String: [RemoteBloggingPrompt]].self, from: data)
                     completion(.success(response.values.first ?? []))
                 } catch {
                     completion(.failure(error))

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -1,7 +1,6 @@
-import Foundation
-
-public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
-
+/// Encapsulates logic to fetch blogging prompts from the remote endpoint.
+///
+open class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
     /// Used to format dates so the time information is omitted.
     private static var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -19,10 +18,10 @@ public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
     ///   - number: The number of prompts to query. When not specified, this will default to remote implementation.
     ///   - fromDate: When specified, this will fetch prompts from the given date. When not specified, this will default to remote implementation.
     ///   - completion: A closure that will be called when the fetch request completes.
-    public func fetchPrompts(for siteID: NSNumber,
-                      number: Int? = nil,
-                      fromDate: Date? = nil,
-                      completion: @escaping (Result<[RemoteBloggingPrompt], Error>) -> Void) {
+    open func fetchPrompts(for siteID: NSNumber,
+                           number: Int? = nil,
+                           fromDate: Date? = nil,
+                           completion: @escaping (Result<[RemoteBloggingPrompt], Error>) -> Void) {
         let path = path(forEndpoint: "sites/\(siteID)/blogging-prompts", withVersion: ._2_0)
         let requestParameter: [String: AnyHashable] = {
             var params = [String: AnyHashable]()

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -1,19 +1,9 @@
 import Foundation
 
-struct Root: Decodable {
-    let prompts: [RemoteBloggingPrompt]
-}
-
 public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
 
-    /// Used to format dates so the time information is omitted.
-    private static var dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-
-        return formatter
-    }()
+    /// Used to format dates so the time & timezone information is omitted.
+    private static var calendar: Calendar = .autoupdatingCurrent
 
     /// Fetches a number of blogging prompts for the specified site.
     /// Note that this method hits wpcom/v2, which means the `WordPressComRestAPI` needs to be initialized with `LocaleKeyV2`.
@@ -36,9 +26,12 @@ public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
             }
 
             if let fromDate = fromDate {
-                // convert to yyyy-MM-dd format.
-                // this parameter doesn't need to be timezone-accurate since prompts are grouped by date.
-                params["from"] = Self.dateFormatter.string(from: fromDate)
+                // convert to yyyy-MM-dd format, excluding the timezone information.
+                // the date parameter doesn't need to be timezone-accurate since prompts are grouped by date.
+                params["from"] = String(format: "%d-%02d-%02d",
+                                        Self.calendar.component(.year, from: fromDate),
+                                        Self.calendar.component(.month, from: fromDate),
+                                        Self.calendar.component(.day, from: fromDate))
             }
 
             return params

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
+
+    /// Fetches a number of blogging prompts for the specified site.
+    ///
+    /// - Parameters:
+    ///   - siteID: Used to check which prompts have been answered for the site with given `siteID`.
+    ///   - number: The number of prompts to query. When not specified, this will default to remote implementation.
+    ///   - after: When specified, this will fetch prompts after the given date. When not specified, this will default to remote implementation.
+    func fetchPrompts(for siteID: NSNumber, number: Int? = nil, after: Date? = nil) {
+        // TODO: Implement.
+    }
+
+}

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -27,7 +27,7 @@ public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
                       number: Int? = nil,
                       fromDate: Date? = nil,
                       completion: @escaping (Result<[RemoteBloggingPrompt], Error>) -> Void) {
-        let path = path(forEndpoint: "blogging-prompts", withVersion: ._2_0)
+        let path = path(forEndpoint: "sites/\(siteID)/blogging-prompts", withVersion: ._2_0)
         let requestParameter: [String: AnyHashable] = {
             var params = [String: AnyHashable]()
 

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -1,15 +1,52 @@
 import Foundation
+import WordPressShared
 
 public class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
 
     /// Fetches a number of blogging prompts for the specified site.
     ///
+    /// Note that this method hits version 2.0, which means the `WordPressComRestAPI` needs to be initialized with `LocaleKeyV2`.
+    ///
     /// - Parameters:
     ///   - siteID: Used to check which prompts have been answered for the site with given `siteID`.
     ///   - number: The number of prompts to query. When not specified, this will default to remote implementation.
     ///   - after: When specified, this will fetch prompts after the given date. When not specified, this will default to remote implementation.
-    func fetchPrompts(for siteID: NSNumber, number: Int? = nil, after: Date? = nil) {
-        // TODO: Implement.
-    }
+    ///   - success: A closure that will be called when the request succeeds.
+    ///   - failure: A closure that will be called when the request fails.
+    func fetchPrompts(for siteID: NSNumber,
+                      number: Int? = nil,
+                      after: Date? = nil,
+                      success: @escaping ([RemoteBloggingPrompt]) -> Void,
+                      failure: @escaping (Error) -> Void) {
+        let path = path(forEndpoint: "blogging-prompts", withVersion: ._2_0)
+        let requestParameter: [String: AnyHashable] = {
+            var params = [String: AnyHashable]()
 
+            if let number = number, number > 0 {
+                params["number"] = number
+            }
+
+            if let dateAfter = after {
+                params["after"] = DateUtils.isoString(from: dateAfter)
+            }
+
+            return params
+        }()
+
+        wordPressComRestApi.GET(path, parameters: requestParameter as [String: AnyObject]) { result, _ in
+            switch result {
+            case .success(let responseObject):
+                do {
+                    let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
+                    let response = try JSONDecoder().decode([String:[RemoteBloggingPrompt]].self, from: data)
+                    success(response.values.first ?? [])
+                } catch {
+                    failure(error)
+                }
+
+            case .failure(let error):
+                failure(error)
+            }
+        }
+    }
 }

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -1,0 +1,56 @@
+public struct RemoteBloggingPrompt {
+    public var promptID: Int
+    public var text: String
+    public var title: String
+    public var content: String
+    public var date: Date
+    public var answered: Bool
+    public var answeringUserCount: Int
+    public var answeringUserAvatarURLs: [URL]
+}
+
+// MARK: - Decodable
+
+extension RemoteBloggingPrompt: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case text
+        case title
+        case content
+        case date = "date_gmt"
+        case answered = "i_answered"
+        case answeringUserCount = "answering_user_count"
+        case answeringUserAvatarURLs = "answering_user_avatars"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.promptID = try container.decode(Int.self, forKey: .id)
+        self.text = try container.decode(String.self, forKey: .text)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.content = try container.decode(String.self, forKey: .content)
+
+        // since `date_gmt` is already in GMT timezone, manually add the timezone string to make the rfc3339 formatter happy (or it will throw otherwise).
+        guard let dateString = try? container.decode(String.self, forKey: .date),
+              let date = NSDate(wordPressComJSONString: dateString + "+00:00") as Date? else {
+            throw DecodingError.dataCorruptedError(forKey: .date, in: container, debugDescription: "Date parsing failed")
+        }
+        self.date = date
+        self.answered = try container.decode(Bool.self, forKey: .answered)
+        self.answeringUserCount = try container.decode(Int.self, forKey: .answeringUserCount)
+
+        let userAvatars = try container.decode([UserAvatar].self, forKey: .answeringUserAvatarURLs)
+        self.answeringUserAvatarURLs = userAvatars.compactMap { URL(string: $0.avatarURL) }
+    }
+
+    /// meta structure to simplify decoding logic for user avatar objects.
+    /// this is intended to be private.
+    private struct UserAvatar: Codable {
+        var avatarURL: String
+
+        enum CodingKeys: String, CodingKey {
+            case avatarURL = "avatar_URL"
+        }
+    }
+}

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -5,8 +5,8 @@ public struct RemoteBloggingPrompt {
     public var content: String
     public var date: Date
     public var answered: Bool
-    public var answeringUserCount: Int
-    public var answeringUsersAvatarURLs: [URL]
+    public var answeredUsersCount: Int
+    public var answeredUserAvatarURLs: [URL]
 }
 
 // MARK: - Decodable
@@ -17,10 +17,10 @@ extension RemoteBloggingPrompt: Decodable {
         case text
         case title
         case content
-        case date = "date_gmt"
-        case answered = "i_answered"
-        case answeringUserCount = "answering_user_count"
-        case answeringUsersAvatarURLs = "answering_users_avatars"
+        case date
+        case answered
+        case answeredUsersCount = "answered_users_count"
+        case answeredUserAvatarURLs = "answered_users_sample"
     }
 
     public init(from decoder: Decoder) throws {
@@ -30,36 +30,17 @@ extension RemoteBloggingPrompt: Decodable {
         self.text = try container.decode(String.self, forKey: .text)
         self.title = try container.decode(String.self, forKey: .title)
         self.content = try container.decode(String.self, forKey: .content)
-
-//        // since `date_gmt` is already in GMT timezone, manually add the timezone string to make the rfc3339 formatter happy (or it will throw otherwise).
-//        guard let dateString = try? container.decode(String.self, forKey: .date),
-//              let date = NSDate(wordPressComJSONString: dateString + "+00:00") as? Date else {
-//            throw DecodingError.dataCorruptedError(forKey: .date, in: container, debugDescription: "Date parsing failed")
-//        }
-
         self.answered = try container.decode(Bool.self, forKey: .answered)
+        self.date = try container.decode(Date.self, forKey: .date)
+        self.answeredUsersCount = try container.decode(Int.self, forKey: .answeredUsersCount)
 
-        do {
-            self.date = try container.decode(Date.self, forKey: .date)
-        } catch {
-            print(error)
-            self.date = Date()
-        }
-
-
-        self.answeringUserCount = try container.decode(Int.self, forKey: .answeringUserCount)
-
-        let userAvatars = try container.decode([UserAvatar].self, forKey: .answeringUsersAvatarURLs)
-        self.answeringUsersAvatarURLs = userAvatars.compactMap { URL(string: $0.avatarURL) }
+        let userAvatars = try container.decode([UserAvatar].self, forKey: .answeredUserAvatarURLs)
+        self.answeredUserAvatarURLs = userAvatars.compactMap { URL(string: $0.avatar) }
     }
 
     /// meta structure to simplify decoding logic for user avatar objects.
     /// this is intended to be private.
     private struct UserAvatar: Codable {
-        var avatarURL: String
-
-        enum CodingKeys: String, CodingKey {
-            case avatarURL = "avatar_URL"
-        }
+        var avatar: String
     }
 }

--- a/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
+++ b/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
@@ -1,0 +1,98 @@
+import XCTest
+
+@testable import WordPressKit
+
+class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
+
+    let siteID = NSNumber(value: 1)
+    static let dateFormatter = ISO8601DateFormatter()
+
+    var mockApi: WordPressComRestApi!
+    var service: BloggingPromptsServiceRemote!
+
+    // MARK: Setup
+
+    override func setUp() {
+        super.setUp()
+
+        mockApi = getRestApi()
+        service = BloggingPromptsServiceRemote(wordPressComRestApi: mockApi)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        mockApi = nil
+        service = nil
+    }
+
+    // MARK: Tests
+
+    func test_fetchPrompts_returnsRemotePrompts() {
+        let formatter = JSONDecoder.DateDecodingStrategy.DateFormat.dateWithTime.formatter
+        let expectedDate = formatter.date(from: "2022-01-01 10:00:00") // using value from the first prompt in blogging-prompts-success.json.
+        let expectedAvatarURLString = "https://0.gravatar.com/avatar/example?s=96&d=identicon&r=G"
+        stubRemoteResponse(.bloggingPromptsEndpoint, filename: .mockFileName, contentType: .ApplicationJSON)
+
+        let expect = expectation(description: "Fetch blogging prompts succeeded")
+        service.fetchPrompts(for: siteID) { result in
+            guard case .success(let prompts) = result else {
+                XCTFail("Expected success result type")
+                return
+            }
+
+            XCTAssertEqual(prompts.count, 2)
+
+            let firstPrompt = prompts.first!
+            XCTAssertEqual(firstPrompt.promptID, 239)
+            XCTAssertEqual(firstPrompt.text, "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.")
+            XCTAssertEqual(firstPrompt.title, "Prompt number 1")
+            XCTAssertEqual(firstPrompt.content, "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->")
+            XCTAssertEqual(firstPrompt.date, expectedDate)
+            XCTAssertFalse(firstPrompt.answered)
+            XCTAssertEqual(firstPrompt.answeringUserCount, 0)
+
+            let secondPrompt = prompts.last!
+            XCTAssertEqual(secondPrompt.answeringUserCount, 1)
+            XCTAssertEqual(secondPrompt.answeringUsersAvatarURLs.count, 1)
+
+            let avatarURL = secondPrompt.answeringUsersAvatarURLs.first!
+            XCTAssertEqual(avatarURL.absoluteString, expectedAvatarURLString)
+
+            expect.fulfill()
+        }
+
+        wait(for:[expect], timeout: timeout)
+    }
+
+    func test_fetchPrompts_correctlyAddsParametersToRequest() {
+        let expectedNumber = 10
+        let expectedDateString = "2022-01-02"
+        let isoDateString = "2022-01-02T01:00:00+0400" // ensure that the converted date doesn't change dates (notice the time & timezone).
+        let expectedDate = Self.dateFormatter.date(from: isoDateString)
+        let customMockApi = MockWordPressComRestApi()
+        service = BloggingPromptsServiceRemote(wordPressComRestApi: customMockApi)
+
+        // no-op; we just need to check the passed params.
+        service.fetchPrompts(for: siteID, number: expectedNumber, after: expectedDate, completion: { _ in })
+
+        XCTAssertNotNil(customMockApi.parametersPassedIn as? [String: AnyObject])
+        let params = customMockApi.parametersPassedIn! as! [String: AnyObject]
+
+        XCTAssertNotNil(params[.numberKey])
+        XCTAssertEqual(params[.numberKey] as! Int, expectedNumber)
+
+        XCTAssertNotNil(params[.dateKey])
+        XCTAssertEqual(params[.dateKey] as! String, expectedDateString)
+    }
+
+}
+
+// MARK: - Private Helpers
+
+private extension String {
+    static let bloggingPromptsEndpoint = "blogging-prompts"
+    static let mockFileName = "blogging-prompts-success.json"
+    static let numberKey = "number"
+    static let dateKey = "after"
+}

--- a/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
+++ b/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
@@ -4,8 +4,8 @@ import XCTest
 
 class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
 
-    let siteID = NSNumber(value: 1)
-    static let dateFormatter = ISO8601DateFormatter()
+    private let siteID = NSNumber(value: 1)
+    private let dateFormatter = JSONDecoder.DateDecodingStrategy.DateFormat.noTime.formatter
 
     var mockApi: WordPressComRestApi!
     var service: BloggingPromptsServiceRemote!
@@ -68,8 +68,7 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
     func test_fetchPrompts_correctlyAddsParametersToRequest() {
         let expectedNumber = 10
         let expectedDateString = "2022-01-02"
-        let isoDateString = "2022-01-02T01:00:00+0400" // ensure that the converted date doesn't change dates (notice the time & timezone).
-        let expectedDate = Self.dateFormatter.date(from: isoDateString)
+        let expectedDate = dateFormatter.date(from: expectedDateString)
         let customMockApi = MockWordPressComRestApi()
         service = BloggingPromptsServiceRemote(wordPressComRestApi: customMockApi)
 

--- a/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
+++ b/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
@@ -62,7 +62,7 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }
 
-        wait(for:[expect], timeout: timeout)
+        wait(for: [expect], timeout: timeout)
     }
 
     func test_fetchPrompts_correctlyAddsParametersToRequest() {

--- a/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
+++ b/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
@@ -91,7 +91,7 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
 // MARK: - Private Helpers
 
 private extension String {
-    static let bloggingPromptsEndpoint = "blogging-prompts"
+    static let bloggingPromptsEndpoint = "sites/1/blogging-prompts"
     static let mockFileName = "blogging-prompts-success.json"
     static let numberKey = "number"
     static let dateKey = "from"

--- a/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
+++ b/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
@@ -29,8 +29,8 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
     // MARK: Tests
 
     func test_fetchPrompts_returnsRemotePrompts() {
-        let formatter = JSONDecoder.DateDecodingStrategy.DateFormat.dateWithTime.formatter
-        let expectedDate = formatter.date(from: "2022-01-01 10:00:00") // using value from the first prompt in blogging-prompts-success.json.
+        let formatter = JSONDecoder.DateDecodingStrategy.DateFormat.noTime.formatter
+        let expectedDate = formatter.date(from: "2022-01-01") // using value from the first prompt in blogging-prompts-success.json.
         let expectedAvatarURLString = "https://0.gravatar.com/avatar/example?s=96&d=identicon&r=G"
         stubRemoteResponse(.bloggingPromptsEndpoint, filename: .mockFileName, contentType: .ApplicationJSON)
 
@@ -50,13 +50,13 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(firstPrompt.content, "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->")
             XCTAssertEqual(firstPrompt.date, expectedDate)
             XCTAssertFalse(firstPrompt.answered)
-            XCTAssertEqual(firstPrompt.answeringUserCount, 0)
+            XCTAssertEqual(firstPrompt.answeredUsersCount, 0)
 
             let secondPrompt = prompts.last!
-            XCTAssertEqual(secondPrompt.answeringUserCount, 1)
-            XCTAssertEqual(secondPrompt.answeringUsersAvatarURLs.count, 1)
+            XCTAssertEqual(secondPrompt.answeredUsersCount, 1)
+            XCTAssertEqual(secondPrompt.answeredUserAvatarURLs.count, 1)
 
-            let avatarURL = secondPrompt.answeringUsersAvatarURLs.first!
+            let avatarURL = secondPrompt.answeredUserAvatarURLs.first!
             XCTAssertEqual(avatarURL.absoluteString, expectedAvatarURLString)
 
             expect.fulfill()
@@ -74,7 +74,7 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
         service = BloggingPromptsServiceRemote(wordPressComRestApi: customMockApi)
 
         // no-op; we just need to check the passed params.
-        service.fetchPrompts(for: siteID, number: expectedNumber, after: expectedDate, completion: { _ in })
+        service.fetchPrompts(for: siteID, number: expectedNumber, fromDate: expectedDate, completion: { _ in })
 
         XCTAssertNotNil(customMockApi.parametersPassedIn as? [String: AnyObject])
         let params = customMockApi.parametersPassedIn! as! [String: AnyObject]
@@ -94,5 +94,5 @@ private extension String {
     static let bloggingPromptsEndpoint = "blogging-prompts"
     static let mockFileName = "blogging-prompts-success.json"
     static let numberKey = "number"
-    static let dateKey = "after"
+    static let dateKey = "from"
 }

--- a/WordPressKitTests/Mock Data/blogging-prompts-success.json
+++ b/WordPressKitTests/Mock Data/blogging-prompts-success.json
@@ -1,0 +1,28 @@
+{
+  "prompts": [
+    {
+      "id": 239,
+      "text": "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.",
+      "title": "Prompt number 1",
+      "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
+      "date_gmt": "2022-01-01 10:00:00",
+      "i_answered": false,
+      "answering_user_count": 0,
+      "answering_users_avatars": []
+    },
+    {
+      "id": 248,
+      "text": "Tell us about a time when you felt out of place.",
+      "title": "Prompt number 10",
+      "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Tell us about a time when you felt out of place.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
+      "date_gmt": "2022-01-10 10:00:00",
+      "i_answered": false,
+      "answering_user_count": 1,
+      "answering_users_avatars": [
+        {
+          "avatar_URL": "https://0.gravatar.com/avatar/example?s=96&d=identicon&r=G"
+        }
+      ]
+    }
+  ]
+}

--- a/WordPressKitTests/Mock Data/blogging-prompts-success.json
+++ b/WordPressKitTests/Mock Data/blogging-prompts-success.json
@@ -5,22 +5,22 @@
       "text": "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.",
       "title": "Prompt number 1",
       "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
-      "date_gmt": "2022-01-01 10:00:00",
-      "i_answered": false,
-      "answering_user_count": 0,
-      "answering_users_avatars": []
+      "date": "2022-01-01",
+      "answered": false,
+      "answered_users_count": 0,
+      "answered_users_sample": []
     },
     {
       "id": 248,
       "text": "Tell us about a time when you felt out of place.",
       "title": "Prompt number 10",
       "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Tell us about a time when you felt out of place.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
-      "date_gmt": "2022-01-10 10:00:00",
-      "i_answered": false,
-      "answering_user_count": 1,
-      "answering_users_avatars": [
+      "date": "2022-01-02",
+      "answered": false,
+      "answered_users_count": 1,
+      "answered_users_sample": [
         {
-          "avatar_URL": "https://0.gravatar.com/avatar/example?s=96&d=identicon&r=G"
+          "avatar": "https://0.gravatar.com/avatar/example?s=96&d=identicon&r=G"
         }
       ]
     }


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/18375

### Description

Adds the remote service to fetch blogging prompts.

**Note:** This is still pending since there might be changes to the request parameters. There are some code paths to cover from the unit test, but I'll reserve them until the changes have been finalized in D78621-code.

### Testing Details

Testing steps will be updated later with the accompanying PR from WordPress-iOS.

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.