### PR TITLE
Bump version to 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,23 +48,17 @@ _None._
 
 _None._
 
-## 7.2.0
+## 8.0.0
 
 ### Breaking Changes
 
-_None._
+- `Activity` now conforms to `Decodable` and no longer offers `init(dictionary:)` [#591] – _This was originally shipped as 7.2.0 before we realized it was a breaking change._
+
+## 7.2.0
 
 ### New Features
 
 - `Activity` now conforms to `Decodable` [#591]
-
-### Bug Fixes
-
-_None._
-
-### Internal Changes
-
-_None._
 
 ## 7.1.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '7.3.0-beta.1'
+  s.version       = '8.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
See conversation in #594 and https://github.com/wordpress-mobile/WordPress-iOS/pull/20557.

This version bump PR is part of the code freeze workflow for WordPress iOS 22.2 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

[I had a PR already open](https://github.com/wordpress-mobile/WordPress-iOS/pull/20557) using a different working version of WordPressKit so I used it to verify these changes work in Jetpack and WordPress: 

![image](https://user-images.githubusercontent.com/1218433/232980396-6aa7d3b4-8d60-4f98-b8f5-fbc7efc89219.png)
