### PR TITLE
[Site Design Revamp] Add optional group array for remote site designs

### DIFF
--- a/WordPressKit/RemoteSiteDesign.swift
+++ b/WordPressKit/RemoteSiteDesign.swift
@@ -33,6 +33,7 @@ public struct RemoteSiteDesign: Codable {
     public let mobileScreenshot: String?
     public let tabletScreenshot: String?
     public let themeSlug: String?
+    public let groups: [String]?
     public let segmentID: Int64?
     public let categories: [RemoteSiteDesignCategory]
 
@@ -44,6 +45,7 @@ public struct RemoteSiteDesign: Codable {
         case mobileScreenshot = "preview_mobile"
         case tabletScreenshot = "preview_tablet"
         case themeSlug = "theme"
+        case groups
         case segmentID = "segment_id"
         case categories
     }
@@ -57,6 +59,7 @@ public struct RemoteSiteDesign: Codable {
         mobileScreenshot = try? map.decode(String.self, forKey: .mobileScreenshot)
         tabletScreenshot = try? map.decode(String.self, forKey: .tabletScreenshot)
         themeSlug = try? map.decode(String.self, forKey: .themeSlug)
+        groups = try? map.decode([String].self, forKey: .groups)
         segmentID = try? map.decode(Int64.self, forKey: .segmentID)
         categories = try map.decode([RemoteSiteDesignCategory].self, forKey: .categories)
     }

--- a/WordPressKit/RemoteSiteDesign.swift
+++ b/WordPressKit/RemoteSiteDesign.swift
@@ -33,7 +33,7 @@ public struct RemoteSiteDesign: Codable {
     public let mobileScreenshot: String?
     public let tabletScreenshot: String?
     public let themeSlug: String?
-    public let groups: [String]?
+    public let group: [String]?
     public let segmentID: Int64?
     public let categories: [RemoteSiteDesignCategory]
 
@@ -45,7 +45,7 @@ public struct RemoteSiteDesign: Codable {
         case mobileScreenshot = "preview_mobile"
         case tabletScreenshot = "preview_tablet"
         case themeSlug = "theme"
-        case groups
+        case group
         case segmentID = "segment_id"
         case categories
     }
@@ -59,7 +59,7 @@ public struct RemoteSiteDesign: Codable {
         mobileScreenshot = try? map.decode(String.self, forKey: .mobileScreenshot)
         tabletScreenshot = try? map.decode(String.self, forKey: .tabletScreenshot)
         themeSlug = try? map.decode(String.self, forKey: .themeSlug)
-        groups = try? map.decode([String].self, forKey: .groups)
+        group = try? map.decode([String].self, forKey: .group)
         segmentID = try? map.decode(Int64.self, forKey: .segmentID)
         categories = try map.decode([RemoteSiteDesignCategory].self, forKey: .categories)
     }


### PR DESCRIPTION
### Description

Related:
- https://github.com/wordpress-mobile/WordPress-iOS/issues/18434
- https://github.com/wordpress-mobile/WordPress-iOS/pull/18657
- D80005-code

This PR adds the ability to decode the optional `group` array parameter from remote designs served by the [themes endpoint](https://public-api.wordpress.com/wpcom/v2/common-starter-site-designs/?type=mobile). It is backwards compatible in the event that the API doesn't serve the `group` parameter.

### Testing Details

Use https://github.com/wordpress-mobile/WordPress-iOS/pull/18657 for testing.

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.