### PR TITLE
Blogging Prompts: fix prompt date

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.52.0-beta.1'
+  s.version       = '4.52.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -29,6 +29,7 @@ extension RemoteBloggingPrompt: Decodable {
     private static var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .init(identifier: "en_US_POSIX")
+        formatter.timeZone = .init(secondsFromGMT: 0)
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter
     }()

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -27,7 +27,10 @@ extension RemoteBloggingPrompt: Decodable {
 
     /// Used to format the fetched object's date string to a date.
     private static var dateFormatter: DateFormatter = {
-        JSONDecoder.DateDecodingStrategy.DateFormat.noTime.formatter
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
     }()
 
     public init(from decoder: Decoder) throws {

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -25,6 +25,14 @@ extension RemoteBloggingPrompt: Decodable {
         case answeredUserAvatarURLs = "answered_users_sample"
     }
 
+    /// Used to format the fetched object's date string to a date.
+    private static var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+    
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -34,7 +42,7 @@ extension RemoteBloggingPrompt: Decodable {
         self.content = try container.decode(String.self, forKey: .content)
         self.attribution = try container.decode(String.self, forKey: .attribution)
         self.answered = try container.decode(Bool.self, forKey: .answered)
-        self.date = try container.decode(Date.self, forKey: .date)
+        self.date = Self.dateFormatter.date(from: try container.decode(String.self, forKey: .date)) ?? Date()
         self.answeredUsersCount = try container.decode(Int.self, forKey: .answeredUsersCount)
 
         let userAvatars = try container.decode([UserAvatar].self, forKey: .answeredUserAvatarURLs)

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -27,10 +27,7 @@ extension RemoteBloggingPrompt: Decodable {
 
     /// Used to format the fetched object's date string to a date.
     private static var dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.locale = .init(identifier: "en_US_POSIX")
-        formatter.dateFormat = "yyyy-MM-dd"
-        return formatter
+        JSONDecoder.DateDecodingStrategy.DateFormat.noTime.formatter
     }()
 
     public init(from decoder: Decoder) throws {

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -32,7 +32,7 @@ extension RemoteBloggingPrompt: Decodable {
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter
     }()
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
@@ -47,7 +47,7 @@ extension RemoteBloggingPrompt: Decodable {
 
         let userAvatars = try container.decode([UserAvatar].self, forKey: .answeredUserAvatarURLs)
         self.answeredUserAvatarURLs = userAvatars.compactMap { URL(string: $0.avatar) }
-        
+
         // TODO: remove before merging
         print("🔴 endpoint object date: ", try container.decode(String.self, forKey: .date))
         print("🔴 RemoteBloggingPrompt date: ", self.date)

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -48,10 +48,6 @@ extension RemoteBloggingPrompt: Decodable {
 
         let userAvatars = try container.decode([UserAvatar].self, forKey: .answeredUserAvatarURLs)
         self.answeredUserAvatarURLs = userAvatars.compactMap { URL(string: $0.avatar) }
-
-        // TODO: remove before merging
-        print("🔴 endpoint object date: ", try container.decode(String.self, forKey: .date))
-        print("🔴 RemoteBloggingPrompt date: ", self.date)
     }
 
     /// meta structure to simplify decoding logic for user avatar objects.

--- a/WordPressKit/RemoteBloggingPrompt.swift
+++ b/WordPressKit/RemoteBloggingPrompt.swift
@@ -47,6 +47,10 @@ extension RemoteBloggingPrompt: Decodable {
 
         let userAvatars = try container.decode([UserAvatar].self, forKey: .answeredUserAvatarURLs)
         self.answeredUserAvatarURLs = userAvatars.compactMap { URL(string: $0.avatar) }
+        
+        // TODO: remove before merging
+        print("🔴 endpoint object date: ", try container.decode(String.self, forKey: .date))
+        print("🔴 RemoteBloggingPrompt date: ", self.date)
     }
 
     /// meta structure to simplify decoding logic for user avatar objects.

--- a/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
+++ b/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
@@ -5,7 +5,12 @@ import XCTest
 class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     private let siteID = NSNumber(value: 1)
-    private let dateFormatter = JSONDecoder.DateDecodingStrategy.DateFormat.noTime.formatter
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
 
     var mockApi: WordPressComRestApi!
     var service: BloggingPromptsServiceRemote!
@@ -29,14 +34,6 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
     // MARK: Tests
 
     func test_fetchPrompts_returnsRemotePrompts() {
-        let formatter: DateFormatter = {
-            let formatter = DateFormatter()
-            formatter.locale = .init(identifier: "en_US_POSIX")
-            formatter.dateFormat = "yyyy-MM-dd"
-            return formatter
-        }()
-
-        let expectedDate = formatter.date(from: "2022-01-01") // using value from the first prompt in blogging-prompts-success.json.
         let expectedAvatarURLString = "https://0.gravatar.com/avatar/example?s=96&d=identicon&r=G"
         stubRemoteResponse(.bloggingPromptsEndpoint, filename: .mockFileName, contentType: .ApplicationJSON)
 
@@ -55,7 +52,12 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(firstPrompt.title, "Prompt number 1")
             XCTAssertEqual(firstPrompt.content, "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->")
             XCTAssertEqual(firstPrompt.attribution, "dayone")
-            XCTAssertEqual(firstPrompt.date, expectedDate)
+
+            let firstDateComponents = firstPrompt.date.dateAndTimeComponents()
+            XCTAssertEqual(firstDateComponents.year!, 2022)
+            XCTAssertEqual(firstDateComponents.month!, 5)
+            XCTAssertEqual(firstDateComponents.day!, 3)
+
             XCTAssertFalse(firstPrompt.answered)
             XCTAssertEqual(firstPrompt.answeredUsersCount, 0)
 
@@ -63,6 +65,11 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(secondPrompt.answeredUsersCount, 1)
             XCTAssertEqual(secondPrompt.answeredUserAvatarURLs.count, 1)
             XCTAssertTrue(secondPrompt.attribution.isEmpty)
+
+            let secondDateComponents = secondPrompt.date.dateAndTimeComponents()
+            XCTAssertEqual(secondDateComponents.year!, 2021)
+            XCTAssertEqual(secondDateComponents.month!, 9)
+            XCTAssertEqual(secondDateComponents.day!, 12)
 
             let avatarURL = secondPrompt.answeredUserAvatarURLs.first!
             XCTAssertEqual(avatarURL.absoluteString, expectedAvatarURLString)

--- a/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
+++ b/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
@@ -29,7 +29,13 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
     // MARK: Tests
 
     func test_fetchPrompts_returnsRemotePrompts() {
-        let formatter = JSONDecoder.DateDecodingStrategy.DateFormat.noTime.formatter
+        let formatter: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = .init(identifier: "en_US_POSIX")
+            formatter.dateFormat = "yyyy-MM-dd"
+            return formatter
+        }()
+
         let expectedDate = formatter.date(from: "2022-01-01") // using value from the first prompt in blogging-prompts-success.json.
         let expectedAvatarURLString = "https://0.gravatar.com/avatar/example?s=96&d=identicon&r=G"
         stubRemoteResponse(.bloggingPromptsEndpoint, filename: .mockFileName, contentType: .ApplicationJSON)

--- a/WordPressKitTests/Mock Data/blogging-prompts-success.json
+++ b/WordPressKitTests/Mock Data/blogging-prompts-success.json
@@ -6,7 +6,7 @@
       "title": "Prompt number 1",
       "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
       "attribution": "dayone",
-      "date": "2022-01-01",
+      "date": "2022-05-03",
       "answered": false,
       "answered_users_count": 0,
       "answered_users_sample": []
@@ -17,7 +17,7 @@
       "title": "Prompt number 10",
       "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Tell us about a time when you felt out of place.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
       "attribution": "",
-      "date": "2022-01-02",
+      "date": "2021-09-12",
       "answered": false,
       "answered_users_count": 1,
       "answered_users_sample": [


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/18375

The date string for each fetched prompt is now converted to a Date.

### Testing Details

Can be tested with WPiOS PR https://github.com/wordpress-mobile/WordPress-iOS/pull/18545.

I added some temporary logging to confirm the prompt dates. I will remove it before merging (hence the `DO NOT MERGE` label).

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
