### PR TITLE
Use proper Swift alternatives of Foundation types

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 		4A68E3ED2942A196004AC3DC /* NSObject+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E3EC2942A196004AC3DC /* NSObject+Debug.swift */; };
 		4A68E3F32942BDAC004AC3DC /* RemoteComment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E3F22942BDAC004AC3DC /* RemoteComment.swift */; };
 		4A68E3F52942BDB8004AC3DC /* RemoteMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E3F42942BDB8004AC3DC /* RemoteMedia.swift */; };
+		4A68E41529512482004AC3DC /* RemotePostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E41429512482004AC3DC /* RemotePostTests.swift */; };
+		4A68E41729512596004AC3DC /* post-edit-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4A68E41629512596004AC3DC /* post-edit-success.json */; };
 		57BCD3D426209D9500292CB3 /* AppTransportSecuritySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */; };
 		730E869F21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */; };
 		731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */; };
@@ -788,6 +790,8 @@
 		4A68E3EC2942A196004AC3DC /* NSObject+Debug.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSObject+Debug.swift"; sourceTree = "<group>"; };
 		4A68E3F22942BDAC004AC3DC /* RemoteComment.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteComment.swift; sourceTree = "<group>"; };
 		4A68E3F42942BDB8004AC3DC /* RemoteMedia.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteMedia.swift; sourceTree = "<group>"; };
+		4A68E41429512482004AC3DC /* RemotePostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemotePostTests.swift; sourceTree = "<group>"; };
+		4A68E41629512596004AC3DC /* post-edit-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "post-edit-success.json"; sourceTree = "<group>"; };
 		57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTransportSecuritySettings.swift; sourceTree = "<group>"; };
 		6C2A33D76FD1052D6F30466D /* Pods-WordPressKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.debug.xcconfig"; sourceTree = "<group>"; };
 		6F2E0CC4FA01B5475A378DA2 /* Pods-WordPressKitTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -1474,6 +1478,7 @@
 				AB49D09225D1A85D0084905B /* PostServiceRemoteRESTLikesTests.swift */,
 				740B23D01F17F6BB00067A2A /* PostServiceRemoteRESTTests.m */,
 				740B23D11F17F6BB00067A2A /* PostServiceRemoteXMLRPCTests.swift */,
+				4A68E41429512482004AC3DC /* RemotePostTests.swift */,
 			);
 			name = Post;
 			sourceTree = "<group>";
@@ -2110,6 +2115,7 @@
 				BA4BFC572498C04D005C83E7 /* plugin-update-jetpack-already-updated.json */,
 				BA8EA71C24A07CA600D5CC9F /* plugin-update-response-malformed.json */,
 				32A29A1E236BE4CC009488C2 /* post-autosave-mapping-success.json */,
+				4A68E41629512596004AC3DC /* post-edit-success.json */,
 				AB49D0B225D1B4D80084905B /* post-likes-failure.json */,
 				AB49D09625D1AC0A0084905B /* post-likes-success.json */,
 				9AB6D64C218730130008F274 /* post-revisions-failure.json */,
@@ -2898,6 +2904,7 @@
 				74D67F361F15C3740010C5ED /* site-users-delete-site-owner-failure.json in Resources */,
 				BA3F139424A0B783006367A3 /* plugin-modify-malformed-response.json in Resources */,
 				74C473CB1EF33696009918F2 /* site-active-purchases-auth-failure.json in Resources */,
+				4A68E41729512596004AC3DC /* post-edit-success.json in Resources */,
 				FFE247B520C891E6002DF3A2 /* WordPressComAuthenticateWithIDTokenExistingUserNeedsConnection.json in Resources */,
 				BA8EA71B24A07B2200D5CC9F /* plugin-service-remote-auth-failure.json in Resources */,
 				FA79F1872591730D00D235A9 /* backup-get-backup-status-complete-success.json in Resources */,
@@ -3245,6 +3252,7 @@
 				9F3E0BAC20873785009CB5BA /* ServiceRequestTest.swift in Sources */,
 				4624223E2548C26D002B8A12 /* SiteDesignServiceRemoteTests.swift in Sources */,
 				4A1DEF44293051BC00322608 /* LoggingTests.swift in Sources */,
