### PR TITLE
Add featured image URL to StatsLastPostInsight

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.51.0-beta.1'
+  s.version       = '4.51.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.50.0'
+  s.version       = '4.51.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/Insights/StatsLastPostInsight.swift
+++ b/WordPressKit/Insights/StatsLastPostInsight.swift
@@ -6,6 +6,7 @@ public struct StatsLastPostInsight {
     public let commentsCount: Int
     public let viewsCount: Int
     public let postID: Int
+    public let featuredImageURL: URL?
 
     public init(title: String,
                 url: URL,
@@ -13,7 +14,8 @@ public struct StatsLastPostInsight {
                 likesCount: Int,
                 commentsCount: Int,
                 viewsCount: Int,
-                postID: Int) {
+                postID: Int,
+                featuredImageURL: URL?) {
         self.title = title
         self.url = url
         self.publishedDate = publishedDate
@@ -21,6 +23,7 @@ public struct StatsLastPostInsight {
         self.commentsCount = commentsCount
         self.viewsCount = viewsCount
         self.postID = postID
+        self.featuredImageURL = featuredImageURL
     }
 }
 
@@ -31,7 +34,7 @@ extension StatsLastPostInsight: StatsInsightData {
         return ["order_by": "date",
                 "number": "1",
                 "type": "post",
-                "fields": "ID, title, URL, discussion, like_count, date"]
+                "fields": "ID, title, URL, discussion, like_count, date, featured_image"]
     }
 
     public static var pathComponent: String {
@@ -69,5 +72,12 @@ extension StatsLastPostInsight: StatsInsightData {
         self.commentsCount = commentsCount
         self.viewsCount = views
         self.postID = postID
+
+        if let featuredImage = jsonDictionary["featured_image"] as? String,
+           let featuredURL = URL(string: featuredImage) {
+            self.featuredImageURL = featuredURL
+        } else {
+            self.featuredImageURL = nil
+        }
     }
 }


### PR DESCRIPTION
As part of the updated [Latest Post Summary](https://github.com/wordpress-mobile/WordPress-iOS/issues/18431) card, we need to display a featured image thumbnail. This PR adds the featured image URL to the `StatsLastPostInsight` model.

### Testing Details

Please test with the associated WPiOS PR (link coming shortly)

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
