### PR TITLE
Make properties be backwards compatible with the original ObjC API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-- Re-implement a few reader model types in Swift. [#556]
+- Re-implement a few reader model types in Swift. [#556, #557, #558]
 
 ### New Features
 

--- a/WordPressKit/RemoteBlog.swift
+++ b/WordPressKit/RemoteBlog.swift
@@ -5,31 +5,31 @@ import NSObject_SafeExpectations
 @objcMembers public class RemoteBlog: NSObject {
 
     /// The ID of the Blog entity.
-    public var blogID: NSNumber?
+    public var blogID: NSNumber!
 
     /// The organization ID of the Blog entity.
-    public var organizationID: NSNumber?
+    public var organizationID: NSNumber!
 
     /// Represents the Blog Name.
-    public var name: String?
+    public var name: String!
 
     /// Description of the WordPress Blog.
-    public var tagline: String?
+    public var tagline: String!
 
     /// Represents the Blog Name.
-    public var url: String?
+    public var url: String!
 
     /// Maps to the XMLRPC endpoint.
-    public var xmlrpc: String?
+    public var xmlrpc: String!
 
     /// Site Icon's URL.
-    public var icon: String?
+    public var icon: String!
 
     /// Product ID of the site's current plan, if it has one.
-    public var planID: NSNumber?
+    public var planID: NSNumber!
 
     /// Product name of the site's current plan, if it has one.
-    public var planTitle: String?
+    public var planTitle: String!
 
     /// Indicates whether the current's blog plan is paid, or not.
     public var hasPaidPlan: Bool = false
@@ -44,16 +44,16 @@ import NSObject_SafeExpectations
     public var visible: Bool = false
 
     /// Blog's options preferences.
-    public var options: NSDictionary?
+    public var options: NSDictionary!
 
     /// Blog's capabilities: Indicate which actions are allowed / not allowed, for the current user.
-    public var capabilities: NSDictionary?
+    public var capabilities: NSDictionary!
 
     /// Blog's total disk quota space.
-    public var quotaSpaceAllowed: NSNumber?
+    public var quotaSpaceAllowed: NSNumber!
 
     /// Blog's total disk quota space used.
-    public var quotaSpaceUsed: NSNumber?
+    public var quotaSpaceUsed: NSNumber!
 
     /// Parses details from a JSON dictionary, as returned by the WordPress.com REST API.
     public init(JSONDictionary json: NSDictionary) {

--- a/WordPressKit/RemoteReaderSite.swift
+++ b/WordPressKit/RemoteReaderSite.swift
@@ -2,12 +2,12 @@ import Foundation
 
 @objcMembers public class RemoteReaderSite: NSObject {
 
-    public var recordID: NSNumber?
-    public var siteID: NSNumber?
-    public var feedID: NSNumber?
-    public var name: String?
-    public var path: String? // URL
-    public var icon: String? // Sites only
+    public var recordID: NSNumber!
+    public var siteID: NSNumber!
+    public var feedID: NSNumber!
+    public var name: String!
+    public var path: String! // URL
+    public var icon: String! // Sites only
     public var isSubscribed: Bool = false
 
 }

--- a/WordPressKit/RemoteReaderSiteInfo.swift
+++ b/WordPressKit/RemoteReaderSiteInfo.swift
@@ -27,23 +27,23 @@ private let DeliveryMethodEmailKey = "email"
 private let DeliveryMethodNotificationKey = "notification"
 
 @objcMembers public class RemoteReaderSiteInfo: NSObject {
-    public var feedID: NSNumber?
-    public var feedURL: String?
+    public var feedID: NSNumber!
+    public var feedURL: String!
     public var isFollowing: Bool = false
     public var isJetpack: Bool = false
     public var isPrivate: Bool = false
     public var isVisible: Bool = false
-    public var organizationID: NSNumber?
-    public var postCount: NSNumber?
-    public var siteBlavatar: String?
-    public var siteDescription: String?
-    public var siteID: NSNumber?
-    public var siteName: String?
-    public var siteURL: String?
-    public var subscriberCount: NSNumber?
-    public var unseenCount: NSNumber?
-    public var postsEndpoint: String?
-    public var endpointPath: String?
+    public var organizationID: NSNumber!
+    public var postCount: NSNumber!
+    public var siteBlavatar: String!
+    public var siteDescription: String!
+    public var siteID: NSNumber!
+    public var siteName: String!
+    public var siteURL: String!
+    public var subscriberCount: NSNumber!
+    public var unseenCount: NSNumber!
+    public var postsEndpoint: String!
+    public var endpointPath: String!
 
     public var postSubscription: RemoteReaderSiteInfoSubscriptionPost?
     public var emailSubscription: RemoteReaderSiteInfoSubscriptionEmail?

--- a/WordPressKit/RemoteReaderTopic.swift
+++ b/WordPressKit/RemoteReaderTopic.swift
@@ -5,13 +5,13 @@ import Foundation
     public var isMenuItem: Bool = false
     public var isRecommended: Bool = false
     public var isSubscribed: Bool = false
-    public var path: String?
-    public var slug: String?
-    public var title: String?
-    public var topicDescription: String?
-    public var topicID: NSNumber?
-    public var type: String?
-    public var owner: String?
-    public var organizationID: NSNumber?
+    public var path: String!
+    public var slug: String!
+    public var title: String!
+    public var topicDescription: String!
+    public var topicID: NSNumber!
+    public var type: String!
+    public var owner: String!
+    public var organizationID: NSNumber!
 
 }


### PR DESCRIPTION
### Description

@jkmassel raised a concern regarding changing the `null_unspecified` Objective-C properties to `nullable`, that since we may need a while to finish the translation from Objective-C to Swift, the apps will need to make lots of code changes (potentially _repeatedly_) to adopt the new API if we release new versions of WordPressKit for minor fixes. We agreed to keep the model properties backwards compatible with the original API, and create a long running branch for the Objective-C to Swift translation work.

There are three related PRs that were merged into trunk: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/556, https://github.com/wordpress-mobile/WordPressKit-iOS/pull/557, and https://github.com/wordpress-mobile/WordPressKit-iOS/pull/558. They translated following models to Swift:
- [RemoteBlog.swift](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-20c2644fb9574e07807f765931c96bfe49e77436c83e0428d0c18332efaef611) from [RemoteBlog.h](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-091544062e6a35715dc08abc78965c6301459cd299f5182a5cf17543ebead22e)
- [RemoteMenu.swift](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-341b9394a233f3a169ccd6c6b5312d5e1d6fe5e6ea85353d6562b18130ec5dd9) from [RemoteMenu.h](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-d08e436f079388be3e87baa1d052acbe374facc2a868ef6202abec1fa9dc9f70)
- [RemoteMenuItem.swift](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-a5391712b8cd7887b344979d593738720a384a4584c1af527b99c9df0a15cb68) from [RemoteMenuItem.h](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-9d6fb608b23b406ee8fa8d88c21c03f01187149f08c4e2615d0c7c09ee0060d4)
- [RemoteMenuLocation.swift](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-69ed1d907a85fe1fa1685a61e33ed2ec9226c9c3355b52a214555672b9f58de4) from [RemoteMenuLocation.h](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-72359e3d5cfda2acceeec4d95e7e69455001636fe8db4ed5942448ccd17cf58e)
- [RemoteReaderSite.swift](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-020d78ae3b0f8f18e28ed050842e2024d6c82b9054b460e08aa6902b0a28116d) from [RemoteReaderSite.h](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-e3f0e3df7ed6feb9052306ce99091ab0bd8b4e57725cd683371d4485f815d6f0)
- [RemoteReaderSiteInfo.swift](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-77ddd0aaf840a4b64e6587f757f00f03dfee9abfb01597df1a4506f09829b70a) from [RemoteReaderSiteInfo.h](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-1f296f83c2f0fbed70f2f71389241ad0166017124bcb4a7cbb78eb6c8a0ba35e)
- [RemoteReaderTopic.swift](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-67cbee7549c7c9dd6e1a6895db25bca735c35945d25e91d50056c7a998d47477) from [RemoteReaderTopic.h](https://github.com/wordpress-mobile/WordPressKit-iOS/compare/5.0.0...1baed487b45bb5cbf7c041ebd21e9a0551272d14#diff-da3146f9b9fee5f2b07678c9f20fc8ad49a1bb58803afbec966def0387a68b46)

This PR reverts most of above model's properties back to Implicitly Unwrapped Optionals (as declared in their original Objective-C interface), except `RemoteMenu`, `RemoteMenuItem`, and `RemoteMenuLocation` since their original Objective-C interface declares their properties as all `nullable`.

### Testing Details

I think we are all good as long as CI jobs are green.

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