+				4A68E41529512482004AC3DC /* RemotePostTests.swift in Sources */,
 				740B23D31F17F6BB00067A2A /* PostServiceRemoteXMLRPCTests.swift in Sources */,
 				93188D221F2264E60028ED4D /* TaxonomyServiceRemoteRESTTests.m in Sources */,
 				F194E1232417ED9F00874408 /* AtomicAuthenticationServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/RemoteMedia.swift
+++ b/WordPressKit/RemoteMedia.swift
@@ -20,7 +20,7 @@ import Foundation
     public var height: NSNumber?
     public var width: NSNumber?
     public var shortcode: String?
-    public var exif: NSDictionary?
+    public var exif: [String: Any]?
     public var videopressGUID: String?
     public var length: NSNumber?
     public var remoteThumbnailURL: String?

--- a/WordPressKit/RemotePost.swift
+++ b/WordPressKit/RemotePost.swift
@@ -19,11 +19,11 @@ import ObjectiveC
     public var authorEmail: String?
     public var authorURL: String?
     public var authorID: NSNumber?
-    public var date: NSDate?
-    public var dateModified: NSDate?
+    public var date: Date?
+    public var dateModified: Date?
     public var title: String?
-    public var URL: NSURL?
-    public var shortURL: NSURL?
+    public var URL: URL?
+    public var shortURL: URL?
     public var content: String?
     public var excerpt: String?
     public var slug: String?
@@ -46,9 +46,9 @@ import ObjectiveC
     public var commentCount: NSNumber?
     public var likeCount: NSNumber?
 
-    public var categories: NSArray?
-    public var revisions: NSArray?
-    public var tags: NSArray?
+    public var categories: [RemotePostCategory]?
+    public var revisions: [NSNumber]?
+    public var tags: [String]?
     public var pathForDisplayImage: String?
     public var isStickyPost: NSNumber?
     public var isFeaturedImageChanged: Bool = false

--- a/WordPressKitTests/Mock Data/post-edit-success.json
+++ b/WordPressKitTests/Mock Data/post-edit-success.json
@@ -1,0 +1,161 @@
+{
+  "ID": 9,
+  "site_ID": 123,
+  "author": {
+    "ID": 455,
+    "login": "author",
+    "email": "author@email.com",
+    "name": "author",
+    "first_name": "",
+    "last_name": "",
+    "nice_name": "author",
+    "URL": "http:\/\/wordpresskittest.wordpress.com",
+    "avatar_URL": "https:\/\/0.gravatar.com\/avatar\/1?s=96&d=identicon&r=G",
+    "profile_URL": "https:\/\/en.gravatar.com\/author",
+    "site_ID": 123
+  },
+  "date": "2022-12-11T21:37:26+13:00",
+  "modified": "2022-12-20T12:00:42+13:00",
+  "title": "Draft",
+  "URL": "https:\/\/wordpresskittest.wordpress.com\/2022\/12\/11\/draft\/",
+  "short_URL": "https:\/\/wp.me\/123-draft",
+  "content": "Edited",
+  "excerpt": "",
+  "slug": "draft",
+  "guid": "https:\/\/wordpresskittest.wordpress.com\/?p=9",
+  "status": "publish",
+  "sticky": false,
+  "password": "",
+  "parent": false,
+  "type": "post",
+  "discussion": {
+    "comments_open": true,
+    "comment_status": "open",
+    "pings_open": true,
+    "ping_status": "open",
+    "comment_count": 4
+  },
+  "likes_enabled": true,
+  "sharing_enabled": true,
+  "like_count": 0,
+  "i_like": false,
+  "is_reblogged": false,
+  "is_following": true,
+  "global_ID": "61971ad",
+  "featured_image": "",
+  "post_thumbnail": null,
+  "format": "standard",
+  "geo": false,
+  "menu_order": 0,
+  "page_template": "",
+  "publicize_URLs": [],
+  "terms": {
+    "category": {
+      "Uncategorized": {
+        "ID": 1,
+        "name": "Uncategorized",
+        "slug": "uncategorized",
+        "description": "",
+        "post_count": 1,
+        "parent": 0,
+        "meta": {
+          "links": {
+            "self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/123\/categories\/slug:uncategorized",
+            "help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123\/categories\/slug:uncategorized\/help",
+            "site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123"
+          }
+        }
+      }
+    },
+    "post_tag": {
+      "random-tag": {
+        "ID": 67890,
+        "name": "random-tag",
+        "slug": "random-tag",
+        "description": "",
+        "post_count": 1,
+        "meta": {
+          "links": {
+            "self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/123\/tags\/slug:random-tag",
+            "help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123\/tags\/slug:random-tag\/help",
+            "site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123"
+          }
+        }
+      }
+    },
+    "post_format": {},
+    "mentions": {}
+  },
+  "tags": {
+    "random-tag": {
+      "ID": 67890,
+      "name": "random-tag",
+      "slug": "random-tag",
+      "description": "",
+      "post_count": 1,
+      "meta": {
+        "links": {
+          "self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/123\/tags\/slug:random-tag",
+          "help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123\/tags\/slug:random-tag\/help",
+          "site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123"
+        }
+      }
+    }
+  },
+  "categories": {
+    "Uncategorized": {
+      "ID": 1,
+      "name": "Uncategorized",
+      "slug": "uncategorized",
+      "description": "",
+      "post_count": 1,
+      "parent": 0,
+      "meta": {
+        "links": {
+          "self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/123\/categories\/slug:uncategorized",
+          "help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123\/categories\/slug:uncategorized\/help",
+          "site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123"
+        }
+      }
+    }
+  },
+  "attachments": {},
+  "attachment_count": 0,
+  "metadata": [
+    {
+      "id": "120",
+      "key": "jabber_published",
+      "value": "48"
+    },
+    {
+      "id": "129",
+      "key": "timeline_notification",
+      "value": "52"
+    },
+    {
+      "id": "131",
+      "key": "wordads_ufa",
+      "value": "s:wpcom-ufa-v3-beta:11"
+    }
+  ],
+  "meta": {
+    "links": {
+      "self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/123\/posts\/9",
+      "help": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123\/posts\/9\/help",
+      "site": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123",
+      "replies": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/123\/posts\/9\/replies\/",
+      "likes": "https:\/\/public-api.wordpress.com\/rest\/v1.2\/sites\/123\/posts\/9\/likes\/"
+    }
+  },
+  "capabilities": {
+    "publish_post": true,
+    "delete_post": true,
+    "edit_post": true
+  },
+  "revisions": [
+    61,
+    60,
+    57
+  ],
+  "other_URLs": {}
+}

--- a/WordPressKitTests/RemotePostTests.swift
+++ b/WordPressKitTests/RemotePostTests.swift
@@ -6,6 +6,7 @@ class RemotePostTests: RemoteTestCase, RESTTestable {
     private var remote: PostServiceRemoteREST!
 
     override func setUp() {
+        super.setUp()
         remote = PostServiceRemoteREST(wordPressComRestApi: getRestApi(), siteID: 123)
     }
 

--- a/WordPressKitTests/RemotePostTests.swift
+++ b/WordPressKitTests/RemotePostTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+import WordPressKit
+
+class RemotePostTests: RemoteTestCase, RESTTestable {
+
+    private var remote: PostServiceRemoteREST!
+
+    override func setUp() {
+        remote = PostServiceRemoteREST(wordPressComRestApi: getRestApi(), siteID: 123)
+    }
+
+    func testEditPost() {
+        stubRemoteResponse("sites/123/posts/9", filename: "post-edit-success.json", contentType: .ApplicationJSON)
+        let apiResponseRecived = expectation(description: "Receive API response")
+        let post = RemotePost(siteID: 123, status: RemotePost.statusPublish, title: "Draft", content: "Edited")
+        post.postID = 9
+        remote.update(post) { post in
+            XCTAssertNotNil(post)
+            XCTAssertEqual(post?.revisions, [61, 60, 57])
+            XCTAssertEqual(post?.categories?.first?.name, "Uncategorized")
+            XCTAssertEqual(post?.tags, ["random-tag"])
+            apiResponseRecived.fulfill()
+        } failure: { error in
+            apiResponseRecived.fulfill()
+            XCTFail("error: \(String(describing: error))")
+        }
+        wait(for: [apiResponseRecived], timeout: 1)
+    }
+    
+}

--- a/WordPressKitTests/RemotePostTests.swift
+++ b/WordPressKitTests/RemotePostTests.swift
@@ -26,5 +26,5 @@ class RemotePostTests: RemoteTestCase, RESTTestable {
         }
         wait(for: [apiResponseRecived], timeout: 1)
     }
-    
+
 }


### PR DESCRIPTION
### Description

This PR corrects a few properties that were declared as Foundation classes and collections in my previous PRs.

### Testing Details

Green CI jobs should be suffient. No extra test required.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
