### PR TITLE
Update feature flag platform name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Changes the feature flag platform identifier to `ios`
 
 ### Internal Changes
 
@@ -58,7 +58,6 @@ _None._
 ### Bug Fixes
 
 - Fixes regression in logic to decode whether user has a free plan from JSON [#578]
-- Changes the feature flag platform identifier to `ios`
 
 ## 6.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ _None._
 ### Bug Fixes
 
 - Fixes regression in logic to decode whether user has a free plan from JSON [#578]
+- Changes the feature flag platform identifier to `ios`
 
 ## 6.0.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '6.1.0'
+  s.version       = '6.2.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '6.2.0-beta.1'
+  s.version       = '6.1.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -15,7 +15,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
 
         let parameters: [String: AnyObject] = [
             "device_id": deviceId as NSString,
-            "platform": "apple" as NSString,
+            "platform": "ios" as NSString,
             "build_number": NSString(string: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"),
             "marketing_version": NSString(string: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"),
             "identifier": NSString(string: Bundle.main.bundleIdentifier ?? "Unknown")


### PR DESCRIPTION
### Description

Addresses https://github.com/wordpress-mobile/WordPress-iOS/issues/20222

The feature flag name should be `ios` as mentioned in the above issue. On Android we're using the OS name `android`, so on iOS we should use `ios`..

### Testing Details

See https://github.com/wordpress-mobile/WordPress-iOS/pull/20238

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
