### PR TITLE
Created functionality to add domain with a plan to a cart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 8.6.0
+
+### Bug Fixes
+
+- Add `createShoppingCart` method to add domains and plans when creating a new cart [#628]
+
 ## 8.5.2
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ _None._
 
 ## 8.6.0
 
-### Bug Fixes
+### New Features
 
 - Add `createShoppingCart` method to add domains and plans when creating a new cart [#628]
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.5.2'
+  s.version       = '8.6.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/TransactionsServiceRemote.swift
+++ b/WordPressKit/TransactionsServiceRemote.swift
@@ -55,12 +55,12 @@ import WordPressShared
         for product in products {
             switch product {
             case .domain(let domainSuggestion, let privacyProtectionEnabled):
-                productsDictionary.append(["product_id":domainSuggestion.productID as AnyObject,
+                productsDictionary.append(["product_id": domainSuggestion.productID as AnyObject,
                                            "meta": domainSuggestion.domainName as AnyObject,
                                            "extra": ["privacy": privacyProtectionEnabled] as AnyObject])
 
             case .plan(let productId):
-                productsDictionary.append(["product_id":productId as AnyObject])
+                productsDictionary.append(["product_id": productId as AnyObject])
             case .other(let productDict):
                 productsDictionary.append(productDict)
             }


### PR DESCRIPTION
### Description

Parent PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/21667

Created functionality to add a domain with a plan to a cart.

Until this change, we had `createTemporaryDomainShoppingCart`, and `createPersistentDomainShoppingCart` methods which are domain-specific and not flexible.

`createShoppingCart` method reuses the whole functionality of `createDomainShoppingCart` and instead of `DomainSuggestion` accepts an array of domains, plans, or other types of products.

Leaving public `createTemporaryDomainShoppingCart`, and `createPersistentDomainShoppingCart` methods existing for backward compatibility but adding deprecation warnings, since now `createShoppingCart` can be used for all the cases.

### Example usage

```
        transactionsServiceRemote.createShoppingCart(
            siteID: siteID,
            products:[
                .domain(domainSuggestion, privacyProtectionEnabled),
                .plan(1009)
            ],
            temporary: false,
            success: success,
            failure: failure
        )
```


Related to https://github.com/wordpress-mobile/WordPress-iOS/issues/21636

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

Check the testing detail on https://github.com/wordpress-mobile/WordPress-iOS/pull/21667


ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
