### PR TITLE
Add ui_status field to BlazeCampaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add `ui_status` field to `BlazeCampaign` [#611]
 
 ### Bug Fixes
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.4.0-beta.1'
+  s.version       = '8.4.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.4.0-beta.1'
+  s.version       = '8.5.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/BlazeCampaign.swift
+++ b/WordPressKit/BlazeCampaign.swift
@@ -5,19 +5,24 @@ public final class BlazeCampaign: Decodable {
     public let name: String?
     public let startDate: Date?
     public let endDate: Date?
+    /// A raw campaign status on the server.
     public let status: Status
+    /// A subset of ``BlazeCampaign/status-swift.property`` values where some
+    /// cases are skipped for simplicity and mapped to other more common ones.
+    public let uiStatus: Status
     public let budgetCents: Int?
     public let targetURL: String?
     public let stats: Stats?
     public let contentConfig: ContentConfig?
     public let creativeHTML: String?
 
-    public init(campaignID: Int, name: String?, startDate: Date?, endDate: Date?, status: Status, budgetCents: Int?, targetURL: String?, stats: Stats?, contentConfig: ContentConfig?, creativeHTML: String?) {
+    public init(campaignID: Int, name: String?, startDate: Date?, endDate: Date?, status: Status, uiStatus: Status, budgetCents: Int?, targetURL: String?, stats: Stats?, contentConfig: ContentConfig?, creativeHTML: String?) {
         self.campaignID = campaignID
         self.name = name
         self.startDate = startDate
         self.endDate = endDate
         self.status = status
+        self.uiStatus = uiStatus
         self.budgetCents = budgetCents
         self.targetURL = targetURL
         self.stats = stats
@@ -31,6 +36,7 @@ public final class BlazeCampaign: Decodable {
         case startDate
         case endDate
         case status
+        case uiStatus
         case budgetCents
         case targetURL = "targetUrl"
         case contentConfig

--- a/WordPressKit/BlazeCampaign.swift
+++ b/WordPressKit/BlazeCampaign.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public final class BlazeCampaign: Decodable {
+public final class BlazeCampaign: Codable {
     public let campaignID: Int
     public let name: String?
     public let startDate: Date?
@@ -44,7 +44,7 @@ public final class BlazeCampaign: Decodable {
         case creativeHTML = "creativeHtml"
     }
 
-    public enum Status: String, Decodable {
+    public enum Status: String, Codable {
         case scheduled
         case created
         case rejected
@@ -61,7 +61,7 @@ public final class BlazeCampaign: Decodable {
         }
     }
 
-    public struct Stats: Decodable {
+    public struct Stats: Codable {
         public let impressionsTotal: Int?
         public let clicksTotal: Int?
 
@@ -71,7 +71,7 @@ public final class BlazeCampaign: Decodable {
         }
     }
 
-    public struct ContentConfig: Decodable {
+    public struct ContentConfig: Codable {
         public let title: String?
         public let snippet: String?
         public let clickURL: String?

--- a/WordPressKitTests/BlazeServiceRemoteTests.swift
+++ b/WordPressKitTests/BlazeServiceRemoteTests.swift
@@ -37,6 +37,7 @@ final class BlazeServiceRemoteTests: RemoteTestCase, RESTTestable {
         XCTAssertEqual(campaign.startDate, ISO8601DateFormatter().date(from: "2023-06-13T00:00:00Z"))
         XCTAssertEqual(campaign.endDate, ISO8601DateFormatter().date(from: "2023-06-01T19:15:45Z"))
         XCTAssertEqual(campaign.status, .canceled)
+        XCTAssertEqual(campaign.uiStatus, .canceled)
         XCTAssertEqual(campaign.budgetCents, 500)
         XCTAssertEqual(campaign.targetURL, "https://alextest9123.wordpress.com/2023/06/01/test-post/")
         XCTAssertEqual(campaign.contentConfig?.title, "Test Post - don't approve")

--- a/WordPressKitTests/Mock Data/blaze-campaigns-search.json
+++ b/WordPressKitTests/Mock Data/blaze-campaigns-search.json
@@ -8,6 +8,7 @@
             "end_date": "2023-06-01T19:15:45.000Z",
             "status_smart": 0,
             "status": "canceled",
+            "ui_status": "canceled",
             "subscription_id": 117499,
             "display_name": "Test User",
             "avatar_url": "https://0.gravatar.com/avatar/614d27bcc21db12e7c49b516b4750387?s=96&amp;d=identicon&amp;r=G",


### PR DESCRIPTION
### Description

PR in WP-iOS [#20939](https://github.com/wordpress-mobile/WordPress-iOS/pull/20939)

- Add the new `ui_status` field to `BlazeCampaign`
- Make `BlazeCampaign` `Codable` so we could cache it on dashboard

### Testing Details

- Covered by the unit test

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
