### PR TITLE
Update bash-cache Buildkite plugin to version 2.8.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ common_params:
   - automattic/bash-cache#2.8.0
   # Common environment values to use with the `env` key.
   env: &common_env
-    IMAGE_ID: xcode-14
+    IMAGE_ID: xcode-13.4.1
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - &bash_cache automattic/bash-cache#2.0.0: ~
+  - automattic/bash-cache#2.8.0
   # Common environment values to use with the `env` key.
   env: &common_env
     IMAGE_ID: xcode-13.4.1
@@ -14,9 +14,6 @@ steps:
   - label: "🧪 Build and Test"
     key: "test"
     command: |
-      # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      gem install bundler
-
       build_and_test_pod
     env: *common_env
     plugins: *common_plugins
@@ -27,9 +24,6 @@ steps:
   - label: "🔬 Validate Podspec"
     key: "validate"
     command: |
-      # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      gem install bundler
-
       validate_podspec
     env: *common_env
     plugins: *common_plugins
@@ -40,9 +34,6 @@ steps:
   - label: "🧹 Lint"
     key: "lint"
     command: |
-      # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      gem install bundler
-
       lint_pod
     env: *common_env
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ common_params:
   - automattic/bash-cache#2.8.0
   # Common environment values to use with the `env` key.
   env: &common_env
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -14,4 +14,4 @@ echo "--- :cocoapods: Publishing Pod to WP Specs Repo"
 publish_private_pod $PODSPEC_PATH $SPECS_REPO "$SPEC_REPO_PUBLIC_DEPLOY_KEY"
 
 echo "--- :slack: Notifying Slack"
-slack_notify_pod_published $PODSPEC_PATH $SLACK_WEBHOOK
+slack_notify_pod_published $PODSPEC_PATH "$SLACK_WEBHOOK"

--- a/.buildkite/publish-pod.sh
+++ b/.buildkite/publish-pod.sh
@@ -5,9 +5,6 @@ SPECS_REPO="git@github.com:wordpress-mobile/cocoapods-specs.git"
 SLACK_WEBHOOK=$PODS_SLACK_WEBHOOK
 
 echo "--- :rubygems: Setting up Gems"
-# See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-gem install bundler:2.3.4
-
 install_gems
 
 echo "--- :cocoapods: Publishing Pod to CocoaPods CDN"

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.58.0-beta.1'
+  s.version       = '4.58.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

This should address the recent [CI failure](https://buildkite.com/automattic/wordpresskit-ios/builds/576#01835db2-67f3-4579-aee0-501886defe24) when attempting to release a new beta.

### Testing Details

If CI is green, we're good.

- [x] Please check here if your pull request includes additional test coverage. – N.A.
- [x] I have considered updating the `version` in the `.podspec` file. – N.A.
