### PR TITLE
Add POST requests helper in `WordPressOrgRestApi`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-Add POST requests helper in `WordPressOrgRestApi`.
+Add POST requests helper in `WordPressOrgRestApi`. [#589]
 
 
 ## 7.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+Add POST requests helper in `WordPressOrgRestApi`.
 
 
 ## 7.0.0

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */; };
 		17D936252475D8AB008B2205 /* RemoteHomepageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D936242475D8AB008B2205 /* RemoteHomepageType.swift */; };
 		1A4F98672279A87D00D86E8E /* WPKit-Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A4F98662279A87D00D86E8E /* WPKit-Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1D969EB329D45745001FE37C /* wp-reusable-blocks.json in Resources */ = {isa = PBXBuildFile; fileRef = 1D969EB229D45745001FE37C /* wp-reusable-blocks.json */; };
 		1DAC3D2629AF4F250068FE13 /* RemoteVideoPressVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DAC3D2529AF4F250068FE13 /* RemoteVideoPressVideo.swift */; };
 		1DC837C229B9F04F009DCD4B /* RemoteVideoPressVideoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DC837C129B9F04F009DCD4B /* RemoteVideoPressVideoTests.swift */; };
 		1DF972BA29B0DF8C007A72BC /* videopress-token.json in Resources */ = {isa = PBXBuildFile; fileRef = 1DF972B729B0DF8C007A72BC /* videopress-token.json */; };
@@ -683,6 +684,7 @@
 		17CE77F320C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderSiteSearchServiceRemoteTests.swift; sourceTree = "<group>"; };
 		17D936242475D8AB008B2205 /* RemoteHomepageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteHomepageType.swift; sourceTree = "<group>"; };
 		1A4F98662279A87D00D86E8E /* WPKit-Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "WPKit-Swift.h"; sourceTree = "<group>"; };
+		1D969EB229D45745001FE37C /* wp-reusable-blocks.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wp-reusable-blocks.json"; sourceTree = "<group>"; };
 		1DAC3D2529AF4F250068FE13 /* RemoteVideoPressVideo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteVideoPressVideo.swift; sourceTree = "<group>"; };
 		1DC837C129B9F04F009DCD4B /* RemoteVideoPressVideoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteVideoPressVideoTests.swift; sourceTree = "<group>"; };
 		1DF972B729B0DF8C007A72BC /* videopress-token.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "videopress-token.json"; sourceTree = "<group>"; };
@@ -2284,6 +2286,7 @@
 				FFA4D4AC2423B1FE00BF5180 /* wp-admin-post-new.html */,
 				FFA4D4AE2423B33800BF5180 /* wp-forbidden.json */,
 				FFA4D4AF2423B33800BF5180 /* wp-pages.json */,
+				1D969EB229D45745001FE37C /* wp-reusable-blocks.json */,
 				740B23EB1F17FB7E00067A2A /* xmlrpc-bad-username-password-error.xml */,
 				740B23EC1F17FB7E00067A2A /* xmlrpc-malformed-request-xml-error.xml */,
 				740B23D71F17FB4200067A2A /* xmlrpc-metaweblog-editpost-bad-xml-failure.xml */,
@@ -2745,6 +2748,7 @@
 				E14694031F344F71004052C8 /* site-plugins-error.json in Resources */,
 				C738CAF728622B94001BE107 /* qrlogin-authenticate-200.json in Resources */,
 				829BA4311FACF187003ADEEA /* activity-rewind-status-success.json in Resources */,
+				1D969EB329D45745001FE37C /* wp-reusable-blocks.json in Resources */,
 				93BD27571EE73442002BB00B /* auth-send-login-email-no-user-failure.json in Resources */,
 				9A88174C223C01E400A3AB20 /* jetpack-service-success.json in Resources */,
 				9A881755223C01E400A3AB20 /* jetpack-service-error-activation-response.json in Resources */,

--- a/WordPressKit/WordPressOrgRestApi.swift
+++ b/WordPressKit/WordPressOrgRestApi.swift
@@ -32,6 +32,13 @@ open class WordPressOrgRestApi: NSObject, WordPressRestApi {
     }
 
     @discardableResult
