### PR TITLE
Add unit tests for the MediaServiceRemote.getMediaLibrary API

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -145,6 +145,8 @@
 		4A68E3DD294070A7004AC3DC /* RemoteReaderSite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E3DC294070A7004AC3DC /* RemoteReaderSite.swift */; };
 		4A68E3DF29407100004AC3DC /* RemoteReaderTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E3DE29407100004AC3DC /* RemoteReaderTopic.swift */; };
 		4A68E3E1294076C1004AC3DC /* RemoteReaderSiteInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E3E0294076C1004AC3DC /* RemoteReaderSiteInfo.swift */; };
+		4AA5A1A32AA68F6B00969464 /* MediaLibraryTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5A1A22AA68F6B00969464 /* MediaLibraryTestSupport.swift */; };
+		4AA5A1A52AA695D700969464 /* LoadMediaLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5A1A42AA695D700969464 /* LoadMediaLibraryTests.swift */; };
 		57BCD3D426209D9500292CB3 /* AppTransportSecuritySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */; };
 		730E869F21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */; };
 		731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */; };
@@ -827,6 +829,8 @@
 		4A68E3DC294070A7004AC3DC /* RemoteReaderSite.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteReaderSite.swift; sourceTree = "<group>"; };
 		4A68E3DE29407100004AC3DC /* RemoteReaderTopic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteReaderTopic.swift; sourceTree = "<group>"; };
 		4A68E3E0294076C1004AC3DC /* RemoteReaderSiteInfo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteReaderSiteInfo.swift; sourceTree = "<group>"; };
+		4AA5A1A22AA68F6B00969464 /* MediaLibraryTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryTestSupport.swift; sourceTree = "<group>"; };
+		4AA5A1A42AA695D700969464 /* LoadMediaLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadMediaLibraryTests.swift; sourceTree = "<group>"; };
 		57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTransportSecuritySettings.swift; sourceTree = "<group>"; };
 		6C2A33D76FD1052D6F30466D /* Pods-WordPressKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.debug.xcconfig"; sourceTree = "<group>"; };
 		6F2E0CC4FA01B5475A378DA2 /* Pods-WordPressKitTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -1667,6 +1671,8 @@
 			isa = PBXGroup;
 			children = (
 				74FA25F61F1FDA200044BC54 /* MediaServiceRemoteRESTTests.swift */,
+				4AA5A1A22AA68F6B00969464 /* MediaLibraryTestSupport.swift */,
+				4AA5A1A42AA695D700969464 /* LoadMediaLibraryTests.swift */,
 			);
 			name = Media;
 			sourceTree = "<group>";
@@ -3371,6 +3377,7 @@
 				E1E89C6A1FD6BDB1006E7A33 /* PluginDirectoryTests.swift in Sources */,
 				9F3E0BAA20873773009CB5BA /* MockServiceRequest.swift in Sources */,
 				8B2F4BE524ABB3C70056C08A /* RemoteReaderPostTests.m in Sources */,
+				4AA5A1A32AA68F6B00969464 /* MediaLibraryTestSupport.swift in Sources */,
 				748437EF1F1D4D8B00E8DDAF /* MenusServiceRemoteTests.m in Sources */,
 				73D5930121E550F500E4CF84 /* SiteVerticalsResponseDecodingTests.swift in Sources */,
 				FE5096682A309E4600DDD071 /* JetpackSocialServiceRemoteTests.swift in Sources */,
@@ -3453,6 +3460,7 @@
 				73D5930521E5541200E4CF84 /* WordPressComServiceRemoteTests+SiteVerticals.swift in Sources */,
 				8BB5F62427A9A5D100B2FFAF /* DashboardServiceRemoteTests.swift in Sources */,
 				0152100C28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift in Sources */,
+				4AA5A1A52AA695D700969464 /* LoadMediaLibraryTests.swift in Sources */,
 				17CE77F420C701C8001DEA5A /* ReaderSiteSearchServiceRemoteTests.swift in Sources */,
 				73A2F38D21E7FC8200388609 /* WordPressComServiceRemoteTests+SiteVerticalsPrompt.swift in Sources */,
 				74C473AF1EF2F7D1009918F2 /* SiteManagementServiceRemoteTests.swift in Sources */,

