### PR TITLE
Add `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,33 @@ The format of this document is inspired by [Keep a Changelog](https://keepachang
 
 <!-- This is a comment, you won't see it when GitHub renders the Markdown file.
 
-Types of changes:
+When releasing a new version:
 
-- Breaking Changes
-- New Features
-- Bug Fixes
-- Internal Changes
--->
+1. Remove any empty entry (those with `_None._`)
+2. Update the `## Unreleased` header to `## [<version_number>](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/<version_number>)`
+3. Add a new "Unreleased" section for the next iteration, by copy/pasting the following template:
 
 ## Unreleased
 
-<!-- When adding a new version, use this template
-## [<version_number>](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/<version_number>)
+### Breaking Changes
+
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
 -->
+
+## Unreleased
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+The format of this document is inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- This is a comment, you won't see it when GitHub renders the Markdown file.
+
+Types of changes:
+
+- Breaking Changes
+- New Features
+- Bug Fixes
+- Internal Changes
+-->
+
+## Unreleased
+
+<!-- When adding a new version, use this template
+## [<version_number>](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/<version_number>)
+-->
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format of this document is inspired by [Keep a Changelog](https://keepachang
 
 When releasing a new version:
 
-1. Remove any empty entry (those with `_None._`)
+1. Remove any empty section (those with `_None._`)
 2. Update the `## Unreleased` header to `## [<version_number>](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/<version_number>)`
 3. Add a new "Unreleased" section for the next iteration, by copy/pasting the following template:
 


### PR DESCRIPTION
I based this on what we are already [using in release-toolkit](https://github.com/wordpress-mobile/release-toolkit/blob/ae2f0924b2ed996bc9957728d9f0efb3cc5cf062/CHANGELOG.md).

After this goes through code review and eventually lands into `trunk`, I'll carbon-copy it in the other iOS libraries for which we want to improve our SemVer workflow.