### PR TITLE
Bump `wpxmlrpc` to version 0.10.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -11,7 +11,7 @@ def wordpresskit_pods
   pod 'Alamofire', '~> 4.8.0'
   pod 'WordPressShared', '~> 2.0.0-beta.2'
   pod 'NSObject-SafeExpectations', '~> 0.0.4'
-  pod 'wpxmlrpc', '~> 0.9.0'
+  pod 'wpxmlrpc', '~> 0.10.0'
   pod 'UIDeviceIdentifier', '~> 2.0'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -19,7 +19,7 @@ PODS:
     - OHHTTPStubs/Default
   - UIDeviceIdentifier (2.2.0)
   - WordPressShared (2.0.0-beta.2)
-  - wpxmlrpc (0.9.0)
+  - wpxmlrpc (0.10.0)
 
 DEPENDENCIES:
   - Alamofire (~> 4.8.0)
@@ -29,7 +29,7 @@ DEPENDENCIES:
   - OHHTTPStubs/Swift (~> 9.0)
   - UIDeviceIdentifier (~> 2.0)
   - WordPressShared (~> 2.0.0-beta.2)
-  - wpxmlrpc (~> 0.9.0)
+  - wpxmlrpc (~> 0.10.0)
 
 SPEC REPOS:
   trunk:
@@ -48,8 +48,8 @@ SPEC CHECKSUMS:
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
   UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
-  wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
+  wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
 
-PODFILE CHECKSUM: 1ef97fe2f82b603af51c77b68405a14d8e07063f
+PODFILE CHECKSUM: 5e4ba02626e43d8ae1cdc02077e9086e8861cd77
 
 COCOAPODS: 1.11.3

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
 
   s.dependency 'Alamofire', '~> 4.8.0'
   s.dependency 'NSObject-SafeExpectations', '~> 0.0.4'
-  s.dependency 'wpxmlrpc', '~> 0.9'
+  s.dependency 'wpxmlrpc', '~> 0.10'
   s.dependency 'UIDeviceIdentifier', '~> 2.0'
 
   # Use a loose restriction that allows both production and beta versions, up to the next major version.


### PR DESCRIPTION
### Description

This version has iOS 11 deployment target, making it compliant with Xcode 14.

Notice it was not necessary to update the value in the `podspec` file because `~> 0.9` would have picked it already. I did that for consistency with what defined in `Podfile`.

### Testing Details

If CI builds, we're fine.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.

I decided not to update the changelog because this is an irrelevant internal change.