### PR TITLE
[Gutenberg] RemoteBlockEditorSettings - Add List block V2 flag

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.56.0'
+  s.version       = '4.57.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -5,7 +5,7 @@ public class RemoteBlockEditorSettings: Codable {
         case isFSETheme = "__unstableEnableFullSiteEditingBlocks"
         case galleryWithImageBlocks = "__unstableGalleryWithImageBlocks"
         case quoteBlockV2 = "__experimentalEnableQuoteBlockV2"
-        case listBlockV2 = "__experimentalEnablelistBlockV2"
+        case listBlockV2 = "__experimentalEnableListBlockV2"
         case rawStyles = "__experimentalStyles"
         case rawFeatures = "__experimentalFeatures"
         case colors

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -5,6 +5,7 @@ public class RemoteBlockEditorSettings: Codable {
         case isFSETheme = "__unstableEnableFullSiteEditingBlocks"
         case galleryWithImageBlocks = "__unstableGalleryWithImageBlocks"
         case quoteBlockV2 = "__experimentalEnableQuoteBlockV2"
+        case listBlockV2 = "__experimentalEnablelistBlockV2"
         case rawStyles = "__experimentalStyles"
         case rawFeatures = "__experimentalFeatures"
         case colors
@@ -14,6 +15,7 @@ public class RemoteBlockEditorSettings: Codable {
     public let isFSETheme: Bool
     public let galleryWithImageBlocks: Bool
     public let quoteBlockV2: Bool
+    public let listBlockV2: Bool
     public let rawStyles: String?
     public let rawFeatures: String?
     public let colors: [[String: String]]?
@@ -40,6 +42,7 @@ public class RemoteBlockEditorSettings: Codable {
         self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
         self.galleryWithImageBlocks = (try? map.decode(Bool.self, forKey: .galleryWithImageBlocks)) ?? false
         self.quoteBlockV2 = (try? map.decode(Bool.self, forKey: .quoteBlockV2)) ?? false
+        self.listBlockV2 = (try? map.decode(Bool.self, forKey: .listBlockV2)) ?? false
         self.rawStyles = RemoteBlockEditorSettings.parseToString(map, .rawStyles)
         self.rawFeatures = RemoteBlockEditorSettings.parseToString(map, .rawFeatures)
         self.colors = try? map.decode([[String: String]].self, forKey: .colors)


### PR DESCRIPTION
- **Gutenberg PR**: https://github.com/WordPress/gutenberg/pull/42702

### Description
Adds a Gutenberg feature flag for the List V2 block. For more information, check the Gutenberg PR description.

### Fixes
- https://github.com/WordPress/gutenberg/issues/42624

### Testing Details

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
