### PR TITLE
Update NSObject-SafeExpecations

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-  - automattic/bash-cache#2.8.0
+  - automattic/bash-cache#2.12.0
   # Common environment values to use with the `env` key.
   env: &common_env
     IMAGE_ID: xcode-13.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-- Change the NSObject+SafeExpectations dependency to `~> 0.0.4`.
+- Change the NSObject+SafeExpectations dependency to `~> 0.0.4`. [#555]
 
 ## [5.0.0](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/5.0.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Change the NSObject+SafeExpectations dependency to `~> 0.0.4`.
 
 ## [5.0.0](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/5.0.0)
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Alamofire (4.8.2)
-  - NSObject-SafeExpectations (0.0.4)
-  - OCMock (3.8.1)
+  - NSObject-SafeExpectations (0.0.6)
+  - OCMock (3.9.1)
   - OHHTTPStubs (9.1.0):
     - OHHTTPStubs/Default (= 9.1.0)
   - OHHTTPStubs/Core (9.1.0)
@@ -17,7 +17,7 @@ PODS:
   - OHHTTPStubs/OHPathHelpers (9.1.0)
   - OHHTTPStubs/Swift (9.1.0):
     - OHHTTPStubs/Default
-  - UIDeviceIdentifier (2.0.0)
+  - UIDeviceIdentifier (2.2.0)
   - WordPressShared (2.0.0-beta.2)
   - wpxmlrpc (0.9.0)
 
@@ -43,10 +43,10 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  NSObject-SafeExpectations: ab8fe623d36b25aa1f150affa324e40a2f3c0374
-  OCMock: 29f6e52085b4e7d9b075cbf03ed7c3112f82f934
+  NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
+  OCMock: 9491e4bec59e0b267d52a9184ff5605995e74be8
   OHHTTPStubs: 90eac6d8f2c18317baeca36698523dc67c513831
-  UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
+  UIDeviceIdentifier: f33af270ba9045ea18b31d9aab88e42a0082ea67
   WordPressShared: 04403b43f821c4ed2b84a2112ef9f64f1e7cdceb
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -23,7 +23,7 @@ Pod::Spec.new do |s|
   s.header_dir = 'WordPressKit'
 
   s.dependency 'Alamofire', '~> 4.8.0'
-  s.dependency 'NSObject-SafeExpectations', '0.0.4'
+  s.dependency 'NSObject-SafeExpectations', '~> 0.0.4'
   s.dependency 'wpxmlrpc', '~> 0.9'
   s.dependency 'UIDeviceIdentifier', '~> 2.0'
 

--- a/WordPressKit/SharingServiceRemote.swift
+++ b/WordPressKit/SharingServiceRemote.swift
@@ -57,22 +57,22 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                 }
 
                 let responseString = responseObject.description as NSString
