### PR TITLE
Merge 8.2.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 8.2.0
+
+### New Features
+
+- Add WordPress.com `/v2` external services endpoint [#600]
+
 ## 8.1.0
 
 ### Internal Changes

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.2.0-beta.1'
+  s.version       = '8.2.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION

This version bump PR is part of the code freeze workflow for WordPress iOS [22.5](https://github.com/wordpress-mobile/WordPress-iOS/milestone/247) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.