### PR TITLE
Merge 8.4.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,9 +48,12 @@ _None._
 
 _None._
 
-### Breaking Changes
+## 8.4.0
 
-_None._
+### New Features
+
+- Add new endpoint to fetch Jetpack Social Publicize configurations [#606]
+- Add `can_blaze` property to blog options [#609]
 
 ## 8.3.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.4.0-beta.2'
+  s.version       = '8.4.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION


This version bump PR is part of the code freeze workflow for WordPress iOS [22.7](https://github.com/wordpress-mobile/WordPress-iOS/milestone/249) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.