### PR TITLE
Merge 4.57.0 stable release

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.57.0-beta.1'
+  s.version       = '4.57.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION

This version bump PR is part of the code freeze workflow for WordPress iOS 20.5 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.