### PR TITLE
[EU-US Compliance] Add `IPLocationRemote`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Add `IPLocationRemote` [#613]
 
 ### Bug Fixes
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.4.0-beta.1'
+  s.version       = '8.4.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0152100C28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */; };
 		0847B92C2A4442730044D32F /* IPLocationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0847B92B2A4442730044D32F /* IPLocationRemote.swift */; };
+		08C7493E2A45EA11000DA0E2 /* IPLocationRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C7493D2A45EA11000DA0E2 /* IPLocationRemoteTests.swift */; };
 		0CB1905E2A2A5E83004D3E80 /* BlazeCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB1905D2A2A5E83004D3E80 /* BlazeCampaign.swift */; };
 		0CB190612A2A6A13004D3E80 /* blaze-campaigns-search.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CB1905F2A2A6943004D3E80 /* blaze-campaigns-search.json */; };
 		0CB190652A2A7569004D3E80 /* BlazeCampaignsSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB190642A2A7569004D3E80 /* BlazeCampaignsSearchResponse.swift */; };
@@ -686,6 +687,7 @@
 /* Begin PBXFileReference section */
 		0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsAnnualAndMostPopularTimeInsightDecodingTests.swift; sourceTree = "<group>"; };
 		0847B92B2A4442730044D32F /* IPLocationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPLocationRemote.swift; sourceTree = "<group>"; };
+		08C7493D2A45EA11000DA0E2 /* IPLocationRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPLocationRemoteTests.swift; sourceTree = "<group>"; };
 		0C3A2A412A2E7BA500FD91D6 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		0CB1905D2A2A5E83004D3E80 /* BlazeCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaign.swift; sourceTree = "<group>"; };
 		0CB1905F2A2A6943004D3E80 /* blaze-campaigns-search.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "blaze-campaigns-search.json"; sourceTree = "<group>"; };
@@ -1385,6 +1387,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		08C7493C2A45E9E3000DA0E2 /* Privacy */ = {
+			isa = PBXGroup;
+			children = (
+				08C7493D2A45EA11000DA0E2 /* IPLocationRemoteTests.swift */,
+			);
+			name = Privacy;
+			sourceTree = "<group>";
+		};
 		0CB1905C2A2A5E7B004D3E80 /* Blaze */ = {
 			isa = PBXGroup;
 			children = (
@@ -1758,6 +1768,7 @@
 				7433BC061EFC456B002D9E92 /* Plans */,
 				E13EE14A1F332C3100C15787 /* Plugins */,
 				740B23D41F17F6D200067A2A /* Post */,
+				08C7493C2A45E9E3000DA0E2 /* Privacy */,
 				C738CAED286222C9001BE107 /* QR Login */,
 				7430C9BF1F192C210051B8E6 /* Reader */,
 				74E2294C1F1E73650085F7F2 /* Sharing */,
@@ -3377,6 +3388,7 @@
 				E13EE14C1F332C4400C15787 /* PluginServiceRemoteTests.swift in Sources */,
 				736C971021E80D48007A4200 /* SiteVerticalsPromptResponseDecodingTests.swift in Sources */,
 				74B335D81F06F1CA0053A184 /* MockWordPressComRestApi.swift in Sources */,
+				08C7493E2A45EA11000DA0E2 /* IPLocationRemoteTests.swift in Sources */,
 				32AF21E3236DEB3C001C6502 /* PostServiceRemoteRESTAutosaveTests.swift in Sources */,
 				3236F79A24AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift in Sources */,
 				FEE4EF5B27302317003CDA3C /* CommentServiceRemoteREST+APIv2Tests.swift in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0152100C28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */; };
+		0847B92C2A4442730044D32F /* IPLocationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0847B92B2A4442730044D32F /* IPLocationRemote.swift */; };
 		0CB1905E2A2A5E83004D3E80 /* BlazeCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB1905D2A2A5E83004D3E80 /* BlazeCampaign.swift */; };
 		0CB190612A2A6A13004D3E80 /* blaze-campaigns-search.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CB1905F2A2A6943004D3E80 /* blaze-campaigns-search.json */; };
 		0CB190652A2A7569004D3E80 /* BlazeCampaignsSearchResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB190642A2A7569004D3E80 /* BlazeCampaignsSearchResponse.swift */; };
@@ -684,6 +685,7 @@
 
 /* Begin PBXFileReference section */
 		0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsAnnualAndMostPopularTimeInsightDecodingTests.swift; sourceTree = "<group>"; };
