### PR TITLE
Parse active features in RemoteBlog

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.4.0'
+  s.version       = '8.5.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.5.0-beta.1'
+  s.version       = '8.5.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -636,6 +636,9 @@
 		FEAE3AC7298AC2A300E05A24 /* JetpackProxyServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEAE3AC6298AC2A300E05A24 /* JetpackProxyServiceRemote.swift */; };
 		FEB7A88F271873BD00A8CF85 /* reader-post-comments-update-notification-success.json in Resources */ = {isa = PBXBuildFile; fileRef = FEB7A88E271873BD00A8CF85 /* reader-post-comments-update-notification-success.json */; };
 		FED77253298B819900C2346E /* JetpackProxyServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED77252298B819900C2346E /* JetpackProxyServiceRemoteTests.swift */; };
+		FEE48EF62A4B3602008A48E0 /* BlogServiceRemote+ActiveFeaturesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE48EF52A4B3602008A48E0 /* BlogServiceRemote+ActiveFeaturesTests.swift */; };
+		FEE48EF82A4B3E43008A48E0 /* sites-site-active-features.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE48EF72A4B3E43008A48E0 /* sites-site-active-features.json */; };
+		FEE48EFA2A4B3E50008A48E0 /* sites-site-no-active-features.json in Resources */ = {isa = PBXBuildFile; fileRef = FEE48EF92A4B3E50008A48E0 /* sites-site-no-active-features.json */; };
 		FEE4EF57272FDD4B003CDA3C /* RemoteCommentV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE4EF56272FDD4B003CDA3C /* RemoteCommentV2.swift */; };
 		FEE4EF59272FF78C003CDA3C /* CommentServiceRemoteREST+ApiV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE4EF58272FF78C003CDA3C /* CommentServiceRemoteREST+ApiV2.swift */; };
 		FEE4EF5B27302317003CDA3C /* CommentServiceRemoteREST+APIv2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEE4EF5A27302317003CDA3C /* CommentServiceRemoteREST+APIv2Tests.swift */; };
@@ -1324,6 +1327,9 @@
 		FEAE3AC6298AC2A300E05A24 /* JetpackProxyServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackProxyServiceRemote.swift; sourceTree = "<group>"; };
 		FEB7A88E271873BD00A8CF85 /* reader-post-comments-update-notification-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-update-notification-success.json"; sourceTree = "<group>"; };
 		FED77252298B819900C2346E /* JetpackProxyServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackProxyServiceRemoteTests.swift; sourceTree = "<group>"; };
+		FEE48EF52A4B3602008A48E0 /* BlogServiceRemote+ActiveFeaturesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogServiceRemote+ActiveFeaturesTests.swift"; sourceTree = "<group>"; };
+		FEE48EF72A4B3E43008A48E0 /* sites-site-active-features.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "sites-site-active-features.json"; sourceTree = "<group>"; };
+		FEE48EF92A4B3E50008A48E0 /* sites-site-no-active-features.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "sites-site-no-active-features.json"; sourceTree = "<group>"; };
 		FEE4EF56272FDD4B003CDA3C /* RemoteCommentV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteCommentV2.swift; sourceTree = "<group>"; };
 		FEE4EF58272FF78C003CDA3C /* CommentServiceRemoteREST+ApiV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentServiceRemoteREST+ApiV2.swift"; sourceTree = "<group>"; };
 		FEE4EF5A27302317003CDA3C /* CommentServiceRemoteREST+APIv2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CommentServiceRemoteREST+APIv2Tests.swift"; sourceTree = "<group>"; };
@@ -1598,6 +1604,7 @@
 			isa = PBXGroup;
 			children = (
 				74B5F0DD1EF82A9600B411E7 /* BlogServiceRemoteRESTTests.m */,
+				FEE48EF52A4B3602008A48E0 /* BlogServiceRemote+ActiveFeaturesTests.swift */,
 			);
 			name = Blog;
 			sourceTree = "<group>";
@@ -2294,6 +2301,8 @@
 				40819774221E497C00A298E4 /* stats-published-posts.json */,
 				404057DB221C9FD70060250C /* stats-referrer-data.json */,
 				404057C6221B36070060250C /* stats-search-term-result.json */,
