### PR TITLE
Bump version from 6.0.0-beta.3 to 6.0.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,24 @@ _None._
 
 ### Breaking Changes
 
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## [6.0.0](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/6.0.0)
+
+### Breaking Changes
+
 - Re-implement a few reader model types in Swift. [#556, #557, #558]
 - Implicityly Unwrapped Optionals in some model types are removed. [#569]
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '6.0.0-beta.3'
+  s.version       = '6.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
Same rationale as https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/336, with the difference that:

- This aims to close the loop, in a sense, on shipping betas for WordPressKit-iOS.
- I'll admin merge this PR, given we already agreed that it's okay to do out-of-cycle releases in special occasions such as this one