### PR TITLE
[Domain Purchasing] Add ability to fetch free and paid domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add ability to fetch free and paid domains. [#585]
 
 ### Bug Fixes
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '6.2.0'
+  s.version       = '6.3.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -26,12 +26,22 @@ public struct DomainSuggestion: Codable {
     public let cost: Double?
     public let saleCost: Double?
     public let isFree: Bool
+    public let currencyCode: String?
 
     public var domainNameStrippingSubdomain: String {
         return domainName.components(separatedBy: ".").first ?? domainName
     }
 
-    public init(domainName: String, productID: Int?, supportsPrivacy: Bool?, costString: String, cost: Double? = nil, saleCost: Double? = nil, isFree: Bool = false) {
+    public init(
+        domainName: String,
+        productID: Int?,
+        supportsPrivacy: Bool?,
+        costString: String,
+        cost: Double? = nil,
+        saleCost: Double? = nil,
+        isFree: Bool = false,
+        currencyCode: String? = nil
+    ) {
         self.domainName = domainName
         self.productID = productID
         self.supportsPrivacy = supportsPrivacy
@@ -39,6 +49,7 @@ public struct DomainSuggestion: Codable {
         self.cost = cost
         self.saleCost = saleCost
         self.isFree = isFree
+        self.currencyCode = currencyCode
     }
 
     public init(json: [String: AnyObject]) throws {
@@ -53,6 +64,7 @@ public struct DomainSuggestion: Codable {
         self.cost = json["raw_price"] as? Double
         self.saleCost = json["sale_cost"] as? Double
         self.isFree = json["is_free"] as? Bool ?? false
+        self.currencyCode = json["currency_code"] as? String
     }
 }
 

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -25,18 +25,20 @@ public struct DomainSuggestion: Codable {
     public let costString: String
     public let cost: Double?
     public let saleCost: Double?
+    public let isFree: Bool
 
     public var domainNameStrippingSubdomain: String {
         return domainName.components(separatedBy: ".").first ?? domainName
     }
 
-    public init(domainName: String, productID: Int?, supportsPrivacy: Bool?, costString: String, cost: Double? = nil, saleCost: Double? = nil) {
+    public init(domainName: String, productID: Int?, supportsPrivacy: Bool?, costString: String, cost: Double? = nil, saleCost: Double? = nil, isFree: Bool = false) {
         self.domainName = domainName
         self.productID = productID
         self.supportsPrivacy = supportsPrivacy
         self.costString = costString
         self.cost = cost
         self.saleCost = saleCost
+        self.isFree = isFree
     }
 
     public init(json: [String: AnyObject]) throws {
@@ -50,6 +52,7 @@ public struct DomainSuggestion: Codable {
         self.costString = json["cost"] as? String ?? ""
         self.cost = json["raw_price"] as? Double
         self.saleCost = json["sale_cost"] as? Double
+        self.isFree = json["is_free"] as? Bool ?? false
     }
 }
 

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -23,16 +23,20 @@ public struct DomainSuggestion: Codable {
     public let productID: Int?
     public let supportsPrivacy: Bool?
     public let costString: String
+    public let cost: Double?
+    public let saleCost: Double?
 
     public var domainNameStrippingSubdomain: String {
         return domainName.components(separatedBy: ".").first ?? domainName
     }
 
-    public init(domainName: String, productID: Int?, supportsPrivacy: Bool?, costString: String) {
+    public init(domainName: String, productID: Int?, supportsPrivacy: Bool?, costString: String, cost: Double? = nil, saleCost: Double? = nil) {
         self.domainName = domainName
         self.productID = productID
         self.supportsPrivacy = supportsPrivacy
         self.costString = costString
+        self.cost = cost
+        self.saleCost = saleCost
     }
 
     public init(json: [String: AnyObject]) throws {
@@ -44,6 +48,8 @@ public struct DomainSuggestion: Codable {
         self.productID = json["product_id"] as? Int ?? nil
         self.supportsPrivacy = json["supports_privacy"] as? Bool ?? nil
         self.costString = json["cost"] as? String ?? ""
+        self.cost = json["raw_price"] as? Double
+        self.saleCost = json["sale_cost"] as? Double
     }
 }
 
@@ -57,6 +63,10 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         case includeWordPressDotCom
         case onlyWordPressDotCom
         case wordPressDotComAndDotBlogSubdomains
+
+        /// Includes free dotcom and dotblog sudomains and paid domains.
+        case freeAndPaid
+
         case allowlistedTopLevelDomains([String])
 
         fileprivate func parameters() -> [String: AnyObject] {
@@ -73,6 +83,10 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
                         "vendor": "dot" as AnyObject,
                         "only_wordpressdotcom": true as AnyObject,
                         "include_wordpressdotcom": true as AnyObject]
+            case .freeAndPaid:
+                return ["include_dotblogsubdomain": true as AnyObject,
+                        "include_wordpressdotcom": true as AnyObject,
+                        "vendor": "mobile" as AnyObject]
             case .allowlistedTopLevelDomains(let allowlistedTLDs):
                 return ["tlds": allowlistedTLDs.joined(separator: ",") as AnyObject]
             }


### PR DESCRIPTION
### Description

Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/20077

This PR adds the following changes:
- Adds `cost` property to `DomainSuggestion` type.
- Adds `saleCost` property  to `DomainSuggestion` type.
- Adds `isFree` property  to `DomainSuggestion` type.
- Adds `freeAndPaid` case to `DomainSuggestionType` to enable fetching free and paid domains.

### Testing Details

Same test instructions as the following PR:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20339

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
