### PR TITLE
Fix incorrect parameter names used in the media library count API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Correctly set `mime_type` in media library count API calls [#620]
 
 ### Internal Changes
 

--- a/WordPressKit/MediaServiceRemoteREST.m
+++ b/WordPressKit/MediaServiceRemoteREST.m
@@ -101,7 +101,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{ @"number" : @1 }];
     if (mediaType) {
-        parameters[@"media_type"] = mediaType;
+        parameters[@"mime_type"] = mediaType;
     }
     
     [self.wordPressComRestApi GET:requestUrl

--- a/WordPressKit/MediaServiceRemoteXMLRPC.m
+++ b/WordPressKit/MediaServiceRemoteXMLRPC.m
@@ -80,7 +80,7 @@
 {
     NSDictionary *data = @{};
     if (mediaType) {
-        data = @{@"filter":@{ @"media_type": mediaType }};
+        data = @{@"filter":@{ @"mime_type": mediaType }};
     }
     NSArray *parameters = [self XMLRPCArgumentsWithExtra:data];
     [self.api callMethod:@"wp.getMediaLibrary"


### PR DESCRIPTION
### Description

Both [WP.com REST API][wp-com] and [the XML-RPC function][xml-rpc] accepts "mime_type" parameter instead of "media_type".

[wp-com]: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/media/
[xml-rpc]: https://codex.wordpress.org/XML-RPC_WordPress_API/Media#Parameters_2

### Testing Details

See https://github.com/wordpress-mobile/WordPress-iOS/pull/21181.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