+		0847B92B2A4442730044D32F /* IPLocationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPLocationRemote.swift; sourceTree = "<group>"; };
 		0C3A2A412A2E7BA500FD91D6 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		0CB1905D2A2A5E83004D3E80 /* BlazeCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaign.swift; sourceTree = "<group>"; };
 		0CB1905F2A2A6943004D3E80 /* blaze-campaigns-search.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "blaze-campaigns-search.json"; sourceTree = "<group>"; };
@@ -1876,6 +1878,7 @@
 				F9E56DF724EB125600916770 /* FeatureFlagRemote.swift */,
 				74650F711F0EA1A700188EDB /* GravatarServiceRemote.swift */,
 				1769DEA924729AFF00F42EFC /* HomepageSettingsServiceRemote.swift */,
+				0847B92B2A4442730044D32F /* IPLocationRemote.swift */,
 				FAD1344425908F5F00A8FEB1 /* JetpackBackupServiceRemote.swift */,
 				8B749DEC25AF3E4600023F03 /* JetpackCapabilitiesServiceRemote.swift */,
 				32FC1D27255C91ED00CD0A7B /* JetpackScanServiceRemote.swift */,
@@ -3213,6 +3216,7 @@
 				9F4E52002088E38200424676 /* ObjectValidation.swift in Sources */,
 				7EC60EC022DC5D7C00FB0336 /* EditorSettings.swift in Sources */,
 				7403A3021EF0726E00DED7DC /* AccountSettings.swift in Sources */,
