### PR TITLE
Bump version to 7.0.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,11 @@ _None._
 
 ### Breaking Changes
 
-- Refactor the logic to fetch metadata of VideoPress videos [#581]
+_None._
 
 ### New Features
 
-- Add ability to fetch free and paid domains. [#585]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,17 @@ _None._
 ### Internal Changes
 
 _None._
+
+
+## 7.0.0
+
+### Breaking Changes
+
+- Refactor the logic to fetch metadata of VideoPress videos [#581]
+
+### New Features
+
+- Add ability to fetch free and paid domains. [#585]
 
 ## 6.2.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '7.0.0-beta.1'
+  s.version       = '7.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 22.0 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.