### PR TITLE
Merge release 8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Add Blaze campaigns search endpoint [#605]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,16 @@ _None._
 ### Internal Changes
 
 _None._
+
+### Breaking Changes
+
+_None._
+
+## 8.3.0
+
+### New Features
+
+- Add Blaze campaigns search endpoint [#605]
 
 ## 8.2.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.3.0-beta.1'
+  s.version       = '8.3.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
Merge VERSION stable release

This version bump PR is part of the code freeze workflow for [Jetpack and WordPress iOS 22.6](https://github.com/wordpress-mobile/WordPress-iOS/milestone/248) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.