### PR TITLE
Add jetpack_connection_active_plugins to RemoteBlog options

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '6.0.0-beta.2'
+  s.version       = '6.0.0-beta.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/RemoteBlogOptionsHelper.swift
+++ b/WordPressKit/RemoteBlogOptionsHelper.swift
@@ -32,7 +32,8 @@ import Foundation
                 "show_on_front",
                 "page_on_front",
                 "page_for_posts",
-                "blogging_prompts_settings"
+                "blogging_prompts_settings",
+                "jetpack_connection_active_plugins"
             ]
             for key in optionsDirectMapKeys {
                 if let value = response.value(forKeyPath: "options.\(key)") {


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/20015

### Description

This adds a new key, `jetpack_connection_active_plugins`, to be parsed in `RemoteBlogOptionsHelper`.  The value of this options key contains pretty accurate information about what Jetpack plugins are active in the users' Jetpack-connected self-hosted site.

### Testing Details

Refer to the WordPress-iOS PR counterpart here: https://github.com/wordpress-mobile/WordPress-iOS/pull/20031

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
