### PR TITLE
Exclude dot blog subdomains from freeAndPaid domain query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 8.5.2
+
+### Bug Fixes
+
+- Exclude dot blog subdomains from freeAndPaid domain query [#627]
+
 ## 8.5.1
 
 ### Bug Fixes

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.5.1'
+  s.version       = '8.5.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/DomainsServiceRemote.swift
+++ b/WordPressKit/DomainsServiceRemote.swift
@@ -79,7 +79,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         case onlyWordPressDotCom
         case wordPressDotComAndDotBlogSubdomains
 
-        /// Includes free dotcom and dotblog sudomains and paid domains.
+        /// Includes free dotcom sudomains and paid domains.
         case freeAndPaid
 
         case allowlistedTopLevelDomains([String])
@@ -99,7 +99,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
                         "only_wordpressdotcom": true as AnyObject,
                         "include_wordpressdotcom": true as AnyObject]
             case .freeAndPaid:
-                return ["include_dotblogsubdomain": true as AnyObject,
+                return ["include_dotblogsubdomain": false as AnyObject,
                         "include_wordpressdotcom": true as AnyObject,
                         "vendor": "mobile" as AnyObject]
             case .allowlistedTopLevelDomains(let allowlistedTLDs):


### PR DESCRIPTION
### Description

freeAndPaid query on the web excludes dot blog subdomains and only includes wordpress dot com subdomains. Using the same behavior on iOS.

Related to https://github.com/wordpress-mobile/WordPress-iOS/pull/21654, the draft PR contains videos and more explanations.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered updating the `version` in the `.podspec` file.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
