### PR TITLE
Resolve TODOs by backporting async/await code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Enable async/await backporting to iOS 13 for `WordPressComRestApi` (resolves a TODO) [#610]
 
 ### Breaking Changes
 


### PR DESCRIPTION
### Description

While digging into async issues, I came across a couple of TODOs that were pretty quick to clean up. While we can't switch to async/await entirely at this point, enabling backporting is a step toward allowing it (even if just for use in our test suite).

### Testing Details
Ensure tests pass.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
