### PR TITLE
Add changelog entry about changelog itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,4 +46,4 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Add this changelog file. [#545]


### PR DESCRIPTION
### Description

In #545, @AliSoftware [suggested/asked](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/545#pullrequestreview-1145453099) whether to add a template for listing PRs or count on the same pattern from other projects being adopted organically. 

I thought about using the addition of the changelog itself as an example to set the standard. By the time I thought of that, though, auto-merge had already kicked in and my push failed. So here we are in a new PR (which will not be listed in the changelog 🙃 )
