### PR TITLE
Bump version to 8.5.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,7 @@ _None._
 
 ### New Features
 
-- Add `IPLocationRemote` [#613]
-- Add `ui_status` field to `BlazeCampaign` [#611]
+_None._
 
 ### Bug Fixes
 
@@ -48,6 +47,13 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 8.5.0
+
+### New Features
+
+- Add `IPLocationRemote` [#613]
+- Add `ui_status` field to `BlazeCampaign` [#611]
 
 ## 8.4.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.5.0-beta.3'
+  s.version       = '8.5.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for Jetpack and WordPress iOS [22.8](https://github.com/wordpress-mobile/WordPress-iOS/milestone/250) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.