+				FEE48EF72A4B3E43008A48E0 /* sites-site-active-features.json */,
+				FEE48EF92A4B3E50008A48E0 /* sites-site-no-active-features.json */,
 				40F9880D221ACFB400B7B369 /* stats-streak-result.json */,
 				404057CA221B80BC0060250C /* stats-top-authors.json */,
 				404057CF221C46780060250C /* stats-videos-data.json */,
@@ -2880,6 +2889,7 @@
 				E6B0461325E5B6F500DF6F4F /* sites-invites-links-disable.json in Resources */,
 				98E1A60D27AB621200C61A7F /* xmlrpc-site-comment-success.xml in Resources */,
 				74C473C71EF334D4009918F2 /* site-active-purchases-none-active-success.json in Resources */,
+				FEE48EFA2A4B3E50008A48E0 /* sites-site-no-active-features.json in Resources */,
 				FA87FE0D24EB4450003FBEE3 /* reader-post-comments-unsubscribe-success.json in Resources */,
 				98E1A60B27AB604600C61A7F /* site-comment-success.json in Resources */,
 				829BA4321FACF187003ADEEA /* activity-rewind-status-restore-finished.json in Resources */,
@@ -2970,6 +2980,7 @@
 				C738CAF928622BB1001BE107 /* qrlogin-authenticate-failed-400.json in Resources */,
 				74D67F1E1F15C3240010C5ED /* people-send-invitation-failure.json in Resources */,
 				7403A3001EF06FEB00DED7DC /* me-settings-success.json in Resources */,
+				FEE48EF82A4B3E43008A48E0 /* sites-site-active-features.json in Resources */,
 				439A44DE2107CF6F00795ED7 /* site-plans-v3-bad-json-failure.json in Resources */,
 				74B335EA1F06F76B0053A184 /* xmlrpc-response-getpost.xml in Resources */,
 				FEE4EF6127303361003CDA3C /* comments-v2-edit-context-success.json in Resources */,
@@ -3417,6 +3428,7 @@
 				4A1DEF46293051C600322608 /* LoggingTests.m in Sources */,
 				930999521F1658F800F006A1 /* ThemeServiceRemoteTests.m in Sources */,
 				8BE67ED324AD05D3004DB4C9 /* Decodable+DictionaryTests.swift in Sources */,
+				FEE48EF62A4B3602008A48E0 /* BlogServiceRemote+ActiveFeaturesTests.swift in Sources */,
 				74B335DA1F06F3D60053A184 /* WordPressComRestApiTests.swift in Sources */,
 				FA87FE0724EB39C4003FBEE3 /* ReaderPostServiceRemote+SubscriptionTests.swift in Sources */,
 				7403A2E61EF06F7000DED7DC /* AccountSettingsRemoteTests.swift in Sources */,

--- a/WordPressKit/RemoteBlog.swift
+++ b/WordPressKit/RemoteBlog.swift
@@ -34,6 +34,9 @@ import NSObject_SafeExpectations
     /// Indicates whether the current's blog plan is paid, or not.
     public var hasPaidPlan: Bool = false
 
+    /// Features available for the current blog's plan.
+    public var planActiveFeatures = [String]()
+
     /// Indicates whether it's a jetpack site, or not.
     public var jetpack: Bool = false
 
@@ -73,6 +76,7 @@ import NSObject_SafeExpectations
         self.planID = json.number(forKeyPath: "plan.product_id")
         self.planTitle = json.string(forKeyPath: "plan.product_name_short")
         self.hasPaidPlan = !(json.number(forKeyPath: "plan.is_free")?.boolValue ?? true)
+        self.planActiveFeatures = (json.array(forKeyPath: "plan.features.active") as? [String]) ?? []
         self.quotaSpaceAllowed = json.number(forKeyPath: "quota.space_allowed")
         self.quotaSpaceUsed = json.number(forKeyPath: "quota.space_used")
     }

