### PR TITLE
Fix flaky SharingServiceRemoteTests test

### DIFF
--- a/WordPressKitTests/SharingServiceRemoteTests.swift
+++ b/WordPressKitTests/SharingServiceRemoteTests.swift
@@ -39,17 +39,17 @@ final class SharingServiceRemoteTests: RemoteTestCase, RESTTestable {
         stubRemoteResponse(pathToStub, filename: publicizeServicesMockFilename, contentType: .ApplicationJSON)
 
         mockService.getPublicizeServices(for: mockID) { publicizeServices in
-            guard let firstService = publicizeServices.first else {
+            guard let facebookService = publicizeServices.first(where: { $0.serviceID == "facebook" }) else {
                 XCTFail("Expected a RemotePublicizeService to exist")
                 return
             }
-            XCTAssertTrue(firstService.status.isEmpty)
+            XCTAssertTrue(facebookService.status.isEmpty)
 
-            guard let secondService = publicizeServices.last else {
+            guard let twitterService = publicizeServices.first(where: { $0.serviceID == "twitter"}) else {
                 XCTFail("Expected a RemotePublicizeService to exist")
                 return
             }
-            XCTAssertEqual(secondService.status, "unsupported")
+            XCTAssertEqual(twitterService.status, "unsupported")
 
             expectation.fulfill()
 


### PR DESCRIPTION
Fix flaky SharingServiceRemoteTests test

**Root cause**: `[RemotePublicizeService]` is constructed from a dictionary where the order of keys is not stable.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
