### PR TITLE
Bump version to 6.0.0-beta.2

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '6.0.0-beta.1'
+  s.version       = '6.0.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

What says in the title. See [here](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/47054559e948fdaf4a90de15633d1b624d55c39b/CHANGELOG.md#unreleased) for all the changes.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