--- a/WordPressKitTests/BlogServiceRemote+ActiveFeaturesTests.swift
+++ b/WordPressKitTests/BlogServiceRemote+ActiveFeaturesTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import WordPressKit
+
+class BlogServiceRemote_ActiveFeaturesTests: RemoteTestCase, RESTTestable {
+
+    private let siteID = NSNumber(value: 1001)
+    private let syncBlogWithFeaturesFilename = "sites-site-active-features.json"
+    private let syncBlogWithEmptyFeaturesFilename = "sites-site-no-active-features.json"
+
+    private var syncBlogEndpoint: String {
+        "/sites/\(siteID)"
+    }
+
+    private lazy var remote: BlogServiceRemoteREST = {
+        .init(wordPressComRestApi: getRestApi(), siteID: siteID)
+    }()
+
+    // MARK: Tests
+
+    func testSyncBlogParsesActiveFeatures() async throws {
+        stubRemoteResponse(syncBlogEndpoint, filename: syncBlogWithFeaturesFilename, contentType: .ApplicationJSON)
+
+        let blog = try await withCheckedThrowingContinuation { continuation in
+            remote.syncBlog { remoteBlog in
+                continuation.resume(returning: remoteBlog)
+            } failure: { error in
+                continuation.resume(throwing: error!)
+            }
+        }
+
+        let features = try XCTUnwrap(blog?.planActiveFeatures)
+        XCTAssertEqual(features.count, 3)
+    }
+
+    func testActiveFeaturesDefaultValue() async throws {
+        stubRemoteResponse(syncBlogEndpoint, filename: syncBlogWithEmptyFeaturesFilename, contentType: .ApplicationJSON)
+
+        let blog = try await withCheckedThrowingContinuation { continuation in
+            remote.syncBlog { remoteBlog in
+                continuation.resume(returning: remoteBlog)
+            } failure: { error in
+                continuation.resume(throwing: error!)
+            }
+        }
+
+        let features = try XCTUnwrap(blog?.planActiveFeatures)
+        XCTAssertTrue(features.isEmpty)
+    }
+}

