### PR TITLE
Fix date component timezone in blogging prompts unit test

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.52.0-beta.4'
+  s.version       = '4.52.0-beta.5'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
+++ b/WordPressKitTests/BloggingPromptsServiceRemoteTests.swift
@@ -5,6 +5,7 @@ import XCTest
 class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     private let siteID = NSNumber(value: 1)
+    private let utcTimeZone = TimeZone(secondsFromGMT: 0)!
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .init(identifier: "en_US_POSIX")
@@ -53,7 +54,7 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(firstPrompt.content, "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->")
             XCTAssertEqual(firstPrompt.attribution, "dayone")
 
-            let firstDateComponents = firstPrompt.date.dateAndTimeComponents()
+            let firstDateComponents = Calendar.current.dateComponents(in: self.utcTimeZone, from: firstPrompt.date)
             XCTAssertEqual(firstDateComponents.year!, 2022)
             XCTAssertEqual(firstDateComponents.month!, 5)
             XCTAssertEqual(firstDateComponents.day!, 3)
@@ -66,7 +67,7 @@ class BloggingPromptsServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTAssertEqual(secondPrompt.answeredUserAvatarURLs.count, 1)
             XCTAssertTrue(secondPrompt.attribution.isEmpty)
 
-            let secondDateComponents = secondPrompt.date.dateAndTimeComponents()
+            let secondDateComponents = Calendar.current.dateComponents(in: self.utcTimeZone, from: secondPrompt.date)
             XCTAssertEqual(secondDateComponents.year!, 2021)
             XCTAssertEqual(secondDateComponents.month!, 9)
             XCTAssertEqual(secondDateComponents.day!, 12)


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/pull/18607#pullrequestreview-972680258

### Description

Fixes an issue where unit tests for Blogging Prompts could fail locally depending on the system's timezone. 

---

⚠️ NOTE: Auto-merge is turned on. ⚠️ 

---

### Testing Details

If your timezone is behind UTC, simply run the unit tests and ensure that they pass. Especially this test case: `BloggingPromptsServiceRemoteTests#test_fetchPrompts_returnsRemotePrompts`.

Otherwise, you can set a temporary timezone modification in `setUp` and `tearDown` like so:

```swift
// BloggingPromptsServiceRemoteTests.swift

    override func setUp() {
        super.setUp()
        NSTimeZone.default = TimeZone(secondsFromGMT: -2 * 3600)! // Set timezone to UTC-2.
        // ...
    }

    override func tearDown() {
        super.tearDown()
        // ...
        NSTimeZone.default = NSTimeZone.system // Reset the timezone.
    }
```

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
