### PR TITLE
Add twoStepEnabled property to AccountSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add `twoStepEnabled` property to `AccountSettings` model. [#567]
 
 ### Bug Fixes
 

--- a/WordPressKit/AccountSettings.swift
+++ b/WordPressKit/AccountSettings.swift
@@ -18,6 +18,7 @@ public struct AccountSettings {
     public let language: String    // language
     public let tracksOptOut: Bool
     public let blockEmailNotifications: Bool
+    public let twoStepEnabled: Bool // two_step_enabled
 
     public init(firstName: String,
                 lastName: String,
@@ -32,7 +33,8 @@ public struct AccountSettings {
                 webAddress: String,
                 language: String,
                 tracksOptOut: Bool,
-                blockEmailNotifications: Bool) {
+                blockEmailNotifications: Bool,
+                twoStepEnabled: Bool) {
         self.firstName = firstName
         self.lastName = lastName
         self.displayName = displayName
@@ -47,6 +49,7 @@ public struct AccountSettings {
         self.language = language
         self.tracksOptOut = tracksOptOut
         self.blockEmailNotifications = blockEmailNotifications
+        self.twoStepEnabled = twoStepEnabled
     }
 }
 

--- a/WordPressKit/AccountSettingsRemote.swift
+++ b/WordPressKit/AccountSettingsRemote.swift
@@ -157,8 +157,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
     }
 
     private func settingsFromResponse(_ responseObject: AnyObject) throws -> AccountSettings {
-        guard let
-            response = responseObject as? [String: AnyObject],
+        guard let response = responseObject as? [String: AnyObject],
             let firstName = response["first_name"] as? String,
             let lastName = response["last_name"] as? String,
             let displayName = response["display_name"] as? String,
@@ -172,10 +171,12 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
             let webAddress = response["user_URL"] as? String,
             let language = response["language"] as? String,
             let tracksOptOut = response["tracks_opt_out"] as? Bool,
-            let blockEmailNotifications = response["subscription_delivery_email_blocked"] as? Bool else {
-                WPKitLogError("Error decoding me/settings response: \(responseObject)")
-                throw ResponseError.decodingFailure
-            }
+            let blockEmailNotifications = response["subscription_delivery_email_blocked"] as? Bool
+        else {
+            WPKitLogError("Error decoding me/settings response: \(responseObject)")
+            throw ResponseError.decodingFailure
+        }
+        let twoStepEnabled = response["two_step_enabled"] as? Bool ?? false
 
         let aboutMeText = aboutMe.decodingXMLCharacters()
 
@@ -192,7 +193,8 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
                                webAddress: webAddress,
                                language: language,
                                tracksOptOut: tracksOptOut,
-                               blockEmailNotifications: blockEmailNotifications)
+                               blockEmailNotifications: blockEmailNotifications,
+                               twoStepEnabled: twoStepEnabled)
     }
 
     private func fieldNameForChange(_ change: AccountSettingsChange) -> String {

--- a/WordPressKit/AccountSettingsRemote.swift
+++ b/WordPressKit/AccountSettingsRemote.swift
@@ -171,12 +171,12 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
             let webAddress = response["user_URL"] as? String,
             let language = response["language"] as? String,
             let tracksOptOut = response["tracks_opt_out"] as? Bool,
-            let blockEmailNotifications = response["subscription_delivery_email_blocked"] as? Bool
+            let blockEmailNotifications = response["subscription_delivery_email_blocked"] as? Bool,
+            let twoStepEnabled = response["two_step_enabled"] as? Bool
         else {
             WPKitLogError("Error decoding me/settings response: \(responseObject)")
             throw ResponseError.decodingFailure
         }
-        let twoStepEnabled = response["two_step_enabled"] as? Bool ?? false
 
         let aboutMeText = aboutMe.decodingXMLCharacters()
 


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/19567

### Related PR
- https://github.com/wordpress-mobile/WordPress-iOS/pull/19807

### Description

This PR stores the `twoStepEnabled` boolean received from the Backend in `AccountSettings` model. The Jetpack app uses that property to decide whether to show `Scan QR Code` row in `Me` screen or not.

### Testing Details

See [Related PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19807) Test Instructions.

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