--- a/WordPressKitTests/Mock Data/sites-site-active-features.json
+++ b/WordPressKitTests/Mock Data/sites-site-active-features.json
@@ -1,0 +1,163 @@
+{
+    "ID": 55555551,
+    "name": "Public Test Blog",
+    "description": "A fine WordPress.com site",
+    "URL": "https://test1.wordpress.com",
+    "user_can_manage": false,
+    "capabilities": {
+        "edit_pages": true,
+        "edit_posts": true,
+        "edit_others_posts": true,
+        "edit_others_pages": true,
+        "delete_posts": true,
+        "delete_others_posts": true,
+        "edit_theme_options": true,
+        "edit_users": false,
+        "list_users": true,
+        "manage_categories": true,
+        "manage_options": true,
+        "activate_wordads": true,
+        "promote_users": true,
+        "publish_posts": true,
+        "upload_files": true,
+        "delete_users": false,
+        "remove_users": true,
+        "view_stats": true
+    },
+    "jetpack": false,
+    "is_multisite": true,
+    "post_count": 25,
+    "subscribers_count": 51,
+    "lang": "en",
+    "logo": {
+        "id": 1987,
+        "sizes": {
+            "thumbnail": {
+                "height": 150,
+                "width": 113,
+                "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg?w=113",
+                "orientation": "portrait"
+            },
+            "medium": {
+                "height": 300,
+                "width": 225,
+                "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg?w=225",
+                "orientation": "portrait"
+            },
+            "large": {
+                "height": 960,
+                "width": 720,
+                "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg?w=720",
+                "orientation": "portrait"
+            },
+            "full": {
+                "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg",
+                "height": 4032,
+                "width": 3024,
+                "orientation": "portrait"
+            }
+        },
+        "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg"
+    },
+    "visible": true,
+    "is_private": false,
+    "single_user_site": false,
+    "is_vip": false,
+    "is_following": false,
+    "options": {
+        "blog_public": 1,
+        "timezone": "",
+        "gmt_offset": 0,
+        "videopress_enabled": false,
+        "upgraded_filetypes_enabled": false,
+        "login_url": "https://test1.wordpress.com/wp-login.php",
+        "admin_url": "https://test1.wordpress.com/wp-admin/",
+        "is_mapped_domain": false,
+        "is_redirect": false,
+        "unmapped_url": "https://test1.wordpress.com",
+        "featured_images_enabled": false,
+        "theme_slug": "pub/libretto",
+        "header_image": false,
+        "background_color": false,
+        "image_default_link_type": "file",
+        "image_thumbnail_width": 150,
+        "image_thumbnail_height": 150,
+        "image_thumbnail_crop": 0,
+        "image_medium_width": 300,
+        "image_medium_height": 300,
+        "image_large_width": 1024,
+        "image_large_height": 1024,
+        "permalink_structure": "/%year%/%monthnum%/%day%/%postname%/",
+        "post_formats": [],
+        "default_post_format": "standard",
+        "default_category": 1,
+        "allowed_file_types": [
+            "jpg",
+            "jpeg",
+            "png",
+            "gif",
+            "pdf",
+            "doc",
+            "ppt",
+            "odt",
+            "pptx",
+            "docx",
+            "pps",
+            "ppsx",
+            "xls",
+            "xlsx",
+            "key"
+        ],
+        "show_on_front": "posts",
+        "default_likes_enabled": true,
+        "default_sharing_status": true,
+        "default_comment_status": true,
+        "default_ping_status": true,
+        "software_version": "4.7.3",
+        "created_at": "2014-05-27T20:29:22+00:00",
+        "wordads": false,
+        "publicize_permanently_disabled": false,
+        "frame_nonce": "99cc88877b",
+        "headstart": false,
+        "headstart_is_fresh": false,
+        "ak_vp_bundle_enabled": null,
+        "advanced_seo_front_page_description": "",
+        "advanced_seo_title_formats": [],
+        "verification_services_codes": null,
+        "podcasting_archive": null,
+        "is_domain_only": false,
+        "is_automated_transfer": false
+    },
+    "plan": {
+        "product_id": 1,
+        "product_slug": "free_plan",
+        "product_name_short": "Free",
+        "free_trial": false,
+        "expired": false,
+        "user_is_owner": false,
+        "is_free": true,
+        "features": {
+            "active": [
+                "advanced-seo",
+                "social-shares-1000",
+                "donations"
+            ],
+            "available": {}
+        }
+    },
+    "meta": {
+        "links": {
+            "self": "https://public-api.wordpress.com/rest/v1.1/sites/55555551",
+            "help": "https://public-api.wordpress.com/rest/v1.1/sites/55555551/help",
+            "posts": "https://public-api.wordpress.com/rest/v1.1/sites/55555551/posts/",
+            "comments": "https://public-api.wordpress.com/rest/v1.1/sites/55555551/comments/",
+            "xmlrpc": "https://test1.wordpress.com/xmlrpc.php"
+        }
+    },
+    "quota": {
+        "space_allowed": 3221225472,
+        "space_used": 339047395,
+        "percent_used": 10.525416427602,
+        "space_available": 2882178077
+    }
+}

