### PR TITLE
XML-RPC: Use stringForKeyPath when accessing image sizes from remote metadata

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.56.0'
+  s.version       = '4.56.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.56.1'
+  s.version       = '4.57.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/MediaServiceRemoteXMLRPC.m
+++ b/WordPressKit/MediaServiceRemoteXMLRPC.m
@@ -273,12 +273,12 @@
     }
     remoteMedia.file = [link lastPathComponent] ?: [[xmlRPC objectForKeyPath:@"file"] lastPathComponent];
     
-    if ([xmlRPC valueForKeyPath:@"metadata.sizes.large.file"] != nil) {
-        remoteMedia.largeURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@%@", remoteMedia.url.URLByDeletingLastPathComponent, [xmlRPC valueForKeyPath:@"metadata.sizes.large.file"]]];
+    if ([xmlRPC stringForKeyPath:@"metadata.sizes.large.file"] != nil) {
+        remoteMedia.largeURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@%@", remoteMedia.url.URLByDeletingLastPathComponent, [xmlRPC stringForKeyPath:@"metadata.sizes.large.file"]]];
     }
     
-    if ([xmlRPC valueForKeyPath:@"metadata.sizes.medium.file"] != nil) {
-        remoteMedia.mediumURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@%@", remoteMedia.url.URLByDeletingLastPathComponent, [xmlRPC valueForKeyPath:@"metadata.sizes.medium.file"]]];
+    if ([xmlRPC stringForKeyPath:@"metadata.sizes.medium.file"] != nil) {
+        remoteMedia.mediumURL = [NSURL URLWithString: [NSString stringWithFormat:@"%@%@", remoteMedia.url.URLByDeletingLastPathComponent, [xmlRPC stringForKeyPath:@"metadata.sizes.medium.file"]]];
     }
 
     if (xmlRPC[@"date_created_gmt"] != nil) {


### PR DESCRIPTION
### Description

This PR fixes a crash that can occur when trying to access empty file size metadata over XML-RPC.

**Related:**
- https://github.com/wordpress-mobile/WordPress-iOS/pull/19198
- https://github.com/wordpress-mobile/WordPress-iOS/issues/19199
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/529

<details><summary>See stack trace</summary>

```
OS Version: iOS 15.6 (19G71)
Report Version: 104

Exception Type: EXC_CRASH (SIGABRT)
Crashed Thread: 0

Application Specific Information:
[<__NSCFBoolean 0x22a605c08> valueForUndefinedKey:]: this class is not key value coding-compliant for the key sizes.

Thread 0 Crashed:
0   CoreFoundation                  0x350185288         __exceptionPreprocess
1   libobjc.A.dylib                 0x381c66740         objc_exception_throw
2   CoreFoundation                  0x35025c400         -[NSException raise]
3   Foundation                      0x3532332e4         -[NSObject(NSKeyValueCoding) valueForUndefinedKey:]
4   Foundation                      0x353104420         -[NSObject(NSKeyValueCoding) valueForKey:]
5   Foundation                      0x3530f6ffc         -[NSObject(NSKeyValueCoding) valueForKeyPath:]
6   Foundation                      0x3530f700c         -[NSObject(NSKeyValueCoding) valueForKeyPath:]
7   Foundation                      0x35314481c         -[NSDictionary(NSKeyValueCoding) valueForKeyPath:]
8   WordPress                       0x203ef6590         -[MediaServiceRemoteXMLRPC remoteMediaFromXMLRPCDictionary:] (MediaServiceRemoteXMLRPC.m:276)
9   WordPress                       0x2040510a8         -[NSArray(WPMapFilterReduce) wp_map:] (WPMapFilterReduce.m:9)
10  WordPress                       0x203ef610c         -[MediaServiceRemoteXMLRPC remoteMediaFromXMLRPCArray:] (MediaServiceRemoteXMLRPC.m:253)
11  WordPress                       0x203ef4d38         __86-[MediaServiceRemoteXMLRPC getMediaLibraryStartOffset:media:pageLoad:success:failure:]_block_invoke (MediaServiceRemoteXMLRPC.m:57)
12  WordPress                       0x20403e9bc         [inlined] WordPressOrgXMLRPCApi.callMethod (WordPressOrgXMLRPCApi.swift:166)
13  WordPress                       0x20403e9bc         WordPressOrgXMLRPCApi.callMethod
14  WordPress                       0x202df8f0c         thunk for closure
15  libdispatch.dylib               0x34fae7e68         _dispatch_call_block_and_release
16  libdispatch.dylib               0x34fae9a2c         _dispatch_client_callout
17  libdispatch.dylib               0x34faf7f44         _dispatch_main_queue_drain
18  libdispatch.dylib               0x34faf7b94         _dispatch_main_queue_callback_4CF
19  CoreFoundation                  0x35013d7fc         __CFRUNLOOP_IS_SERVICING_THE_MAIN_DISPATCH_QUEUE__
20  CoreFoundation                  0x3500f7700         __CFRunLoopRun
21  CoreFoundation                  0x35010abc4         CFRunLoopRunSpecific
22  GraphicsServices                0x3883fd370         GSEventRunModal
23  UIKitCore                       0x354efcb54         -[UIApplication _run]
24  UIKitCore                       0x354c7e08c         UIApplicationMain
25  WordPress                       0x202dd6ed0         main (main.swift:7)
26  <unknown>                       0x104f45da4         <redacted>
```
</details>

### Testing Details

[Use the build from this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19198)

Manually empty the `sizes` attribute for an attachment in the DB (/ht @dcalhoun for this idea) by [following the steps here](https://github.com/wordpress-mobile/WordPress-iOS/issues/19199#issuecomment-1218187551):

<img src="https://user-images.githubusercontent.com/2092798/185184268-68143f89-d26a-446a-85b1-f0470f34b2ea.png" width="350" />

1. Connect the WP app to a self-hosted site via XML-RPC.
2. Navigate to the site's Media screen in the app.
3. Upload an image.
4. Navigate away from Media in the app.
5. Manually modify the image's meta data within the wp_postmeta table of the MySQL database to empty the sizes attribute (or merely removing one of the relevant sizes, e.g. large).
6. Navigate back to Media in the app.
7. Expect no crash.

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
