### PR TITLE
Bump version to 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,8 +46,13 @@ _None._
 
 ### Internal Changes
 
-Add POST requests helper in `WordPressOrgRestApi`. [#589]
+_None._
 
+## 7.1.0
+
+### New Features
+
+- Add POST requests method to `WordPressOrgRestApi`. [#589]
 
 ## 7.0.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '7.0.0'
+  s.version       = '7.1.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 22.2 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

_Notice the change in the changelog from internal to new feature, because the change is public facing._