### PR TITLE
Merge 4.52.0 and 4.52.1 stable release – Late merge!

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.52.0-beta.5'
+  s.version       = '4.52.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.52.0'
+  s.version       = '4.52.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -563,7 +563,11 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     parameters[@"parent"] = post.parentID ?: @"false";
     parameters[@"featured_image"] = post.postThumbnailID ? [post.postThumbnailID stringValue] : @"";
-    parameters[@"metadata"] = [self metadataForPost:post];
+
+    NSArray *metadata = [self metadataForPost:post];
+    if (metadata.count > 0) {
+        parameters[@"metadata"] = metadata;
+    }
     
     if (post.isStickyPost != nil) {
         parameters[@"sticky"] = post.isStickyPost.boolValue ? @"true" : @"false";


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 19.9 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.