### PR TITLE
Update editor settings models for block based themes

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.0.0'
+  s.version       = '8.1.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public class RemoteBlockEditorSettings: Codable {
     enum CodingKeys: String, CodingKey {
+        case isFSETheme = "__unstableIsBlockBasedTheme"
         case galleryWithImageBlocks = "__unstableGalleryWithImageBlocks"
         case quoteBlockV2 = "__experimentalEnableQuoteBlockV2"
         case listBlockV2 = "__experimentalEnableListBlockV2"
@@ -38,7 +39,7 @@ public class RemoteBlockEditorSettings: Codable {
 
     required public init(from decoder: Decoder) throws {
         let map = try decoder.container(keyedBy: CodingKeys.self)
-        self.isFSETheme = ((try? map.decode([String: Any].self, forKey: .rawStyles)) != nil) ? true : false
+        self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
         self.galleryWithImageBlocks = (try? map.decode(Bool.self, forKey: .galleryWithImageBlocks)) ?? false
         self.quoteBlockV2 = (try? map.decode(Bool.self, forKey: .quoteBlockV2)) ?? false
         self.listBlockV2 = (try? map.decode(Bool.self, forKey: .listBlockV2)) ?? false
@@ -76,6 +77,6 @@ public struct RemoteEditorThemeSupport: Codable {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.colors = try? map.decode([[String: String]].self, forKey: .colors)
         self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
-        self.blockTemplates = ((try? map.decode(Bool.self, forKey: .blockTemplates)) != nil)
+        self.blockTemplates = (try? map.decode(Bool.self, forKey: .blockTemplates)) ?? false
     }
 }

--- a/WordPressKit/RemoteBlockEditorSettings.swift
+++ b/WordPressKit/RemoteBlockEditorSettings.swift
@@ -2,7 +2,6 @@ import Foundation
 
 public class RemoteBlockEditorSettings: Codable {
     enum CodingKeys: String, CodingKey {
-        case isFSETheme = "__unstableEnableFullSiteEditingBlocks"
         case galleryWithImageBlocks = "__unstableGalleryWithImageBlocks"
         case quoteBlockV2 = "__experimentalEnableQuoteBlockV2"
         case listBlockV2 = "__experimentalEnableListBlockV2"
@@ -39,7 +38,7 @@ public class RemoteBlockEditorSettings: Codable {
 
     required public init(from decoder: Decoder) throws {
         let map = try decoder.container(keyedBy: CodingKeys.self)
-        self.isFSETheme = (try? map.decode(Bool.self, forKey: .isFSETheme)) ?? false
+        self.isFSETheme = ((try? map.decode([String: Any].self, forKey: .rawStyles)) != nil) ? true : false
         self.galleryWithImageBlocks = (try? map.decode(Bool.self, forKey: .galleryWithImageBlocks)) ?? false
         self.quoteBlockV2 = (try? map.decode(Bool.self, forKey: .quoteBlockV2)) ?? false
         self.listBlockV2 = (try? map.decode(Bool.self, forKey: .listBlockV2)) ?? false
@@ -66,14 +65,17 @@ public struct RemoteEditorThemeSupport: Codable {
     enum CodingKeys: String, CodingKey {
         case colors = "editor-color-palette"
         case gradients = "editor-gradient-presets"
+        case blockTemplates = "block-templates"
     }
 
     public let colors: [[String: String]]?
     public let gradients: [[String: String]]?
+    public let blockTemplates: Bool
 
     public init(from decoder: Decoder) throws {
         let map = try decoder.container(keyedBy: CodingKeys.self)
         self.colors = try? map.decode([[String: String]].self, forKey: .colors)
         self.gradients = try? map.decode([[String: String]].self, forKey: .gradients)
+        self.blockTemplates = ((try? map.decode(Bool.self, forKey: .blockTemplates)) != nil)
     }
 }


### PR DESCRIPTION
See: https://github.com/wordpress-mobile/WordPress-iOS/issues/20635

## Description

- Updates `isFSETheme` key on `RemoteBlockEditorSettings` to `__unstableIsBlockBasedTheme`
- Adds new key to `RemoteEditorThemeSupport` for block templates

These model changes are to support checking whether a blog has a theme that uses the full screen editor.

## Testing

Checkout the branch: https://github.com/wordpress-mobile/WordPress-iOS/compare/task/20635-update-fse-check

- Build and launch Jetpack
- Sign in to an account with multiple blogs
- Select a blog which has a theme using the full screen editor
- Set a breakpoint on these model changes
- Open the Gutenberg editor by creating a new post, it should kick off a network request fetching the editor settings
- **Verify** `isFSETheme` on the editor settings is `true`
- Modify [this function](https://github.com/wordpress-mobile/WordPress-iOS/blob/22c7f92981801a0254af4201ae3c7d2aa4d84938/WordPress/Classes/Services/BlockEditorSettingsService.swift#L47-L52)  to:
```swift
    func fetchSettings(_ completion: @escaping BlockEditorSettingsServiceCompletion) {
        // if blog.supports(.blockEditorSettings) {
        //     fetchBlockEditorSettings(completion)
        // } else {
            fetchTheme(completion)
        // }
    }
```
- Repeat the steps above except this time **verifying** `blockTemplates` is `true`
- Select a blog which does not have a theme using the full screen editor
- Repeat the above steps

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
