### PR TITLE
Stats Revamp: AnnualAntMostPopularTime percentages are always rounded down

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.58.0'
+  s.version       = '4.58.1-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0152100C28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */; };
 		1769DEAA24729AFF00F42EFC /* HomepageSettingsServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1769DEA924729AFF00F42EFC /* HomepageSettingsServiceRemote.swift */; };
 		17BF9A6C20C7DC3300BF57D2 /* reader-site-search-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */; };
 		17BF9A7220C7E18200BF57D2 /* reader-site-search-success-hasmore.json in Resources */ = {isa = PBXBuildFile; fileRef = 17BF9A6D20C7E18100BF57D2 /* reader-site-search-success-hasmore.json */; };
@@ -666,6 +667,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsAnnualAndMostPopularTimeInsightDecodingTests.swift; sourceTree = "<group>"; };
 		1769DEA924729AFF00F42EFC /* HomepageSettingsServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomepageSettingsServiceRemote.swift; sourceTree = "<group>"; };
 		17BF9A6B20C7DC3300BF57D2 /* reader-site-search-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-site-search-success.json"; sourceTree = "<group>"; };
 		17BF9A6D20C7E18100BF57D2 /* reader-site-search-success-hasmore.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reader-site-search-success-hasmore.json"; sourceTree = "<group>"; };
@@ -1731,6 +1733,7 @@
 			isa = PBXGroup;
 			children = (
 				40F9880B221ACEEE00B7B369 /* StatsRemoteV2Tests.swift */,
+				0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -3337,6 +3340,7 @@
 				F3FF8A21279C8EE200E5C90F /* RemotePersonTests.swift in Sources */,
 				73D5930521E5541200E4CF84 /* WordPressComServiceRemoteTests+SiteVerticals.swift in Sources */,
 				8BB5F62427A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift in Sources */,
+				0152100C28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift in Sources */,
 				17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */,
 				73A2F38D21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift in Sources */,
 				74C473AF1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/Insights/StatsAnnualAndMostPopularTimeInsight.swift
+++ b/WordPressKit/Insights/StatsAnnualAndMostPopularTimeInsight.swift
@@ -90,9 +90,9 @@ extension StatsAnnualAndMostPopularTimeInsight: StatsInsightData {
         let hourComponents = DateComponents(hour: highestHour)
 
         self.mostPopularDayOfWeek = weekDayComponent
-        self.mostPopularDayOfWeekPercentage = Int(highestDayOfWeekPercentageValue)
+        self.mostPopularDayOfWeekPercentage = Int(highestDayOfWeekPercentageValue.rounded())
         self.mostPopularHour = hourComponents
-        self.mostPopularHourPercentage = Int(highestHourPercentageValue)
+        self.mostPopularHourPercentage = Int(highestHourPercentageValue.rounded())
 
         self.annualInsightsYear = currentYear
 

--- a/WordPressKitTests/StatsAnnualAndMostPopularTimeInsightDecodingTests.swift
+++ b/WordPressKitTests/StatsAnnualAndMostPopularTimeInsightDecodingTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import WordPressKit
 
 final class StatsAnnualAndMostPopularTimeInsightDecodingTests: XCTestCase {
-    
+
     func testDecodingWithAllRequiredParametersIsSuccessful() {
         // Given
         let json: [String: Any] = [
@@ -12,14 +12,14 @@ final class StatsAnnualAndMostPopularTimeInsightDecodingTests: XCTestCase {
             "highest_day_percent": 1,
             "years": [["year": "2022"]]
         ]
-        
+
         // When
         let insight = StatsAnnualAndMostPopularTimeInsight(jsonDictionary: json as [String: AnyObject])
-        
+
         // Then
         XCTAssertNotNil(insight)
     }
-    
+
     func testDecodingWithoutAllRequiredParametersIsUnsuccessful() {
         // Given
         let json: [String: Any] = [
@@ -28,14 +28,14 @@ final class StatsAnnualAndMostPopularTimeInsightDecodingTests: XCTestCase {
             "highest_day_of_week": 1,
             "highest_day_percent": 1
         ]
-        
+
         // When
         let insight = StatsAnnualAndMostPopularTimeInsight(jsonDictionary: json as [String: AnyObject])
-        
+
         // Then
         XCTAssertNil(insight)
     }
-    
+
     func testDecodingDecimalPercentagesRoundsSuccessful() {
         // Given
         let json: [String: Any] = [
@@ -45,10 +45,10 @@ final class StatsAnnualAndMostPopularTimeInsightDecodingTests: XCTestCase {
             "highest_day_percent": 5.4,
             "years": [["year": "2022"]]
         ]
-        
+
         // When
         let insight = StatsAnnualAndMostPopularTimeInsight(jsonDictionary: json as [String: AnyObject])
-        
+
         // Then
         XCTAssertEqual(insight?.mostPopularHourPercentage, 21)
         XCTAssertEqual(insight?.mostPopularDayOfWeekPercentage, 5)

--- a/WordPressKitTests/StatsAnnualAndMostPopularTimeInsightDecodingTests.swift
+++ b/WordPressKitTests/StatsAnnualAndMostPopularTimeInsightDecodingTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import WordPressKit
+
+final class StatsAnnualAndMostPopularTimeInsightDecodingTests: XCTestCase {
+    
+    func testDecodingWithAllRequiredParametersIsSuccessful() {
+        // Given
+        let json: [String: Any] = [
+            "highest_hour": 1,
+            "highest_hour_percent": 1,
+            "highest_day_of_week": 1,
+            "highest_day_percent": 1,
+            "years": [["year": "2022"]]
+        ]
+        
+        // When
+        let insight = StatsAnnualAndMostPopularTimeInsight(jsonDictionary: json as [String: AnyObject])
+        
+        // Then
+        XCTAssertNotNil(insight)
+    }
+    
+    func testDecodingWithoutAllRequiredParametersIsUnsuccessful() {
+        // Given
+        let json: [String: Any] = [
+            "highest_hour": 1,
+            "highest_hour_percent": 1,
+            "highest_day_of_week": 1,
+            "highest_day_percent": 1
+        ]
+        
+        // When
+        let insight = StatsAnnualAndMostPopularTimeInsight(jsonDictionary: json as [String: AnyObject])
+        
+        // Then
+        XCTAssertNil(insight)
+    }
+    
+    func testDecodingDecimalPercentagesRoundsSuccessful() {
+        // Given
+        let json: [String: Any] = [
+            "highest_hour": 1,
+            "highest_hour_percent": 20.5,
+            "highest_day_of_week": 1,
+            "highest_day_percent": 5.4,
+            "years": [["year": "2022"]]
+        ]
+        
+        // When
+        let insight = StatsAnnualAndMostPopularTimeInsight(jsonDictionary: json as [String: AnyObject])
+        
+        // Then
+        XCTAssertEqual(insight?.mostPopularHourPercentage, 21)
+        XCTAssertEqual(insight?.mostPopularDayOfWeekPercentage, 5)
+    }
+}


### PR DESCRIPTION
Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/19346

### Description

`StatsAnnualAndMostPopularTimeInsight` `mostPopularDayOfWeekPercentage` and `mostPopularHourPercentage` are always rounded down. It happens when we convert it from `Double` to `Int` during parsing.

### Solution

Use `rounded()` before converting number to `Int`.

#### Other possible solution

Change numbers from `Int` to `Double` and allow users of `WordPressKit` to decide how these numbers are rounded. Decided against it as it would be a major breaking API change and I don't think such change merits that. 


ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
