### PR TITLE
[Privacy Compliance] Access modifier for IPLocationRemote init

### DIFF
--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -9,7 +9,7 @@ public final class IPLocationRemote {
 
     private let urlSession: URLSession
 
-    init(urlSession: URLSession = URLSession.shared) {
+    public init(urlSession: URLSession = URLSession.shared) {
         self.urlSession = urlSession
     }
 


### PR DESCRIPTION
### Description

Refs: https://github.com/wordpress-mobile/WordPress-iOS/issues/20711

Adds the necessary access modifier to init, so that it can be accessed from WP-iOS.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