--- a/WordPressKitTests/Mock Data/sites-site-no-active-features.json
+++ b/WordPressKitTests/Mock Data/sites-site-no-active-features.json
@@ -1,0 +1,159 @@
+{
+    "ID": 55555551,
+    "name": "Public Test Blog",
+    "description": "A fine WordPress.com site",
+    "URL": "https://test1.wordpress.com",
+    "user_can_manage": false,
+    "capabilities": {
+        "edit_pages": true,
+        "edit_posts": true,
+        "edit_others_posts": true,
+        "edit_others_pages": true,
+        "delete_posts": true,
+        "delete_others_posts": true,
+        "edit_theme_options": true,
+        "edit_users": false,
+        "list_users": true,
+        "manage_categories": true,
+        "manage_options": true,
+        "activate_wordads": true,
+        "promote_users": true,
+        "publish_posts": true,
+        "upload_files": true,
+        "delete_users": false,
+        "remove_users": true,
+        "view_stats": true
+    },
+    "jetpack": false,
+    "is_multisite": true,
+    "post_count": 25,
+    "subscribers_count": 51,
+    "lang": "en",
+    "logo": {
+        "id": 1987,
+        "sizes": {
+            "thumbnail": {
+                "height": 150,
+                "width": 113,
+                "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg?w=113",
+                "orientation": "portrait"
+            },
+            "medium": {
+                "height": 300,
+                "width": 225,
+                "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg?w=225",
+                "orientation": "portrait"
+            },
+            "large": {
+                "height": 960,
+                "width": 720,
+                "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg?w=720",
+                "orientation": "portrait"
+            },
+            "full": {
+                "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg",
+                "height": 4032,
+                "width": 3024,
+                "orientation": "portrait"
+            }
+        },
+        "url": "https://test1.files.wordpress.com/2017/02/img_1111.jpg"
+    },
+    "visible": true,
+    "is_private": false,
+    "single_user_site": false,
+    "is_vip": false,
+    "is_following": false,
+    "options": {
+        "blog_public": 1,
+        "timezone": "",
+        "gmt_offset": 0,
+        "videopress_enabled": false,
+        "upgraded_filetypes_enabled": false,
+        "login_url": "https://test1.wordpress.com/wp-login.php",
+        "admin_url": "https://test1.wordpress.com/wp-admin/",
+        "is_mapped_domain": false,
+        "is_redirect": false,
+        "unmapped_url": "https://test1.wordpress.com",
+        "featured_images_enabled": false,
+        "theme_slug": "pub/libretto",
+        "header_image": false,
+        "background_color": false,
+        "image_default_link_type": "file",
+        "image_thumbnail_width": 150,
+        "image_thumbnail_height": 150,
+        "image_thumbnail_crop": 0,
+        "image_medium_width": 300,
+        "image_medium_height": 300,
+        "image_large_width": 1024,
+        "image_large_height": 1024,
+        "permalink_structure": "/%year%/%monthnum%/%day%/%postname%/",
+        "post_formats": [],
+        "default_post_format": "standard",
+        "default_category": 1,
+        "allowed_file_types": [
+            "jpg",
+            "jpeg",
+            "png",
+            "gif",
+            "pdf",
+            "doc",
+            "ppt",
+            "odt",
+            "pptx",
+            "docx",
+            "pps",
+            "ppsx",
+            "xls",
+            "xlsx",
+            "key"
+        ],
+        "show_on_front": "posts",
+        "default_likes_enabled": true,
+        "default_sharing_status": true,
+        "default_comment_status": true,
+        "default_ping_status": true,
+        "software_version": "4.7.3",
+        "created_at": "2014-05-27T20:29:22+00:00",
+        "wordads": false,
+        "publicize_permanently_disabled": false,
+        "frame_nonce": "99cc88877b",
+        "headstart": false,
+        "headstart_is_fresh": false,
+        "ak_vp_bundle_enabled": null,
+        "advanced_seo_front_page_description": "",
+        "advanced_seo_title_formats": [],
+        "verification_services_codes": null,
+        "podcasting_archive": null,
+        "is_domain_only": false,
+        "is_automated_transfer": false
+    },
+    "plan": {
+        "product_id": 1,
+        "product_slug": "free_plan",
+        "product_name_short": "Free",
+        "free_trial": false,
+        "expired": false,
+        "user_is_owner": false,
+        "is_free": true,
+        "features": {
+            "active": [],
+            "available": {}
+        }
+    },
+    "meta": {
+        "links": {
+            "self": "https://public-api.wordpress.com/rest/v1.1/sites/55555551",
+            "help": "https://public-api.wordpress.com/rest/v1.1/sites/55555551/help",
+            "posts": "https://public-api.wordpress.com/rest/v1.1/sites/55555551/posts/",
+            "comments": "https://public-api.wordpress.com/rest/v1.1/sites/55555551/comments/",
+            "xmlrpc": "https://test1.wordpress.com/xmlrpc.php"
+        }
+    },
+    "quota": {
+        "space_allowed": 3221225472,
+        "space_used": 339047395,
+        "percent_used": 10.525416427602,
+        "space_available": 2882178077
+    }
+}


### PR DESCRIPTION
### Description

Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/20806

As titled, this adds a new property, `planActiveFeatures`, which is an array of strings that lists the active features for the blog. In relation to the Jetpack Social project, we'll check this array to determine whether the blog has the auto-sharing limit.

### Testing Details

- Testing details will be provided via the related WordPress-iOS PR.
- Add some unit tests. Please ensure that the tests are passing 🟢.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