-                let services = responseDict.forKey(ServiceDictionaryKeys.services) as NSDictionary
+                let services: NSDictionary = (responseDict.forKey(ServiceDictionaryKeys.services) as? NSDictionary) ?? NSDictionary()
 
                 let publicizeServices: [RemotePublicizeService] = services.allKeys.map { (key) -> RemotePublicizeService in
-                    let dict = services.forKey(key) as NSDictionary
+                    let dict = (services.forKey(key) as? NSDictionary) ?? NSDictionary()
                     let pub = RemotePublicizeService()
 
-                    pub.connectURL = dict.string(forKey: ServiceDictionaryKeys.connectURL)
-                    pub.detail = dict.string(forKey: ServiceDictionaryKeys.description)
-                    pub.externalUsersOnly = dict.number(forKey: ServiceDictionaryKeys.externalUsersOnly).boolValue
-                    pub.icon = dict.string(forKey: ServiceDictionaryKeys.icon)
-                    pub.serviceID = dict.string(forKey: ServiceDictionaryKeys.ID)
-                    pub.jetpackModuleRequired = dict.string(forKey: ServiceDictionaryKeys.jetpackModuleRequired)
-                    pub.jetpackSupport = dict.number(forKey: ServiceDictionaryKeys.jetpackSupport).boolValue
-                    pub.label = dict.string(forKey: ServiceDictionaryKeys.label)
-                    pub.multipleExternalUserIDSupport = dict.number(forKey: ServiceDictionaryKeys.multipleExternalUserIDSupport).boolValue
-                    pub.type = dict.string(forKey: ServiceDictionaryKeys.type)
+                    pub.connectURL = dict.string(forKey: ServiceDictionaryKeys.connectURL) ?? ""
+                    pub.detail = dict.string(forKey: ServiceDictionaryKeys.description) ?? ""
+                    pub.externalUsersOnly = dict.number(forKey: ServiceDictionaryKeys.externalUsersOnly)?.boolValue ?? false
+                    pub.icon = dict.string(forKey: ServiceDictionaryKeys.icon) ?? ""
+                    pub.serviceID = dict.string(forKey: ServiceDictionaryKeys.ID) ?? ""
+                    pub.jetpackModuleRequired = dict.string(forKey: ServiceDictionaryKeys.jetpackModuleRequired) ?? ""
+                    pub.jetpackSupport = dict.number(forKey: ServiceDictionaryKeys.jetpackSupport)?.boolValue ?? false
+                    pub.label = dict.string(forKey: ServiceDictionaryKeys.label) ?? ""
+                    pub.multipleExternalUserIDSupport = dict.number(forKey: ServiceDictionaryKeys.multipleExternalUserIDSupport)?.boolValue ?? false
+                    pub.type = dict.string(forKey: ServiceDictionaryKeys.type) ?? ""
 
                     // We're not guarenteed to get the right order by inspecting the
                     // response dictionary's keys. Instead, we can check the index
@@ -112,7 +112,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                     return
                 }
 
-                let connections: Array = responseDict.array(forKey: ConnectionDictionaryKeys.connections)
+                let connections = responseDict.array(forKey: ConnectionDictionaryKeys.connections) ?? []
                 let keyringConnections: [KeyringConnection] = connections.map { (dict) -> KeyringConnection in
                     let conn = KeyringConnection()
                     let dict = dict as AnyObject
@@ -186,7 +186,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                     return
                 }
 
-                let connections: Array = responseDict.array(forKey: ConnectionDictionaryKeys.connections)
+                let connections = responseDict.array(forKey: ConnectionDictionaryKeys.connections) ?? []
                 let publicizeConnections: [RemotePublicizeConnection] = connections.compactMap { (dict) -> RemotePublicizeConnection? in
                     let conn = self.remotePublicizeConnectionFromDictionary(dict as! NSDictionary)
                     return conn
@@ -421,7 +421,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                     return
                 }
 
-                let buttons = responseDict.array(forKey: SharingButtonsKeys.sharingButtons) as NSArray
+                let buttons = responseDict.array(forKey: SharingButtonsKeys.sharingButtons) as? NSArray ?? NSArray()
                 let sharingButtons = self.remoteSharingButtonsFromDictionary(buttons)
 
                 onSuccess(sharingButtons)
@@ -457,7 +457,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                     return
                 }
 
-                let buttons = responseDict.array(forKey: SharingButtonsKeys.updated) as NSArray
+                let buttons = responseDict.array(forKey: SharingButtonsKeys.updated) as? NSArray ?? NSArray()
                 let sharingButtons = self.remoteSharingButtonsFromDictionary(buttons)
 
                 onSuccess(sharingButtons)


### PR DESCRIPTION
### Description

The dependencies among some Swift and Objective-C types in this library make it impossible to adopt Swift Package Manager. I'm planning to re-implement all Objective-C types in Swift. Since quite a few types uses the functions in `NSObject-SafeExpectations`, using the version that have [nullable annotation](https://github.com/wordpress-mobile/NSObject-SafeExpectations/pull/14) will make the transition safer.

### Testing Details

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
