### PR TITLE
Add support for fetching remote config values

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '4.58.1'
+  s.version       = '4.58.2-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -329,6 +329,8 @@
 		7E3E7A4C20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E3E7A4B20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift */; };
 		7EC60EBE22DC4F9000FB0336 /* EditorServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC60EBD22DC4F9000FB0336 /* EditorServiceRemoteTests.swift */; };
 		7EC60EC022DC5D7C00FB0336 /* EditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC60EBF22DC5D7C00FB0336 /* EditorSettings.swift */; };
+		803DE80F28FFA787007D4E9C /* RemoteConfigRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803DE80E28FFA787007D4E9C /* RemoteConfigRemote.swift */; };
+		803DE81128FFA9C4007D4E9C /* RemoteConfigRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803DE81028FFA9C4007D4E9C /* RemoteConfigRemoteTests.swift */; };
 		8236EB4D2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8236EB4C2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift */; };
 		826016F11F9FA13A00533B6C /* ActivityServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */; };
 		826016F31F9FA17B00533B6C /* Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826016F21F9FA17B00533B6C /* Activity.swift */; };
@@ -991,6 +993,8 @@
 		7E3E7A4B20E443AA0075D159 /* NSMutableParagraphStyle+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableParagraphStyle+extensions.swift"; sourceTree = "<group>"; };
 		7EC60EBD22DC4F9000FB0336 /* EditorServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorServiceRemoteTests.swift; sourceTree = "<group>"; };
 		7EC60EBF22DC5D7C00FB0336 /* EditorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSettings.swift; sourceTree = "<group>"; };
+		803DE80E28FFA787007D4E9C /* RemoteConfigRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigRemote.swift; sourceTree = "<group>"; };
+		803DE81028FFA9C4007D4E9C /* RemoteConfigRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigRemoteTests.swift; sourceTree = "<group>"; };
 		8236EB4C2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteBlogJetpackModulesSettings.swift; sourceTree = "<group>"; };
 		826016F01F9FA13A00533B6C /* ActivityServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceRemote.swift; sourceTree = "<group>"; };
 		826016F21F9FA17B00533B6C /* Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
@@ -1903,6 +1907,7 @@
 				D816857021EDACD10049883E /* WordPressComServiceRemote+SiteSegments.swift */,
 				730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */,
 				73A2F38921E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift */,
+				803DE80E28FFA787007D4E9C /* RemoteConfigRemote.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -2499,6 +2504,7 @@
 				F9E56DFA24EB18C300916770 /* FeatureFlagRemoteTests.swift */,
 				24ADA24D24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift */,
 				465F88BE263B54EE00F4C950 /* ChecksumUtilTests.swift */,
+				803DE81028FFA9C4007D4E9C /* RemoteConfigRemoteTests.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -3064,6 +3070,7 @@
 				7430C9A41F1927180051B8E6 /* ReaderPostServiceRemote.m in Sources */,
 				C797196D2679007B0072F984 /* JetpackPluginManagementClient.swift in Sources */,
 				408197882220A35000A298E4 /* StatsLastPostInsight.swift in Sources */,
+				803DE80F28FFA787007D4E9C /* RemoteConfigRemote.swift in Sources */,
 				F9E56DF624EB11EF00916770 /* FeatureFlag.swift in Sources */,
 				8B2F4BE724ABC8A90056C08A /* ReaderPostServiceRemote+Cards.swift in Sources */,
 				8B16CE8E25250039007BE5A9 /* RemoteReaderPost.swift in Sources */,
@@ -3295,6 +3302,7 @@
 				32AF21E3236DEB3C001C6502 /* PostServiceRemoteRESTAutosaveTests.swift in Sources */,
 				3236F79A24AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift in Sources */,
 				FEE4EF5B27302317003CDA3C /* CommentServiceRemoteREST+APIv2Tests.swift in Sources */,
