### PR TITLE
Add tests for mime_type setting behavior in media lib count API

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -3996,7 +3996,7 @@
 			repositoryURL = "https://github.com/buildkite/test-collector-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
+				minimumVersion = 0.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WordPressKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPressKit.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/buildkite/test-collector-swift",
       "state" : {
-        "revision" : "77c7f492f5c1c9ca159f73d18f56bbd1186390b0",
-        "version" : "0.3.0"
+        "revision" : "6e46839e1a4507ee047acd0896e29b9b278d9e3a",
+        "version" : "0.4.0"
       }
     }
   ],

--- a/WordPressKitTests/MediaServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/MediaServiceRemoteRESTTests.swift
@@ -214,16 +214,39 @@ class MediaServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
         XCTAssertEqual(mockRemoteApi.URLStringPassedIn, expectedPath, "Wrong path")
     }
 
-    func testGetMediaLibraryCount() {
-
+    func testGetMediaLibraryCountNoType() throws {
         let expectedCount = 3
         let response = ["found": expectedCount]
+
         var remoteCount = 0
         mediaServiceRemote.getMediaLibraryCount(forType: nil, withSuccess: { (count) in
             remoteCount = count
         }, failure: nil)
+        // Note: This needs to be called here, after triggerting the API request, or it won't take effect
+        // The behavior seems odd and ought to be researched.
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+
         XCTAssertEqual(remoteCount, expectedCount)
+        let params = try XCTUnwrap(mockRemoteApi.parametersPassedIn as? [String: Any])
+        XCTAssertNil(params["mime_type"] as? String)
+    }
+
+    func testGetMediaLibraryCountWithType() throws {
+        let expectedCount = 3
+        let response = ["found": expectedCount]
+
+        var remoteCount = 0
+        mediaServiceRemote.getMediaLibraryCount(forType: "a_type", withSuccess: { (count) in
+            remoteCount = count
+        }, failure: nil)
+        // Note: This needs to be called here, after triggerting the API request, or it won't take effect.
+        // The behavior seems odd and ought to be researched.
+        mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
+
+        XCTAssertEqual(remoteCount, expectedCount)
+        let params = try XCTUnwrap(mockRemoteApi.parametersPassedIn as? [String: Any])
+        let type = try XCTUnwrap(params["mime_type"] as? String)
+        XCTAssertEqual(type, "a_type")
     }
 
     func testRemoteMediaJSONParsing() {


### PR DESCRIPTION
Adds tests for part of the changes in #620.

### Testing Details

CI will verify if the new unit tests are correct

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file. – N.A.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. – N.A.