--- a/WordPressKit/MediaServiceRemote.h
+++ b/WordPressKit/MediaServiceRemote.h
@@ -38,7 +38,14 @@
             failure:(void (^)(NSError *error))failure;
 
 /**
- *  Get Media items from blog using the options parameter.
+ *  Get all WordPress Media Library items in batches.
+ *
+ *  The `pageLoad` block is called with media items in each page, except the last page. If there is only one page of media
+ *  items, the `pageLoad` block will not be called.
+ *
+ *  The `success` block is called with all media items in the Media Library. Calling this block marks the end of the loading.
+ *
+ *  The `failure` block is called when any API call fails. Calling this block marks the end of the loading.
  *
  *  @param pageLoad a block to be executed when each page of media is loaded.
  *  @param success a block to be executed when the request finishes with success.

--- a/WordPressKitTests/LoadMediaLibraryTests.swift
+++ b/WordPressKitTests/LoadMediaLibraryTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import XCTest
+
+@testable import WordPressKit
+
+private enum Kind {
+    case wpcom
+    case xmlrpc
+}
+
+// This test case is for the `-[MediaServiceRemote getMediaLibraryWithPageLoad:success:failure:]` method, which is
+// implemented in `MediaServiceRemoteREST` and `MediaServiceRemoteXMLRPC`. The test functions in this test case are
+// created to ensure both implementation shares the same behaviour.
+//
+// See the `-[MediaServiceRemote getMediaLibraryWithPageLoad:success:failure:]` API doc for its expected behaviours.
+class LoadMediaLibraryTests: XCTestCase {
+
+    fileprivate var kind: Kind = .wpcom
+
+    func testSmallLibrary() {
+        let mediaLibrary = MediaLibraryTestSupport(total: 50)
+        let (pageLoad, success, failure) = load(mediaLibrary: mediaLibrary, failAtPage: -1)
+        XCTAssertEqual(pageLoad.count, 0)
+        XCTAssertEqual(success?.count, 50)
+        XCTAssertNil(failure)
+    }
+
+    func testTwoPageLibrary() {
+        let mediaLibrary = MediaLibraryTestSupport(total: 120)
+        let (pageLoad, success, failure) = load(mediaLibrary: mediaLibrary, failAtPage: -1)
+        XCTAssertEqual(pageLoad.count, 1)
+        XCTAssertEqual(success?.count, 120)
+        XCTAssertNil(failure)
+    }
+
+    func testLargeLibrary() {
+        let mediaLibrary = MediaLibraryTestSupport(total: 650)
+        let (pageLoad, success, failure) = load(mediaLibrary: mediaLibrary, failAtPage: -1)
+        XCTAssertEqual(pageLoad.count, 6)
+        XCTAssertEqual(success?.count, 650)
+        XCTAssertNil(failure)
+    }
+
+    func testFailure() {
+        let mediaLibrary = MediaLibraryTestSupport(total: 550)
+        let (pageLoad, success, failure) = load(mediaLibrary: mediaLibrary, failAtPage: 3)
+        XCTAssertEqual(pageLoad.count, 2)
+        XCTAssertNil(success)
+        XCTAssertNotNil(failure)
+
+        let loaded = pageLoad.map { $0?.count ?? 0 }.reduce(0, +)
+        XCTAssertEqual(loaded, 200)
+    }
+
+}
+
+private extension LoadMediaLibraryTests {
+
+    func load(mediaLibrary: MediaLibraryTestSupport, failAtPage: Int) -> MediaLibraryResult {
+        let remote: MediaServiceRemote
+
+        switch kind {
+        case .wpcom:
+            remote = MediaServiceRemoteREST(wordPressComRestApi: WordPressComRestApi(), siteID: 42)
+            mediaLibrary.stubREST(siteID: 42, failAtPage: failAtPage)
+        case .xmlrpc:
+            let rpcURL = URL(string: "https://site.com/xmlrpc")!
+            remote = MediaServiceRemoteXMLRPC(api: WordPressOrgXMLRPCApi(endpoint: rpcURL), username: "user", password: "pass")
+            mediaLibrary.stubRPC(endpoint: rpcURL, failAtPage: failAtPage)
+        }
+
+        return waitForLoadingMediaLibrary(using: remote)
+    }
+
+    /// Wait for the `getMediaLibrary` API call to finish, and return all the potential results.
+    func waitForLoadingMediaLibrary(using remote: MediaServiceRemote) -> MediaLibraryResult {
+        var result: MediaLibraryResult = ([], nil, nil)
+
+        let finished = expectation(description: "Finish loading WordPress Media Library")
+        remote.getMediaLibrary {
+            result.pageLoad.append($0)
+        } success: {
+            result.success = $0
+            finished.fulfill()
+        } failure: { error in
+            result.failure = error
+            finished.fulfill()
+        }
+
+        wait(for: [finished], timeout: 5000)
+
+        return result
+    }
+}
+
+/// Each tuple element contains the arguments passed to their corresponding block that's passed to the
+/// `-[MediaServiceRemote getMediaLibraryWithPageLoad:success:failure:]` method.
+///
+/// `pageLoad` is a list of lists, because the `pageLoad` block may gets called multiple times.
+///
+/// - SeeAlso `-[MediaServiceRemote getMediaLibraryWithPageLoad:success:failure:]`
+private typealias MediaLibraryResult = (pageLoad: [[Any]?], success: [Any]?, failure: Error?)
+
+class LoadMediaLibraryRPCTests: LoadMediaLibraryTests {
+
+    override func setUp() {
+        kind = .xmlrpc
+    }
+
+}

--- a/WordPressKitTests/LoadMediaLibraryTests.swift
+++ b/WordPressKitTests/LoadMediaLibraryTests.swift
@@ -87,7 +87,7 @@ private extension LoadMediaLibraryTests {
             finished.fulfill()
         }
 
-        wait(for: [finished], timeout: 5000)
+        wait(for: [finished], timeout: 0.5)
 
         return result
     }

--- a/WordPressKitTests/LoadMediaLibraryTests.swift
+++ b/WordPressKitTests/LoadMediaLibraryTests.swift
@@ -18,7 +18,7 @@ class LoadMediaLibraryTests: XCTestCase {
     fileprivate var kind: Kind = .wpcom
 
     func testSmallLibrary() {
-        let mediaLibrary = MediaLibraryTestSupport(total: 50)
+        let mediaLibrary = MediaLibraryTestSupport(totalMedia: 50)
         let (pageLoad, success, failure) = load(mediaLibrary: mediaLibrary, failAtPage: -1)
         XCTAssertEqual(pageLoad.count, 0)
         XCTAssertEqual(success?.count, 50)
@@ -26,7 +26,7 @@ class LoadMediaLibraryTests: XCTestCase {
     }
 
     func testTwoPageLibrary() {
-        let mediaLibrary = MediaLibraryTestSupport(total: 120)
+        let mediaLibrary = MediaLibraryTestSupport(totalMedia: 120)
         let (pageLoad, success, failure) = load(mediaLibrary: mediaLibrary, failAtPage: -1)
         XCTAssertEqual(pageLoad.count, 1)
         XCTAssertEqual(success?.count, 120)
@@ -34,7 +34,7 @@ class LoadMediaLibraryTests: XCTestCase {
     }
 
     func testLargeLibrary() {
-        let mediaLibrary = MediaLibraryTestSupport(total: 650)
+        let mediaLibrary = MediaLibraryTestSupport(totalMedia: 650)
         let (pageLoad, success, failure) = load(mediaLibrary: mediaLibrary, failAtPage: -1)
         XCTAssertEqual(pageLoad.count, 6)
         XCTAssertEqual(success?.count, 650)
@@ -42,7 +42,7 @@ class LoadMediaLibraryTests: XCTestCase {
     }
 
     func testFailure() {
-        let mediaLibrary = MediaLibraryTestSupport(total: 550)
+        let mediaLibrary = MediaLibraryTestSupport(totalMedia: 550)
         let (pageLoad, success, failure) = load(mediaLibrary: mediaLibrary, failAtPage: 3)
         XCTAssertEqual(pageLoad.count, 2)
         XCTAssertNil(success)

--- a/WordPressKitTests/MediaLibraryTestSupport.swift
+++ b/WordPressKitTests/MediaLibraryTestSupport.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 import UniformTypeIdentifiers
 import OHHTTPStubs
 import wpxmlrpc
@@ -103,7 +104,7 @@ extension MediaLibraryTestSupport {
             return .init(data: Data(), statusCode: 200, headers: nil)
         }
 
-        assert(delegate.methodName == "wp.getMediaLibrary")
+        XCTAssertEqual(delegate.methodName, "wp.getMediaLibrary")
 
         let number = delegate.params["number"] as? Int ?? 100
         let offset = delegate.params["offset"] as? Int ?? 0

--- a/WordPressKitTests/MediaLibraryTestSupport.swift
+++ b/WordPressKitTests/MediaLibraryTestSupport.swift
@@ -30,8 +30,8 @@ class MediaLibraryTestSupport {
         }
     }
 
-    init(total: Int) {
-        media = (1...total).map { id in
+    init(totalMedia: Int) {
+        media = (1...totalMedia).map { id in
             Media(
                 mediaID: id,
                 postID: (1...12345).randomElement()!,

--- a/WordPressKitTests/MediaLibraryTestSupport.swift
+++ b/WordPressKitTests/MediaLibraryTestSupport.swift
@@ -1,0 +1,196 @@
+import Foundation
+import UniformTypeIdentifiers
+import OHHTTPStubs
+import wpxmlrpc
+
+/// This type acts like a WordPress Media Library. It can be used in test cases to stub loading media library content
+/// API calls and provides a close-to-production API responses, which relieves test cases from the burden of creating
+/// appropriate responses.
+///
+/// This class creates many dummy media items upon initlisation. Test cases can call the `stubREST` or `stubRPC`
+/// function to create an HTTP stub for WordPress.com REST API or WordPress XML-RPC API that are used in the
+/// `-[MediaServiceRemote getMediaLibraryWithPageLoad:success:failure:]` method. The stubs parse the pagination
+/// parameters in the API requests and returns appropriate media items accordingly.
+class MediaLibraryTestSupport {
+    private let media: [Media]
+
+    private var restStub: HTTPStubsDescriptor? {
+        didSet {
+            if let oldValue {
+                HTTPStubs.removeStub(oldValue)
+            }
+        }
+    }
+
+    private var rpcStub: HTTPStubsDescriptor? {
+        didSet {
+            if let oldValue {
+                HTTPStubs.removeStub(oldValue)
+            }
+        }
+    }
+
+    init(total: Int) {
+        media = (1...total).map { id in
+            Media(
+                mediaID: id,
+                postID: (1...12345).randomElement()!,
+                mimeType: ["image/png", "audio/mp3", "video/mp4"].randomElement()!,
+                cusor: UUID().uuidString
+            )
+        }
+    }
+
+    deinit {
+        restStub = nil
+        rpcStub = nil
+    }
+}
+
+extension MediaLibraryTestSupport {
+
+    func stubREST(siteID: Int, failAtPage pageToFail: Int) {
+        restStub = stub(condition: isPath("/rest/v1.1/sites/\(siteID)/media")) { [weak self] request in
+            self?.handleREST(request: request, failAtPage: pageToFail) ?? .init(error: URLError(.networkConnectionLost))
+        }
+    }
+
+    private func handleREST(request: URLRequest, failAtPage pageToFail: Int) -> HTTPStubsResponse {
+        let cursor = request.url?.query("page_handle") ?? nil
+        let number = request.url?.query("number").flatMap(Int.init(_:)) ?? 100
+
+        let cursorIndex = media.firstIndex { $0.cusor == cursor } ?? 0
+        let requestPage = (cursorIndex / number) + 1
+
+        if pageToFail == requestPage {
+            return .init(error: URLError(.cannotFindHost))
+        }
+
+        let range = cursorIndex...min(cursorIndex + number - 1, media.count - 1)
+        let json: [String: Any] = [
+            "media": media[range].map { $0.asRESTResponse() },
+            "meta": [
+                "next_page": range.upperBound + 1 < media.count ? media[range.upperBound + 1].cusor : ""
+            ]
+        ]
+
+        return .init(jsonObject: json, statusCode: 200, headers: nil)
+    }
+
+}
+
+extension MediaLibraryTestSupport {
+
+    func stubRPC(endpoint: URL, failAtPage pageToFail: Int) {
+        rpcStub = stub(condition: isMethodPOST() && isAbsoluteURLString(endpoint.absoluteString)) { [weak self] request in
+            self?.handleRPC(request: request, failAtPage: pageToFail) ?? .init(error: URLError(.networkConnectionLost))
+        }
+    }
+
+    private func handleRPC(request: URLRequest, failAtPage pageToFail: Int) -> HTTPStubsResponse {
+        let parser: XMLParser
+        if let stream = request.httpBodyStream {
+            parser = XMLParser(stream: stream)
+        } else if let body = request.httpBody {
+            parser = XMLParser(data: body)
+        } else {
+            return .init(error: URLError(.cannotDecodeContentData))
+        }
+
+        let delegate = RequestParser()
+        parser.delegate = delegate
+        guard parser.parse() else {
+            return .init(data: Data(), statusCode: 200, headers: nil)
+        }
+
+        assert(delegate.methodName == "wp.getMediaLibrary")
+
+        let number = delegate.params["number"] as? Int ?? 100
+        let offset = delegate.params["offset"] as? Int ?? 0
+        let requestPage = (offset / number) + 1
+
+        if pageToFail == requestPage {
+            return .init(error: URLError(.cannotFindHost))
+        }
+
+        let range = offset...min(offset + number - 1, media.count - 1)
+
+        do {
+            let data = try WPXMLRPCEncoder(responseParams: [media[range].map { $0.asRPCResponse() }]).dataEncoded()
+            return .init(data: data, statusCode: 200, headers: ["Content-Type": "application/xml"])
+        } catch {
+            return .init(error: error)
+        }
+    }
+
+    private class RequestParser: NSObject, XMLParserDelegate {
+        var elementPath: [String] = []
+        var methodName: String?
+        var params: [String: Any] = [:]
+        var content: String?
+        var paramName: String?
+
+        func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String] = [:]) {
+            elementPath.append(elementName)
+        }
+
+        func parser(_ parser: XMLParser, foundCharacters string: String) {
+            self.content = string
+        }
+
+        func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
+            assert(elementName == elementPath.last)
+
+            defer {
+                self.content = nil
+                elementPath.removeLast()
+            }
+
+            switch elementPath {
+            case ["methodCall", "methodName"]:
+                self.methodName = self.content
+            case ["methodCall", "params", "param", "value", "struct", "member", "name"]:
+                self.paramName = self.content
+            case ["methodCall", "params", "param", "value", "struct", "member", "value", "i4"]:
+                self.params[self.paramName!] = Int(self.content!)
+                self.paramName = nil
+            default:
+                break
+            }
+        }
+    }
+
+}
+
+private struct Media: Codable {
+    var mediaID: Int
+    var postID: Int
+    var mimeType: String
+
+    var cusor: String
+
+    func asRESTResponse() -> [String: Any] {
+        [
+            "ID": mediaID,
+            "post_ID": postID,
+            "mime_type": mimeType
+        ]
+    }
+
+    func asRPCResponse() -> [String: Any] {
+        [
+            "id": mediaID,
+            "parent": postID,
+            "type": mimeType
+        ]
+    }
+}
+
+private extension URL {
+    func query(_ name: String) -> String? {
+        URLComponents(url: self, resolvingAgainstBaseURL: true)?
+            .queryItems?
+            .first { $0.name == name }?
+            .value
+    }
+}


### PR DESCRIPTION
### Description

While working on the media areas on the Jetpack/WordPress app, I noticed the `-[MediaServiceRemote getMediaLibraryWithPageLoad:success:failure:]` method has somewhat unconventional behaviors. Its implementations (WP.com REST API and XML-RPC API) makes paginated API requests and returns the API call results to the caller via the `pageLoad` block. It also calls the `success` block with all the media items.

I thought it might be valuable to write tests to ensure the API behaviour is maintained in all future releases, and most importantly ensure the API behaviour is consistent between REST API and XML-RPC API implementations.

I created a `MediaLibraryTestSupport` type to stub "load Media Library" HTTP requests. The implementation is complicated enough that I feel like it's worthy adding a "meta test" for it. I'm open to that idea if you think it might be useful.

### Testing Details

It should be all good if CI passes.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