+    open func POST(_ path: String,
+                  parameters: [String: AnyObject]?,
+                  completion: @escaping Completion) -> Progress? {
+        return request(method: .post, path: path, parameters: parameters, completion: completion)
+    }
+
+    @discardableResult
     open func request(method: HTTPMethod,
                          path: String,
                          parameters: [String: AnyObject]?,

--- a/WordPressKitTests/Mock Data/wp-reusable-blocks.json
+++ b/WordPressKitTests/Mock Data/wp-reusable-blocks.json
@@ -1,0 +1,50 @@
+{
+    "id": 6,
+    "date": "2021-02-10T11:51:53",
+    "date_gmt": "2021-02-10T11:51:53",
+    "guid": {
+        "rendered": "https:\/\/test-site.org\/2021\/02\/10\/untitled-reusable-block\/",
+        "raw": "https:\/\/test-site.org\/2021\/02\/10\/untitled-reusable-block\/"
+    },
+    "modified": "2021-02-10T12:31:39",
+    "modified_gmt": "2021-02-10T12:31:39",
+    "password": "",
+    "slug": "untitled-reusable-block",
+    "status": "publish",
+    "type": "wp_block",
+    "link": "https:\/\/test-site.org\/2021\/02\/10\/untitled-reusable-block\/",
+    "title": {
+        "raw": "A resuable block"
+    },
+    "content": {
+        "raw": "<!-- wp:paragraph -->\n<p>Some text<\/p>\n<!-- \/wp:paragraph -->\n\n<!-- wp:list -->\n<ul><li>Item 1<\/li><li>Item 2<\/li><li>Item 3<\/li><\/ul>\n<!-- \/wp:list -->",
+        "protected": false,
+        "block_version": 1
+    },
+    "template": "",
+    "_links": {
+        "self": [{
+            "href": "https:\/\/test-site.org\/wp-json\/wp\/v2\/blocks\/6"
+        }],
+        "collection": [{
+            "href": "https:\/\/test-site.org\/wp-json\/wp\/v2\/blocks"
+        }],
+        "about": [{
+            "href": "https:\/\/test-site.org\/wp-json\/wp\/v2\/types\/wp_block"
+        }],
+        "wp:attachment": [{
+            "href": "https:\/\/test-site.org\/wp-json\/wp\/v2\/media?parent=6"
+        }],
+        "wp:action-publish": [{
+            "href": "https:\/\/test-site.org\/wp-json\/wp\/v2\/blocks\/6"
+        }],
+        "wp:action-unfiltered-html": [{
+            "href": "https:\/\/test-site.org\/wp-json\/wp\/v2\/blocks\/6"
+        }],
+        "curies": [{
+            "name": "wp",
+            "href": "https:\/\/api.w.org\/{rel}",
+            "templated": true
+        }]
+    }
+}

--- a/WordPressKitTests/WordPressOrgRestApiTests.swift
+++ b/WordPressKitTests/WordPressOrgRestApiTests.swift
@@ -41,7 +41,7 @@ class WordPressOrgRestApiTests: XCTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testSuccessfulCall() {
+    func testSuccessfulGetCall() {
         stub(condition: isAPIRequest()) { _ in
             let stubPath = OHPathForFile("wp-pages.json", type(of: self))
             return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
@@ -57,6 +57,36 @@ class WordPressOrgRestApiTests: XCTestCase {
                     return
                 }
                 XCTAssertEqual(pages.count, 10, "The API should return 10 pages")
+            case .failure:
+                XCTFail("This call should not fail")
+            }
+        }
+        waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    func testSuccessfulPostCall() {
+        stub(condition: isAPIRequest()) { _ in
+            let stubPath = OHPathForFile("wp-reusable-blocks.json", type(of: self))
+            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/json" as AnyObject])
+        }
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgRestApi(apiBase: apiBase)
+        let blockContent = "<!-- wp:paragraph -->\n<p>Some text</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:list -->\n<ul><li>Item 1</li><li>Item 2</li><li>Item 3</li></ul>\n<!-- /wp:list -->"
+        let parameters: [String: String] = ["id": "6", "content": blockContent]
+        api.POST("wp/v2/blocks/6", parameters: parameters as [String: AnyObject]) { (result, _) in
+            expect.fulfill()
+            switch result {
+            case .success(let object):
+                guard
+                    let block = object as? [String: AnyObject],
+                    let content = block["content"] as? [String: AnyObject],
+                    let rawContent = content["raw"] as? String
+                else {
+                    XCTFail("Unexpected API result")
+                    return
+                }
+                XCTAssertEqual(block.count, 15, "The API should return the block")
+                XCTAssertEqual(rawContent, blockContent, "The API should return the block")
             case .failure:
                 XCTFail("This call should not fail")
             }


### PR DESCRIPTION
### Description

Add a helper function to make POST requests in `WordPressOrgRestApi`. Note that this is just a helper to make POST requests similar to `GET` function:
https://github.com/wordpress-mobile/WordPressKit-iOS/blob/27aacb20dfbe11c2cdf591e68fb7d068a3b54328/WordPressKit/WordPressOrgRestApi.swift#L28-L32

Most of the POST requests to WP.org Rest API made from WP-iOS use directly the `request` function passing the `POST` method.

### Testing Details

**WP-iOS is not making use of this helper yet**, hence this change can only be tested with a test PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/20430. Specifically, we should test the case _POST request to WPORG_.

---

- [x] Please check here if your pull request includes additional test coverage.
- [ ] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
