### PR TITLE
Remote Feature Flags: Point to the new endpoint

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.57.1'
+  s.version       = '4.57.1-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.57.1-beta.1'
+  s.version       = '4.58.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -18,7 +18,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
             "platform": "apple" as NSString,
             "build_number": NSString(string: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"),
             "marketing_version": NSString(string: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"),
-            "bundle_identifier": NSString(string: Bundle.main.bundleIdentifier ?? "Unknown")
+            "identifier": NSString(string: Bundle.main.bundleIdentifier ?? "Unknown")
         ]
 
         wordPressComRestApi.GET(path,


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/19308
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/19309

This points `FeatureFlagRemote` to the new endpoint by updating the parameters to match the new endpoint contract.

### Testing Details

Please test using the referenced WPiOS PR.

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
