### PR TITLE
Merge 8.1.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 8.1.0
+
+### Internal Changes
+
+- Update editor settings models for block based themes [#598]
+
 ## 8.0.0
 
 ### Breaking Changes

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.1.0-beta.1'
+  s.version       = '8.1.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION


This version bump PR is part of the code freeze workflow for [Jetpack and WordPress iOS](https://github.com/wordpress-mobile/WordPress-iOS/milestone/246) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.