+				0847B92C2A4442730044D32F /* IPLocationRemote.swift in Sources */,
 				40E7FEA9220FA4060032834E /* StatsEmailFollowersInsight.swift in Sources */,
 				404057DA221C9D560060250C /* StatsTopReferrersTimeIntervalData.swift in Sources */,
 				826016F11F9FA13A00533B6C /* ActivityServiceRemote.swift in Sources */,

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -24,6 +24,7 @@ public final class IPLocationRemote {
         let request = URLRequest(url: url)
         let task = urlSession.dataTask(with: request) { data, _, error in
             guard let data else {
+                completion(.failure(IPLocationError.requestFailure(error)))
                 return
             }
 
@@ -41,6 +42,7 @@ public final class IPLocationRemote {
 public extension IPLocationRemote {
     enum IPLocationError: Error {
         case malformedURL
+        case requestFailure(Error?)
     }
 }
 

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -2,31 +2,35 @@ import Foundation
 
 /// Remote type to fetch the user's IP Location using the public `geo` API.
 ///
-public final class IPLocationRemote: ServiceRemoteWordPressComREST {
+public final class IPLocationRemote {
     private enum Constants {
         static let jsonDecoder = JSONDecoder()
+    }
+
+    private let urlSession: URLSession
+
+    init(urlSession: URLSession = URLSession.shared) {
+        self.urlSession = urlSession
     }
 
     /// Fetches the country code from the device ip.
     ///
     public func fetchIPCountryCode(completion: @escaping (Result<String, Error>) -> Void) {
-
         let path = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseUrl + "/geo/"
         guard let url = URL(string: path) else {
             return completion(.failure(IPLocationError.malformedURL))
         }
 
         let request = URLRequest(url: url)
-        let task = URLSession.shared.dataTask(with: request) { data, _, error in
+        let task = urlSession.dataTask(with: request) { data, _, error in
             guard let data else {
                 return
             }
-            
+
             do {
                 let result = try Constants.jsonDecoder.decode(RemoteIPCountryCode.self, from: data)
                 completion(.success(result.countryCode))
             } catch {
-                print(error.localizedDescription)
                 completion(.failure(error))
             }
         }

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -6,7 +6,7 @@ public final class IPLocationRemote: ServiceRemoteWordPressComREST {
 
     /// Fetches the country code from the device ip.
     ///
-    public func fetchIPCountryCode(onCompletion: @escaping (Result<String, Error>) -> Void) {
+    public func fetchIPCountryCode(completion: @escaping (Result<String, Error>) -> Void) {
         let path = path(forEndpoint: wordPressComRestApi.baseURLString + "geo/", withVersion: ._2_0)
 
         wordPressComRestApi.GET(path, parameters: nil) { result, _ in

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -8,7 +8,7 @@ public final class IPLocationRemote: ServiceRemoteWordPressComREST {
     ///
     public func fetchIPCountryCode(completion: @escaping (Result<String, Error>) -> Void) {
 
-        let path = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseUrl + "geo/"
+        let path = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseUrl + "/geo/"
         guard let url = URL(string: path) else {
             return completion(.failure(IPLocationError.malformedURL))
         }

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -17,8 +17,8 @@ public final class IPLocationRemote: ServiceRemoteWordPressComREST {
                     let decoder = JSONDecoder.apiDecoder
                     // our API decoder assumes that we're converting from snake case.
                     // revert it to default so the CodingKeys match the actual response keys.
-                    let response = try decoder.decode(String.self, from: data)
-                    completion(.success(response.values.first ?? []))
+                    let response = try decoder.decode(RemoteIPCountryCode.self, from: data)
+                    completion(.success(response.countryCode))
                 } catch {
                     completion(.failure(error))
                 }
@@ -38,21 +38,10 @@ public extension IPLocationRemote {
     }
 }
 
-/// Private mapper used to extract the country code from the `IPLocationRemote` response.
-///
-private struct IPCountryCodeMapper: Mapper {
-
-    /// Response envelope
-    ///
-    struct Response: Decodable {
-        enum CodingKeys: String, CodingKey {
-            case countryCode = "country_short"
-        }
-
-        let countryCode: String
+public struct RemoteIPCountryCode: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case countryCode = "country_short"
     }
 
-    func map(response: Data) throws -> String {
-        try JSONDecoder().decode(Response.self, from: response).countryCode
-    }
+    let countryCode: String
 }

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -3,6 +3,9 @@ import Foundation
 /// Remote type to fetch the user's IP Location using the public `geo` API.
 ///
 public final class IPLocationRemote: ServiceRemoteWordPressComREST {
+    private enum Constants {
+        static let jsonDecoder = JSONDecoder()
+    }
 
     /// Fetches the country code from the device ip.
     ///
@@ -14,26 +17,23 @@ public final class IPLocationRemote: ServiceRemoteWordPressComREST {
         }
 
         let request = URLRequest(url: url)
-        let task = URLSession.shared.dataTask(with: request) { data, _,error in
-            if let data = data {
-                /// do exception handler so that our app does not crash
-                do {
-                    let decoder = JSONDecoder.apiDecoder
-                    decoder.keyDecodingStrategy = .useDefaultKeys
-                    let result = try decoder.decode(RemoteIPCountryCode.self, from: data)
-                    completion(.success(result.countryCode))
-                } catch {
-                    print(error.localizedDescription)
-                    completion(.failure(error))
-                }
+        let task = URLSession.shared.dataTask(with: request) { data, _, error in
+            guard let data else {
+                return
+            }
+            
+            do {
+                let result = try Constants.jsonDecoder.decode(RemoteIPCountryCode.self, from: data)
+                completion(.success(result.countryCode))
+            } catch {
+                print(error.localizedDescription)
+                completion(.failure(error))
             }
         }
         task.resume()
     }
 }
 
-/// `IPLocationRemote` known errors
-///
 public extension IPLocationRemote {
     enum IPLocationError: Error {
         case malformedURL

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -18,7 +18,9 @@ public final class IPLocationRemote: ServiceRemoteWordPressComREST {
             if let data = data {
                 /// do exception handler so that our app does not crash
                 do {
-                    let result = try JSONDecoder.apiDecoder.decode(RemoteIPCountryCode.self, from: data)
+                    let decoder = JSONDecoder.apiDecoder
+                    decoder.keyDecodingStrategy = .useDefaultKeys
+                    let result = try decoder.decode(RemoteIPCountryCode.self, from: data)
                     completion(.success(result.countryCode))
                 } catch {
                     print(error.localizedDescription)

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// Remote type to fetch the user's IP Location using the public `geo` API.
+///
+public final class IPLocationRemote: ServiceRemoteWordPressComREST {
+
+    /// Fetches the country code from the device ip.
+    ///
+    public func fetchIPCountryCode(onCompletion: @escaping (Result<String, Error>) -> Void) {
+        let path = path(forEndpoint: wordPressComRestApi.baseURLString + "geo/", withVersion: ._2_0)
+
+        wordPressComRestApi.GET(path, parameters: nil) { result, _ in
+            switch result {
+            case .success(let responseObject):
+                do {
+                    let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
+                    let decoder = JSONDecoder.apiDecoder
+                    // our API decoder assumes that we're converting from snake case.
+                    // revert it to default so the CodingKeys match the actual response keys.
+                    let response = try decoder.decode(String.self, from: data)
+                    completion(.success(response.values.first ?? []))
+                } catch {
+                    completion(.failure(error))
+                }
+
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}
+
+/// `IPLocationRemote` known errors
+///
+public extension IPLocationRemote {
+    enum IPLocationError: Error {
+        case malformedURL
+    }
+}
+
+/// Private mapper used to extract the country code from the `IPLocationRemote` response.
+///
+private struct IPCountryCodeMapper: Mapper {
+
+    /// Response envelope
+    ///
+    struct Response: Decodable {
+        enum CodingKeys: String, CodingKey {
+            case countryCode = "country_short"
+        }
+
+        let countryCode: String
+    }
+
+    func map(response: Data) throws -> String {
+        try JSONDecoder().decode(Response.self, from: response).countryCode
+    }
+}

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -7,7 +7,7 @@ public final class IPLocationRemote: ServiceRemoteWordPressComREST {
     /// Fetches the country code from the device ip.
     ///
     public func fetchIPCountryCode(completion: @escaping (Result<String, Error>) -> Void) {
-        let path = path(forEndpoint: wordPressComRestApi.baseURLString + "geo/", withVersion: ._2_0)
+        let path = "https://public-api.wordpress.com/geo/"
 
         wordPressComRestApi.GET(path, parameters: nil) { result, _ in
             switch result {

--- a/WordPressKitTests/IPLocationRemoteTests.swift
+++ b/WordPressKitTests/IPLocationRemoteTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import WordPressKit
+
+
+final class IPLocationRemoteTests: XCTestCase {
+    var remote: IPLocationRemote!
+    let apiURL = URL(string: "https://public-api.wordpress.com/geo/")!
+
+    override func setUp() {
+      let configuration = URLSessionConfiguration.default
+      configuration.protocolClasses = [MockURLProtocol.self]
+      let urlSession = URLSession.init(configuration: configuration)
+
+      remote = IPLocationRemote(urlSession: urlSession)
+    }
+
+    func testCountryCodeIsCorrectlyParsed() {
+        let expectation = expectation(description: "The country code should be parsed as DE")
+        let jsonString = """
+                         {
+                             "latitude": "24.917202",
+                             "longitude": "16.559613",
+                             "country_short": "DE",
+                             "country_long": "Germany",
+                             "region": "Brandenburg",
+                             "city": "Potsdam"
+                         }
+                         """
+
+        let data = jsonString.data(using: .utf8)
+
+        MockURLProtocol.requestHandler = { request in
+          let response = HTTPURLResponse(url: self.apiURL, statusCode: 200, httpVersion: nil, headerFields: nil)!
+          return (response, data)
+        }
+
+        remote.fetchIPCountryCode { result in
+          switch result {
+          case .success(let countryCode):
+            XCTAssertEqual(countryCode, "DE")
+          case .failure(let error):
+            XCTFail("Error was not expected: \(error)")
+          }
+          expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+    }
+}
+
+final class MockURLProtocol: URLProtocol {
+    static var requestHandler: ((URLRequest) throws -> (HTTPURLResponse, Data?))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+
+    override func startLoading() {
+        guard let handler = MockURLProtocol.requestHandler else {
+            fatalError("Handler is unavailable.")
+        }
+
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+
+            if let data = data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+
+    override func stopLoading() { }
+}

--- a/WordPressKitTests/IPLocationRemoteTests.swift
+++ b/WordPressKitTests/IPLocationRemoteTests.swift
@@ -7,11 +7,12 @@ final class IPLocationRemoteTests: XCTestCase {
     let apiURL = URL(string: "https://public-api.wordpress.com/geo/")!
 
     override func setUp() {
-      let configuration = URLSessionConfiguration.default
-      configuration.protocolClasses = [MockURLProtocol.self]
-      let urlSession = URLSession.init(configuration: configuration)
+        super.setUp()
+        let configuration = URLSessionConfiguration.default
+        configuration.protocolClasses = [MockURLProtocol.self]
+        let urlSession = URLSession.init(configuration: configuration)
 
-      remote = IPLocationRemote(urlSession: urlSession)
+        remote = IPLocationRemote(urlSession: urlSession)
     }
 
     func testCountryCodeIsCorrectlyParsed() {


### PR DESCRIPTION
### Description
This PR adds the necessary remote for the public `geo/` Endpoint. It will be used to check the location and decide whether to show the pop up or not.

https://github.com/wordpress-mobile/WordPress-iOS/issues/20711

### Testing Details
This can be tested from the main app once the remote is utilized with a following PR.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