+				803DE81128FFA9C4007D4E9C /* RemoteConfigRemoteTests.swift in Sources */,
 				74B5F0DE1EF82A9600B411E7 /* BlogServiceRemoteRESTTests.m in Sources */,
 				ABD95B7F25DD6C4B00735BEE /* CommentServiceRemoteRESTLikesTests.swift in Sources */,
 				8B749E8225AF7DDA00023F03 /* JetpackCapabilitiesServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/RemoteConfigRemote.swift
+++ b/WordPressKit/RemoteConfigRemote.swift
@@ -22,7 +22,7 @@ open class RemoteConfigRemote: ServiceRemoteWordPressComREST {
             } else {
                 callback(.failure(RemoteConfigRemoteError.InvalidDataError))
             }
-            
+
         }, failure: { error, response in
             DDLogError("Error retrieving remote config values")
             DDLogError("\(error)")

--- a/WordPressKit/RemoteConfigRemote.swift
+++ b/WordPressKit/RemoteConfigRemote.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+open class RemoteConfigRemote: ServiceRemoteWordPressComREST {
+
+    public typealias RemoteConfigDictionary = [String: Any]
+    public typealias RemoteConfigResponseCallback = (Result<RemoteConfigDictionary, Error>) -> Void
+
+    public enum RemoteConfigRemoteError: Error {
+        case InvalidDataError
+    }
+
+    open func getRemoteConfig(callback: @escaping RemoteConfigResponseCallback) {
+
+        let endpoint = "mobile/remote-config"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
+
+        wordPressComRestApi.GET(path,
+                                parameters: nil,
+                                success: { response, _ in
+            if let remoteConfigDictionary = response as? [String: Any] {
+                callback(.success(remoteConfigDictionary))
+            } else {
+                callback(.failure(RemoteConfigRemoteError.InvalidDataError))
+            }
+            
+        }, failure: { error, response in
+            DDLogError("Error retrieving remote config values")
+            DDLogError("\(error)")
+
+            if let response = response {
+                DDLogDebug("Response Code: \(response.statusCode)")
+            }
+
+            callback(.failure(error))
+        })
+    }
+}

--- a/WordPressKitTests/Utilities/RemoteConfigRemoteTests.swift
+++ b/WordPressKitTests/Utilities/RemoteConfigRemoteTests.swift
@@ -2,13 +2,13 @@ import XCTest
 @testable import WordPressKit
 
 final class RemoteConfigRemoteTests: RemoteTestCase, RESTTestable {
-    
+
     // MARK: Variables
-    
+
     private let endpoint = "/wpcom/v2/mobile/remote-config"
-    
+
     // MARK: Tests
-    
+
     func testThatResponsesAreHandledCorrectly() throws {
         // Given
         let dictionary = ["key1": "value", "key2": "value2"]
@@ -18,7 +18,7 @@ final class RemoteConfigRemoteTests: RemoteTestCase, RESTTestable {
         // When
         let expectation = XCTestExpectation()
         RemoteConfigRemote(wordPressComRestApi: getRestApi()).getRemoteConfig { result in
-            
+
             // Then
             let response = try! result.get() as? [String: String]
             XCTAssertEqual(response, dictionary)
@@ -27,7 +27,7 @@ final class RemoteConfigRemoteTests: RemoteTestCase, RESTTestable {
 
         wait(for: [expectation], timeout: 1)
     }
-    
+
     func testThatEmptyResponsesAreHandledCorrectly() throws {
         // Given
         let emptyDictionary: [String: String] = [:]
@@ -37,7 +37,7 @@ final class RemoteConfigRemoteTests: RemoteTestCase, RESTTestable {
         // When
         let expectation = XCTestExpectation()
         RemoteConfigRemote(wordPressComRestApi: getRestApi()).getRemoteConfig { result in
-            
+
             // Then
             XCTAssertEqual(0, try! result.get().count)
             expectation.fulfill()
@@ -45,7 +45,7 @@ final class RemoteConfigRemoteTests: RemoteTestCase, RESTTestable {
 
         wait(for: [expectation], timeout: 1)
     }
-    
+
     func testThatMalformedResponsesReturnEmptyArray() throws {
         // Given
         let data = try toJSON(object: ["Invalid"])
@@ -54,7 +54,7 @@ final class RemoteConfigRemoteTests: RemoteTestCase, RESTTestable {
         // When
         let expectation = XCTestExpectation()
         RemoteConfigRemote(wordPressComRestApi: getRestApi()).getRemoteConfig { result in
-            
+
             // Then
             switch result {
                 case .success: XCTFail()
@@ -72,19 +72,19 @@ final class RemoteConfigRemoteTests: RemoteTestCase, RESTTestable {
         // When
         let expectation = XCTestExpectation()
         RemoteConfigRemote(wordPressComRestApi: getRestApi()).getRemoteConfig { result in
-            
+
             // Then
             if case .success = result {
                 XCTFail()
             }
             expectation.fulfill()
         }
-        
+
         wait(for: [expectation], timeout: 1)
     }
-    
+
     // MARK: Helpers
-    
+
     private func toJSON<T: Codable>(object: T) throws -> Data {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]

--- a/WordPressKitTests/Utilities/RemoteConfigRemoteTests.swift
+++ b/WordPressKitTests/Utilities/RemoteConfigRemoteTests.swift
@@ -1,0 +1,36 @@
+//
+//  RemoteConfigRemoteTests.swift
+//  WordPressKitTests
+//
+//  Created by Hassaan El-Garem on 19/10/2022.
+//  Copyright © 2022 Automattic Inc. All rights reserved.
+//
+
+import XCTest
+
+final class RemoteConfigRemoteTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
### Description

Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/19445
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/19483

This adds a new remote (`RemoteConfigRemote`), which fetches remote config values from a new endpoint.

### Testing Details

Please test using the referenced WPiOS PR.

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
