### PR TITLE
Bump version from 7.2.0-beta.1 to 7.2.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,24 @@ _None._
 
 _None._
 
+## 7.2.0
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
+- `Activity` now conforms to `Decodable` [#591]
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
 ## 7.1.0
 
 ### New Features

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '7.2.0-beta.1'
+  s.version       = '7.2.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for [WordPress iOS 22.2](https://github.com/wordpress-mobile/WordPress-iOS/milestone/244) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.