### PR TITLE
Replace IUOs with appropriate optionality declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _None._
 ### Breaking Changes
 
 - Re-implement a few reader model types in Swift. [#556, #557, #558]
+- Implicityly Unwrapped Optionals in some model types are removed. [#569]
 
 ### New Features
 

--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -8,15 +8,7 @@ static NSString * const TopicMenuSectionSubscribedKey = @"subscribed";
 static NSString * const TopicMenuSectionRecommendedKey = @"recommended";
 static NSString * const TopicRemovedTagKey = @"removed_tag";
 static NSString * const TopicAddedTagKey = @"added_tag";
-static NSString * const TopicDictionaryIDKey = @"ID";
-static NSString * const TopicDictionaryOrganizationIDKey = @"organization_id";
-static NSString * const TopicDictionaryOwnerKey = @"owner";
-static NSString * const TopicDictionarySlugKey = @"slug";
 static NSString * const TopicDictionaryTagKey = @"tag";
-static NSString * const TopicDictionaryTitleKey = @"title";
-static NSString * const TopicDictionaryTypeKey = @"type";
-static NSString * const TopicDictionaryDisplayNameKey = @"display_name";
-static NSString * const TopicDictionaryURLKey = @"URL";
 static NSString * const TopicNotFoundMarker = @"-notfound-";
 
 @implementation ReaderTopicServiceRemote
@@ -303,39 +295,8 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 
 - (RemoteReaderTopic *)normalizeMenuTopicDictionary:(NSDictionary *)topicDict subscribed:(BOOL)subscribed recommended:(BOOL)recommended
 {
-    RemoteReaderTopic *topic = [self normalizeTopicDictionary:topicDict subscribed:subscribed recommended:recommended];
+    RemoteReaderTopic *topic = [[RemoteReaderTopic alloc] initWithDictionary:topicDict subscribed:subscribed recommended:recommended];
     topic.isMenuItem = YES;
-    return topic;
-}
-
-/**
- Normalizes the supplied topics dictionary, ensuring expected keys are always present.
-
- @param topicDict The topic `NSDictionary` to normalize.
- @param subscribed Whether the current account subscribes to the topic.
- @param recommended Whether the topic is recommended.
- @return A RemoteReaderTopic instance.
- */
-- (RemoteReaderTopic *)normalizeTopicDictionary:(NSDictionary *)topicDict
-                                     subscribed:(BOOL)subscribed
-                                    recommended:(BOOL)recommended
-{
-    NSNumber *topicID = [topicDict numberForKey:TopicDictionaryIDKey];
-    if (topicID == nil) {
-        topicID = @0;
-    }
-
-    RemoteReaderTopic *topic = [[RemoteReaderTopic alloc] init];
-    topic.topicID = topicID;
-    topic.isSubscribed = subscribed;
-    topic.isRecommended = recommended;
-    topic.owner = [topicDict stringForKey:TopicDictionaryOwnerKey];
-    topic.path = [[topicDict stringForKey:TopicDictionaryURLKey] lowercaseString];
-    topic.slug = [topicDict stringForKey:TopicDictionarySlugKey];
-    topic.title = [topicDict stringForKey:TopicDictionaryDisplayNameKey] ?: [topicDict stringForKey:TopicDictionaryTitleKey];
-    topic.type = [topicDict stringForKey:TopicDictionaryTypeKey];
-    topic.organizationID = [topicDict numberForKeyPath:TopicDictionaryOrganizationIDKey] ?: @0;
-
     return topic;
 }
 

--- a/WordPressKit/RemoteBlog.swift
+++ b/WordPressKit/RemoteBlog.swift
@@ -5,31 +5,31 @@ import NSObject_SafeExpectations
 @objcMembers public class RemoteBlog: NSObject {
 
     /// The ID of the Blog entity.
-    public var blogID: NSNumber!
+    public var blogID: NSNumber
 
     /// The organization ID of the Blog entity.
-    public var organizationID: NSNumber!
+    public var organizationID: NSNumber
 
     /// Represents the Blog Name.
-    public var name: String!
+    public var name: String
 
     /// Description of the WordPress Blog.
-    public var tagline: String!
+    public var tagline: String?
 
     /// Represents the Blog Name.
-    public var url: String!
+    public var url: String
 
     /// Maps to the XMLRPC endpoint.
-    public var xmlrpc: String!
+    public var xmlrpc: String?
 
     /// Site Icon's URL.
-    public var icon: String!
+    public var icon: String?
 
     /// Product ID of the site's current plan, if it has one.
-    public var planID: NSNumber!
+    public var planID: NSNumber?
 
     /// Product name of the site's current plan, if it has one.
-    public var planTitle: String!
+    public var planTitle: String?
 
     /// Indicates whether the current's blog plan is paid, or not.
     public var hasPaidPlan: Bool = false
@@ -44,29 +44,29 @@ import NSObject_SafeExpectations
     public var visible: Bool = false
 
     /// Blog's options preferences.
-    public var options: NSDictionary!
+    public var options: NSDictionary
 
     /// Blog's capabilities: Indicate which actions are allowed / not allowed, for the current user.
-    public var capabilities: [String: Bool]!
+    public var capabilities: [String: Bool]
 
     /// Blog's total disk quota space.
-    public var quotaSpaceAllowed: NSNumber!
+    public var quotaSpaceAllowed: NSNumber?
 
     /// Blog's total disk quota space used.
-    public var quotaSpaceUsed: NSNumber!
+    public var quotaSpaceUsed: NSNumber?
 
     /// Parses details from a JSON dictionary, as returned by the WordPress.com REST API.
     @objc(initWithJSONDictionary:)
     public init(jsonDictionary json: NSDictionary) {
-        self.blogID = json.number(forKey: "ID")
-        self.organizationID = json.number(forKey: "organization_id")
-        self.name = json.string(forKey: "name")
+        self.blogID = json.number(forKey: "ID") ?? 0
+        self.organizationID = json.number(forKey: "organization_id") ?? 0
+        self.name = json.string(forKey: "name") ?? ""
         self.tagline = json.string(forKey: "description")
-        self.url = json.string(forKey: "URL")
+        self.url = json.string(forKey: "URL") ?? ""
         self.xmlrpc = json.string(forKeyPath: "meta.links.xmlrpc")
         self.jetpack = json.number(forKey: "jetpack")?.boolValue ?? false
         self.icon = json.string(forKeyPath: "icon.img")
-        self.capabilities = json.object(forKey: "capabilities") as? [String: Bool]
+        self.capabilities = json.object(forKey: "capabilities") as? [String: Bool] ?? [:]
         self.isAdmin = json.number(forKeyPath: "capabilities.manage_options")?.boolValue ?? false
         self.visible = json.number(forKey: "visible")?.boolValue ?? false
         self.options = RemoteBlogOptionsHelper.mapOptions(fromResponse: json)

--- a/WordPressKit/RemoteReaderSiteInfo.swift
+++ b/WordPressKit/RemoteReaderSiteInfo.swift
@@ -27,23 +27,23 @@ private let DeliveryMethodEmailKey = "email"
 private let DeliveryMethodNotificationKey = "notification"
 
 @objcMembers public class RemoteReaderSiteInfo: NSObject {
-    public var feedID: NSNumber!
-    public var feedURL: String!
+    public var feedID: NSNumber?
+    public var feedURL: String?
     public var isFollowing: Bool = false
     public var isJetpack: Bool = false
     public var isPrivate: Bool = false
     public var isVisible: Bool = false
-    public var organizationID: NSNumber!
-    public var postCount: NSNumber!
-    public var siteBlavatar: String!
-    public var siteDescription: String!
-    public var siteID: NSNumber!
-    public var siteName: String!
-    public var siteURL: String!
-    public var subscriberCount: NSNumber!
-    public var unseenCount: NSNumber!
-    public var postsEndpoint: String!
-    public var endpointPath: String!
+    public var organizationID: NSNumber?
+    public var postCount: NSNumber?
+    public var siteBlavatar: String?
+    public var siteDescription: String?
+    public var siteID: NSNumber?
+    public var siteName: String?
+    public var siteURL: String?
+    public var subscriberCount: NSNumber?
+    public var unseenCount: NSNumber?
+    public var postsEndpoint: String?
+    public var endpointPath: String?
 
     public var postSubscription: RemoteReaderSiteInfoSubscriptionPost?
     public var emailSubscription: RemoteReaderSiteInfoSubscriptionEmail?

--- a/WordPressKit/RemoteReaderTopic.swift
+++ b/WordPressKit/RemoteReaderTopic.swift
@@ -3,15 +3,41 @@ import Foundation
 @objcMembers public class RemoteReaderTopic: NSObject {
 
     public var isMenuItem: Bool = false
-    public var isRecommended: Bool = false
-    public var isSubscribed: Bool = false
-    public var path: String!
-    public var slug: String!
-    public var title: String!
-    public var topicDescription: String!
-    public var topicID: NSNumber!
-    public var type: String!
-    public var owner: String!
-    public var organizationID: NSNumber!
+    public var isRecommended: Bool
+    public var isSubscribed: Bool
+    public var path: String?
+    public var slug: String?
+    public var title: String?
+    public var topicDescription: String?
+    public var topicID: NSNumber
+    public var type: String?
+    public var owner: String?
+    public var organizationID: NSNumber
 
+    /// Create `RemoteReaderTopic` with the supplied topics dictionary, ensuring expected keys are always present.
+    ///
+    /// - Parameters:
+    ///   - topicDict: The topic `NSDictionary` to normalize.
+    ///   - subscribed: Whether the current account subscribes to the topic.
+    ///   - recommended: Whether the topic is recommended.
+    public init(dictionary topicDict: NSDictionary, subscribed: Bool, recommended: Bool) {
+        topicID = topicDict.number(forKey: topicDictionaryIDKey) ?? 0
+        owner = topicDict.string(forKey: topicDictionaryOwnerKey)
+        path = topicDict.string(forKey: topicDictionaryURLKey)?.lowercased()
+        slug = topicDict.string(forKey: topicDictionarySlugKey)
+        title = topicDict.string(forKey: topicDictionaryDisplayNameKey) ?? topicDict.string(forKey: topicDictionaryTitleKey)
+        type = topicDict.string(forKey: topicDictionaryTypeKey)
+        organizationID = topicDict.number(forKeyPath: topicDictionaryOrganizationIDKey) ?? 0
+        isSubscribed = subscribed
+        isRecommended = recommended
+    }
 }
+
+private let topicDictionaryIDKey = "ID"
+private let topicDictionaryOrganizationIDKey = "organization_id"
+private let topicDictionaryOwnerKey = "owner"
+private let topicDictionarySlugKey = "slug"
+private let topicDictionaryTitleKey = "title"
+private let topicDictionaryTypeKey = "type"
+private let topicDictionaryDisplayNameKey = "display_name"
+private let topicDictionaryURLKey = "URL"

--- a/WordPressKitTests/ReaderTopicServiceRemoteTests.m
+++ b/WordPressKitTests/ReaderTopicServiceRemoteTests.m
@@ -3,10 +3,6 @@
 #import "ReaderTopicServiceRemote.h"
 #import "WPKit-Swift.h"
 
-@interface ReaderTopicServiceRemote()
-- (RemoteReaderTopic *)normalizeTopicDictionary:(NSDictionary *)topicDict subscribed:(BOOL)subscribed recommended:(BOOL)recommended;
-@end
-
 @interface ReaderTopicServiceRemoteTests : XCTestCase
 @end
 
@@ -56,19 +52,19 @@
     ReaderTopicServiceRemote *remoteService = nil;
     XCTAssertNoThrow(remoteService = [self service]);
 
-    RemoteReaderTopic *remoteTopic = [remoteService normalizeTopicDictionary:topicDictionaryWithID subscribed:YES recommended:YES];
+    RemoteReaderTopic *remoteTopic = [[RemoteReaderTopic alloc] initWithDictionary:topicDictionaryWithID subscribed:YES recommended:YES];
     XCTAssertTrue(remoteTopic.isRecommended, @"Remote topic should be recommended but wasn't.");
     XCTAssertTrue(remoteTopic.isSubscribed, @"Remote topic should be subscribed but wasn't.");
     XCTAssertTrue([remoteTopic.path isEqualToString:topicDictionaryWithID[@"URL"]], @"Remote topic path did not match.");
     XCTAssertEqual(remoteTopic.title, topicDictionaryWithID[@"display_name"], @"Remote topic should prefer display_name over title.");
     XCTAssertEqual([remoteTopic.topicID integerValue], [topicDictionaryWithID[@"ID"] integerValue], @"Remote topic ID did not match.");
 
-    remoteTopic = [remoteService normalizeTopicDictionary:topicDictionaryWithoutID subscribed:NO recommended:NO];
+    remoteTopic = [[RemoteReaderTopic alloc] initWithDictionary:topicDictionaryWithoutID subscribed:NO recommended:NO];
     XCTAssertFalse(remoteTopic.isRecommended, @"Remote topic should not be recommended but was.");
     XCTAssertFalse(remoteTopic.isSubscribed, @"Remote topic should not be subscribed but was.");
     XCTAssertTrue([remoteTopic.path isEqualToString:topicDictionaryWithID[@"URL"]], @"Remote topic path did not match.");
     XCTAssertEqual(remoteTopic.title, topicDictionaryWithID[@"title"], @"Remote topic title did not match.");
-    XCTAssertEqual(remoteTopic.topicID, @0, @"Remote topic ID was not 0.");
+    XCTAssertEqual(remoteTopic.topicID.intValue, 0, @"Remote topic ID was not 0.");
 }
 
 @end


### PR DESCRIPTION
### Description

When translating some Objective-C models to Swift, their properties were declared as Implicitly Unwrapped Optionals, to keep the library backwards compatible. This PR changes those IUO declarations to Optional or non-Optional types. I've used corresponding Core Data model types in WordPress repo as references to decide whether to declare the properties as Optional or not.

### Testing Details

CI jobs in this PR and [this WordPress PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19908) should be sufficient.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
