### PR TITLE
Bump Podspec to 4.56.0-beta.1

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.55.0'
+  s.version       = '4.56.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

This PR updates the Podspec to `4.56.0-beta.1`

That will include the changes from https://github.com/wordpress-mobile/WordPressKit-iOS/pull/529

### Testing Details

N/A

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
