### PR TITLE
Post creation/update: handle when post metadata has a "key".

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.53.0-beta.1'
+  s.version       = '4.53.0-beta.x'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -586,12 +586,17 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     return [post.metadata wp_map:^id(NSDictionary *meta) {
         NSNumber *metaID = [meta objectForKey:@"id"];
         NSString *metaValue = [meta objectForKey:@"value"];
+        NSString *metaKey = [meta objectForKey:@"key"];
         NSString *operation = @"update";
-        if (metaID && !metaValue) {
-            operation = @"delete";
-        } else if (!metaID && metaValue) {
-            operation = @"add";
+
+        if (!metaKey) {
+            if (metaID && !metaValue) {
+                operation = @"delete";
+            } else if (!metaID && metaValue) {
+                operation = @"add";
+            }
         }
+
         NSMutableDictionary *modifiedMeta = [meta mutableCopy];
         modifiedMeta[@"operation"] = operation;
         return [NSDictionary dictionaryWithDictionary:modifiedMeta];


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/18429
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/18717

This handles when a Post's metadata has a `key` in the dictionary. Specifically, use the default `update` operation.

### Testing Details

Can be tested with the referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered updating the `version` in the `.podspec` file. [NEEDS TO BE UPDATED BEFORE MERGING]
