### PR TITLE
Use Xcode 14.2 on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,7 @@ common_params:
   - automattic/bash-cache#2.12.0
   # Common environment values to use with the `env` key.
   env: &common_env
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14.2
 
 # This is the default pipeline – it will build and test the app
 steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ _None._
 ### Internal Changes
 
 - Change the NSObject+SafeExpectations dependency to `~> 0.0.4`. [#555]
+- Use Xcode 14.2 on CI. [#568]
 
 ## [5.0.0](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/5.0.0)
 

--- a/WordPressKitTests/WordPressAPI/WordPressOrgXMLRPCValidatorTests.swift
+++ b/WordPressKitTests/WordPressAPI/WordPressOrgXMLRPCValidatorTests.swift
@@ -39,7 +39,12 @@ final class WordPressOrgXMLRPCValidatorTests: XCTestCase {
         wait(for: [expectation], timeout: 2.0)
 
         // Then
-        XCTAssertEqual(schemes, Set(arrayLiteral: "https"))
+        if #available(iOS 16.0, *) {
+            // 'NSAllowsArbitraryLoads' is true on iOS 16.
+            XCTAssertEqual(schemes, ["https", "http"])
+        } else {
+            XCTAssertEqual(schemes, ["https"])
+        }
     }
 
     func testItWillGuessXMLRPCOnBothHTTPAndHTTPSIfUnsecuredConnectionsAreAllowed() {


### PR DESCRIPTION
### Description

What says in the title.

### Testing Details

A green tick from CI should be sufficient.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
