### PR TITLE
Fix: Bump to 8.4.0-beta.2

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.4.0-beta.1'
+  s.version       = '8.4.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

PR #606 should've bumped the version to `8.4.0-beta.2`, but it was left at `beta-1`. This is a one-liner fix to update the podspec version to the correct one.

I'll create a new pre-release once this PR is merged.

### Testing Details

N/A.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
