### PR TITLE
Fix a couple or backward compatibility issus missed in #562

### DIFF
--- a/WordPressKit/RemoteBlog.swift
+++ b/WordPressKit/RemoteBlog.swift
@@ -47,7 +47,7 @@ import NSObject_SafeExpectations
     public var options: NSDictionary!
 
     /// Blog's capabilities: Indicate which actions are allowed / not allowed, for the current user.
-    public var capabilities: NSDictionary!
+    public var capabilities: [String: Bool]!
 
     /// Blog's total disk quota space.
     public var quotaSpaceAllowed: NSNumber!
@@ -56,7 +56,8 @@ import NSObject_SafeExpectations
     public var quotaSpaceUsed: NSNumber!
 
     /// Parses details from a JSON dictionary, as returned by the WordPress.com REST API.
-    public init(JSONDictionary json: NSDictionary) {
+    @objc(initWithJSONDictionary:)
+    public init(jsonDictionary json: NSDictionary) {
         self.blogID = json.number(forKey: "ID")
         self.organizationID = json.number(forKey: "organization_id")
         self.name = json.string(forKey: "name")
@@ -65,7 +66,7 @@ import NSObject_SafeExpectations
         self.xmlrpc = json.string(forKeyPath: "meta.links.xmlrpc")
         self.jetpack = json.number(forKey: "jetpack")?.boolValue ?? false
         self.icon = json.string(forKeyPath: "icon.img")
-        self.capabilities = json.object(forKey: "capabilities") as? NSDictionary
+        self.capabilities = json.object(forKey: "capabilities") as? [String: Bool]
         self.isAdmin = json.number(forKeyPath: "capabilities.manage_options")?.boolValue ?? false
         self.visible = json.number(forKey: "visible")?.boolValue ?? false
         self.options = RemoteBlogOptionsHelper.mapOptions(fromResponse: json)


### PR DESCRIPTION
### Description

I missed a couple places that introduced breaking API changes in #562. 

I've integrated this change into WPiOS and verified there is no unintentional breaking changes (other than [this one](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/562#discussion_r1049153503)).

### Testing Details

As long as CI jobs are green.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
