### PR TITLE
Blaze Manage Campaigns: Add can_blaze property to blog options

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.3.0'
+  s.version       = '8.4.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/BlazeServiceRemote.swift
+++ b/WordPressKit/BlazeServiceRemote.swift
@@ -2,38 +2,6 @@ import Foundation
 
 open class BlazeServiceRemote: ServiceRemoteWordPressComREST {
 
-    public typealias BlazeStatusResponseCallback = (Result<Bool, Error>) -> Void
-
-    public enum BlazeServiceRemoteError: Error {
-        case InvalidDataError
-    }
-
-    // MARK: - Status
-
-    open func getStatus(forSiteId siteId: Int, callback: @escaping BlazeStatusResponseCallback) {
-
-        let endpoint = "sites/\(siteId)/blaze/status"
-        let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
-
-        wordPressComRestApi.GET(path, parameters: nil, success: { response, _ in
-            if let json = response as? [String: Any],
-               let approved = json["approved"] as? Bool {
-                callback(.success(approved))
-            } else {
-                callback(.failure(BlazeServiceRemoteError.InvalidDataError))
-            }
-        }, failure: { error, response in
-            WPKitLogError("Error retrieving blaze status")
-            WPKitLogError("\(error)")
-
-            if let response = response {
-                WPKitLogDebug("Response Code: \(response.statusCode)")
-            }
-
-            callback(.failure(error))
-        })
-    }
-
     // MARK: - Campaigns
 
     /// Searches the campaigns for the site with the given ID. The campaigns are returned ordered by the post date.

--- a/WordPressKit/RemoteBlogOptionsHelper.swift
+++ b/WordPressKit/RemoteBlogOptionsHelper.swift
@@ -33,7 +33,8 @@ import Foundation
                 "page_on_front",
                 "page_for_posts",
                 "blogging_prompts_settings",
-                "jetpack_connection_active_plugins"
+                "jetpack_connection_active_plugins",
+                "can_blaze"
             ]
             for key in optionsDirectMapKeys {
                 if let value = response.value(forKeyPath: "options.\(key)") {

--- a/WordPressKitTests/BlazeServiceRemoteTests.swift
+++ b/WordPressKitTests/BlazeServiceRemoteTests.swift
@@ -9,74 +9,8 @@ final class BlazeServiceRemoteTests: RemoteTestCase, RESTTestable {
 
     // MARK: - Properties
 
-    var statusEndpoint: String { "sites/\(siteId)/blaze/status" }
     var searchEndpoint: String { "sites/\(siteId)/wordads/dsp/api/v1/search/campaigns/site/\(siteId)" }
     var service: BlazeServiceRemote!
-
-    // MARK: - Get Status
-
-    func testGetStatusReturnsSuccess() throws {
-        // Given
-        let status = ["approved": true]
-        let data = try JSONEncoder().encode(status)
-        stubRemoteResponse(statusEndpoint, data: data, contentType: .ApplicationJSON)
-
-        // When
-        let expectation = XCTestExpectation()
-        BlazeServiceRemote(wordPressComRestApi: getRestApi()).getStatus(forSiteId: siteId) { result in
-
-            // Then
-            let approved = try! result.get()
-            XCTAssertEqual(approved, true)
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 1)
-    }
-
-    func testMalformedResponseReturnsError() throws {
-        // Given
-        let data = try toJSON(object: ["Invalid"])
-        stubRemoteResponse(statusEndpoint, data: data, contentType: .ApplicationJSON)
-
-        // When
-        let expectation = XCTestExpectation()
-        BlazeServiceRemote(wordPressComRestApi: getRestApi()).getStatus(forSiteId: siteId) { result in
-
-            // Then
-            switch result {
-            case .success: XCTFail()
-            case .failure: expectation.fulfill()
-            }
-
-        }
-
-        wait(for: [expectation], timeout: 1)
-    }
-
-    func testGetStatusReturnsFailure() {
-        // Given
-        stubRemoteResponse(statusEndpoint, data: Data(), contentType: .NoContentType, status: 403)
-
-        // When
-        let expectation = XCTestExpectation()
-        BlazeServiceRemote(wordPressComRestApi: getRestApi()).getStatus(forSiteId: siteId) { result in
-
-            // Then
-            if case .success = result {
-                XCTFail()
-            }
-            expectation.fulfill()
-        }
-
-        wait(for: [expectation], timeout: 1)
-    }
-
-    private func toJSON<T: Codable>(object: T) throws -> Data {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        return try encoder.encode(object)
-    }
 
     // MARK: - Campaigns
 


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/20915
WPiOS PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/20916

### Description
- Adds the `can_blaze` property to blog options
- Removes the `/sites/{siteId}/blaze/status` endpoint

### Testing Details
See testing instructions in https://github.com/wordpress-mobile/WordPress-iOS/pull/20916

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
