### PR TITLE
Add site editor settings tests for block theme support

### DIFF
--- a/WordPressKitTests/Mock Data/BlockEditorSettings/get_wp_v2_themes_twentytwentyone-no-colors.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/get_wp_v2_themes_twentytwentyone-no-colors.json
@@ -178,7 +178,8 @@
             "post-thumbnails": true,
             "responsive-embeds": true,
             "title-tag": true,
-            "wp-block-styles": true
+            "wp-block-styles": true,
+            "block-templates": false
         },
         "_links": {
             "self": [

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/get_wp_v2_themes_twentytwentyone.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/get_wp_v2_themes_twentytwentyone.json
@@ -229,7 +229,8 @@
             "post-thumbnails": true,
             "responsive-embeds": true,
             "title-tag": true,
-            "wp-block-styles": true
+            "wp-block-styles": true,
+            "block-templates": true
         },
         "_links": {
             "self": [

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-NotThemeJSON.json
@@ -1,4 +1,5 @@
 {
+    "__unstableIsBlockBasedTheme": false,
     "__unstableEnableFullSiteEditingBlocks": true,
     "alignWide": true,
     "allowedBlockTypes": true,

--- a/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
+++ b/WordPressKitTests/Mock Data/BlockEditorSettings/wp-block-editor-v1-settings-success-ThemeJSON.json
@@ -1,4 +1,5 @@
 {
+    "__unstableIsBlockBasedTheme": true,
     "__unstableEnableFullSiteEditingBlocks": true,
     "alignWide": false,
     "allowedBlockTypes": true,


### PR DESCRIPTION
## Description

Adds some tests to cover the changes made in #598.

### Testing Details

- Run the tests
- **Verify** they pass

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
