### PR TITLE
Bump version to 8.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,17 @@ _None._
 
 ### Bug Fixes
 
-- Correctly set `mime_type` in media library count API calls [#620]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 8.5.1
+
+### Bug Fixes
+
+- Correctly set `mime_type` in media library count API calls [#620]
 
 ## 8.5.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.5.0'
+  s.version       = '8.5.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for [WordPress iOS 22.30](https://github.com/wordpress-mobile/WordPress-iOS/issues?q=milestone%3A%2223.0%22+sort%3Aupdated-desc+) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.