### PR TITLE
Add public initializers to `RemoteBloggingPromptsSettings` & `ReminderDays`

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.53.0-beta.3'
+  s.version       = '4.53.0-beta.4'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.53.0-beta.2'
+  s.version       = '4.53.0-beta.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/RemoteBloggingPromptsSettings.swift
+++ b/WordPressKit/RemoteBloggingPromptsSettings.swift
@@ -13,6 +13,16 @@ public struct RemoteBloggingPromptsSettings: Codable {
         public var friday: Bool
         public var saturday: Bool
         public var sunday: Bool
+
+        public init(monday: Bool, tuesday: Bool, wednesday: Bool, thursday: Bool, friday: Bool, saturday: Bool, sunday: Bool) {
+            self.monday = monday
+            self.tuesday = tuesday
+            self.wednesday = wednesday
+            self.thursday = thursday
+            self.friday = friday
+            self.saturday = saturday
+            self.sunday = sunday
+        }
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -29,4 +39,13 @@ public struct RemoteBloggingPromptsSettings: Codable {
         try container.encode(reminderDays, forKey: .reminderDays)
         try container.encode(reminderTime, forKey: .reminderTime)
     }
+
+    public init(promptCardEnabled: Bool = false, promptRemindersEnabled: Bool, reminderDays: RemoteBloggingPromptsSettings.ReminderDays, reminderTime: String, isPotentialBloggingSite: Bool = false) {
+        self.promptCardEnabled = promptCardEnabled
+        self.promptRemindersEnabled = promptRemindersEnabled
+        self.reminderDays = reminderDays
+        self.reminderTime = reminderTime
+        self.isPotentialBloggingSite = isPotentialBloggingSite
+    }
+
 }


### PR DESCRIPTION
See: wordpress-mobile/WordPress-iOS#18549
WP PR: wordpress-mobile/WordPress-iOS#18737

### Description

Add public initializers to `RemoteBloggingPromptsSettings` & `ReminderDays`

### Testing Details

See WordPress PR linked above for testing.

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
