### PR TITLE
Merge version 6.1.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ _None._
 
 _None._
 
+## 6.1.0
+
+### New Features
+
+- Add remote to make requests to self-hosted, Jetpack-connected sites via the Jetpack Proxy API [#576]
+- Add Blaze status endpoint [#577]
+
+### Bug Fixes
+
+- Fixes regression in logic to decode whether user has a free plan from JSON [#578]
+
 ## 6.0.0
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format of this document is inspired by [Keep a Changelog](https://keepachang
 When releasing a new version:
 
 1. Remove any empty section (those with `_None._`)
-2. Update the `## Unreleased` header to `## [<version_number>](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/<version_number>)`
+2. Update the `## Unreleased` header to `## <version_number>`
 3. Add a new "Unreleased" section for the next iteration, by copy/pasting the following template:
 
 ## Unreleased
@@ -48,7 +48,7 @@ _None._
 
 _None._
 
-## [6.0.0](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/6.0.0)
+## 6.0.0
 
 ### Breaking Changes
 
@@ -65,10 +65,10 @@ _None._
 
 ### Internal Changes
 
-- Change the NSObject+SafeExpectations dependency to `~> 0.0.4`. [#555]
+- Change the `NSObject+SafeExpectations` dependency to `~> 0.0.4`. [#555]
 - Use Xcode 14.2 on CI. [#568]
 
-## [5.0.0](https://github.com/wordpress-mobile/WordPressKit-iOS/releases/tag/5.0.0)
+## 5.0.0
 
 ### Breaking Changes
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '6.1.0-beta.3'
+  s.version       = '6.1.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION

This version bump PR is part of the code freeze workflow for WordPress iOS 21.8 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.