### PR TITLE
Set variant param as "next-step" for Quick Start complete notification

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.52.0-beta.1'
+  s.version       = '4.52.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.52.0-beta.2'
+  s.version       = '4.52.0-beta.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/SiteManagementServiceRemote.swift
+++ b/WordPressKit/SiteManagementServiceRemote.swift
@@ -110,9 +110,10 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
     @objc open func markQuickStartChecklistAsComplete(_ siteID: NSNumber, success: (() -> Void)?, failure: ((NSError) -> Void)?) {
         let endpoint = "sites/\(siteID)/mobile-quick-start"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
+        let parameters = ["variant": "next-steps"] as [String: AnyObject]
 
         wordPressComRestApi.POST(path,
-                                 parameters: nil,
+                                 parameters: parameters,
                                  success: { _, _ in
                                     success?()
         },


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/18389

## Description
- Set variant param as "next-step" for Quick Start complete notification in order to match Android implementation (ref: pdcxQM-Jw-p2#comment-584)


## How to test
- Please test this PR using https://github.com/wordpress-mobile/WordPress-iOS/pull/18551


- [x] I have considered updating the `version` in the `.podspec` file.