### PR TITLE
Add Webauthn endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ _None._
 ### New Features
 
 - Add `createShoppingCart` method to add domains and plans when creating a new cart [#628]
+- Update `WordPressComOAuthClient` to add support to webauthn endpoints.
 
 ## 8.5.2
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.6.0-beta.2'
+  s.version       = '8.7.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.6.0-beta.1'
+  s.version       = '8.6.0-beta.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -33,6 +33,7 @@
 		1DF972C129B107E7007A72BC /* videopress-site-default-video.json in Resources */ = {isa = PBXBuildFile; fileRef = 1DF972BE29B107E7007A72BC /* videopress-site-default-video.json */; };
 		240315B0A1D6C2B981572B5B /* Pods_WordPressKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED05C8FF3E61D93CE5BA527E /* Pods_WordPressKitTests.framework */; };
 		24ADA24E24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24D24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift */; };
+		264E09B32AD0B3BB004B5A5F /* WebauthChallengeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264E09B22AD0B3BB004B5A5F /* WebauthChallengeInfo.swift */; };
 		3236F77824AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */; };
 		3236F79A24AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */; };
 		3236F79C24AE413A0088E8F3 /* reader-interests-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 3236F79B24AE413A0088E8F3 /* reader-interests-success.json */; };
@@ -716,6 +717,7 @@
 		1DF972BD29B107E7007A72BC /* videopress-public-video.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "videopress-public-video.json"; sourceTree = "<group>"; };
 		1DF972BE29B107E7007A72BC /* videopress-site-default-video.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "videopress-site-default-video.json"; sourceTree = "<group>"; };
 		24ADA24D24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagSerializationTest.swift; sourceTree = "<group>"; };
+		264E09B22AD0B3BB004B5A5F /* WebauthChallengeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebauthChallengeInfo.swift; sourceTree = "<group>"; };
 		264F5C834541BBF2018F4964 /* Pods-WordPressKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemote+Interests.swift"; sourceTree = "<group>"; };
 		3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemote+InterestsTests.swift"; sourceTree = "<group>"; };
@@ -2060,6 +2062,7 @@
 				436D563B2118E18D00CEAA33 /* WPState.swift */,
 				E1D6B555200E46F200325669 /* WPTimeZone.swift */,
 				E632D7771F6E047400297F6D /* SocialLogin2FANonceInfo.swift */,
+				264E09B22AD0B3BB004B5A5F /* WebauthChallengeInfo.swift */,
 				17CE77F020C6EB41001DEA5A /* ReaderFeed.swift */,
 				32E1DD22236AA09A008914B0 /* RemotePostAutosave.swift */,
 				F9E56DF524EB11EF00916770 /* FeatureFlag.swift */,
@@ -3334,6 +3337,7 @@
 				74A44DD11F13C64B006CD8F4 /* RemoteNotificationSettings.swift in Sources */,
 				FEF7419D28085D89002C4203 /* RemoteBloggingPrompt.swift in Sources */,
 				74DA56331F06EAF000FE9BF4 /* MediaServiceRemoteREST.m in Sources */,
+				264E09B32AD0B3BB004B5A5F /* WebauthChallengeInfo.swift in Sources */,
 				17CD0CC320C58A0D000D9620 /* ReaderSiteSearchServiceRemote.swift in Sources */,
 				74DA563B1F06EB3000FE9BF4 /* RemoteMedia.m in Sources */,
 				9311A6861F22625A00704AC9 /* RemoteTaxonomyPaging.m in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		264E09B32AD0B3BB004B5A5F /* WebauthChallengeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264E09B22AD0B3BB004B5A5F /* WebauthChallengeInfo.swift */; };
 		264E09B52AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json in Resources */ = {isa = PBXBuildFile; fileRef = 264E09B42AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json */; };
 		264E09B72AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json in Resources */ = {isa = PBXBuildFile; fileRef = 264E09B62AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json */; };
+		264E09B92AD2709A004B5A5F /* WordPressComOAuthNeedsWebauthnMFA.json in Resources */ = {isa = PBXBuildFile; fileRef = 264E09B82AD2709A004B5A5F /* WordPressComOAuthNeedsWebauthnMFA.json */; };
 		3236F77824AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */; };
 		3236F79A24AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */; };
 		3236F79C24AE413A0088E8F3 /* reader-interests-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 3236F79B24AE413A0088E8F3 /* reader-interests-success.json */; };
@@ -722,6 +723,7 @@
 		264E09B22AD0B3BB004B5A5F /* WebauthChallengeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebauthChallengeInfo.swift; sourceTree = "<group>"; };
 		264E09B42AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WordPressComOAuthRequestChallenge.json; sourceTree = "<group>"; };
 		264E09B62AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WordPressComOAuthAuthenticateSignature.json; sourceTree = "<group>"; };
+		264E09B82AD2709A004B5A5F /* WordPressComOAuthNeedsWebauthnMFA.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WordPressComOAuthNeedsWebauthnMFA.json; sourceTree = "<group>"; };
 		264F5C834541BBF2018F4964 /* Pods-WordPressKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemote+Interests.swift"; sourceTree = "<group>"; };
 		3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemote+InterestsTests.swift"; sourceTree = "<group>"; };
@@ -2350,6 +2352,7 @@
 				FFE247AB20C891E5002DF3A2 /* WordPressComAuthenticateWithIDTokenBearerTokenSuccess.json */,
 				FFE247AE20C891E6002DF3A2 /* WordPressComAuthenticateWithIDTokenExistingUserNeedsConnection.json */,
 				FFE247AC20C891E5002DF3A2 /* WordPressComOAuthNeeds2FAFail.json */,
+				264E09B82AD2709A004B5A5F /* WordPressComOAuthNeedsWebauthnMFA.json */,
 				264E09B42AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json */,
 				264E09B62AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json */,
 				FFE247AD20C891E5002DF3A2 /* WordPressComOAuthSuccess.json */,
@@ -3006,6 +3009,7 @@
 				74FC6F431F191C1D00112505 /* notifications-load-all.json in Resources */,
 				74C473C11EF32C74009918F2 /* site-export-missing-status-failure.json in Resources */,
 				1DF972C129B107E7007A72BC /* videopress-site-default-video.json in Resources */,
+				264E09B92AD2709A004B5A5F /* WordPressComOAuthNeedsWebauthnMFA.json in Resources */,
 				828A2400201B671F004F6859 /* activity-restore-success.json in Resources */,
 				826016FC1F9FAF6300533B6C /* activity-log-success-2.json in Resources */,
 				C738CAF928622BB1001BE107 /* qrlogin-authenticate-failed-400.json in Resources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		240315B0A1D6C2B981572B5B /* Pods_WordPressKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = ED05C8FF3E61D93CE5BA527E /* Pods_WordPressKitTests.framework */; };
 		24ADA24E24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24ADA24D24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift */; };
 		264E09B32AD0B3BB004B5A5F /* WebauthChallengeInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264E09B22AD0B3BB004B5A5F /* WebauthChallengeInfo.swift */; };
+		264E09B52AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json in Resources */ = {isa = PBXBuildFile; fileRef = 264E09B42AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json */; };
+		264E09B72AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json in Resources */ = {isa = PBXBuildFile; fileRef = 264E09B62AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json */; };
 		3236F77824AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */; };
 		3236F79A24AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */; };
 		3236F79C24AE413A0088E8F3 /* reader-interests-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 3236F79B24AE413A0088E8F3 /* reader-interests-success.json */; };
@@ -718,6 +720,8 @@
 		1DF972BE29B107E7007A72BC /* videopress-site-default-video.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "videopress-site-default-video.json"; sourceTree = "<group>"; };
 		24ADA24D24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagSerializationTest.swift; sourceTree = "<group>"; };
 		264E09B22AD0B3BB004B5A5F /* WebauthChallengeInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebauthChallengeInfo.swift; sourceTree = "<group>"; };
+		264E09B42AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WordPressComOAuthRequestChallenge.json; sourceTree = "<group>"; };
+		264E09B62AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = WordPressComOAuthAuthenticateSignature.json; sourceTree = "<group>"; };
 		264F5C834541BBF2018F4964 /* Pods-WordPressKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3236F77724AE34B40088E8F3 /* ReaderTopicServiceRemote+Interests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemote+Interests.swift"; sourceTree = "<group>"; };
 		3236F79924AE406D0088E8F3 /* ReaderTopicServiceRemote+InterestsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderTopicServiceRemote+InterestsTests.swift"; sourceTree = "<group>"; };
@@ -2346,6 +2350,8 @@
 				FFE247AB20C891E5002DF3A2 /* WordPressComAuthenticateWithIDTokenBearerTokenSuccess.json */,
 				FFE247AE20C891E6002DF3A2 /* WordPressComAuthenticateWithIDTokenExistingUserNeedsConnection.json */,
 				FFE247AC20C891E5002DF3A2 /* WordPressComOAuthNeeds2FAFail.json */,
+				264E09B42AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json */,
+				264E09B62AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json */,
 				FFE247AD20C891E5002DF3A2 /* WordPressComOAuthSuccess.json */,
 				FFE247A820C891E5002DF3A2 /* WordPressComOAuthWrongPasswordFail.json */,
 				74B335DF1F06F6290053A184 /* WordPressComRestApiFailInvalidInput.json */,
@@ -2799,6 +2805,7 @@
 				74D67F2F1F15C3740010C5ED /* site-followers-delete-auth-failure.json in Resources */,
 				74C473B51EF320CC009918F2 /* site-delete-bad-json-failure.json in Resources */,
 				740B23E21F17FB4200067A2A /* xmlrpc-metaweblog-editpost-change-format-failure.xml in Resources */,
+				264E09B52AD259FF004B5A5F /* WordPressComOAuthRequestChallenge.json in Resources */,
 				FFE247BD20C9C88B002DF3A2 /* empty.json in Resources */,
 				1DF972BA29B0DF8C007A72BC /* videopress-token.json in Resources */,
 				BA8EA71324A056C300D5CC9F /* plugin-service-remote-featured-malformed.json in Resources */,
@@ -2991,6 +2998,7 @@
 				74B040721EF8B366002C6258 /* rest-site-settings.json in Resources */,
 				8B749E8625AF808600023F03 /* jetpack-capabilities-107159616-success.json in Resources */,
 				93BD27611EE73442002BB00B /* me-sites-empty-success.json in Resources */,
+				264E09B72AD25ED9004B5A5F /* WordPressComOAuthAuthenticateSignature.json in Resources */,
 				98EA910526BC96B8004098A1 /* xmlrpc-site-comments-success.xml in Resources */,
 				40E4698D2017D2E30030DB5F /* plugin-directory-new.json in Resources */,
 				4081977C221F153B00A298E4 /* stats-visits-day.json in Resources */,

--- a/WordPressKit/SocialLogin2FANonceInfo.swift
+++ b/WordPressKit/SocialLogin2FANonceInfo.swift
@@ -1,11 +1,14 @@
 import Foundation
 
 @objc
+/// This type is not only used for social logins, but we have not renamed it to maintain compatibility.
+///
 public class SocialLogin2FANonceInfo: NSObject {
     @objc public var nonceSMS = ""
+    @objc public var nonceWebauthn = ""
     @objc var nonceBackup = ""
     @objc var nonceAuthenticator = ""
-    @objc var supportedAuthTypes = [String]() // backup|authenticator|sms
+    @objc var supportedAuthTypes = [String]() // backup|authenticator|sms|webauthn
     @objc var notificationSent = "" // none|sms
     @objc var phoneNumber = "" // The last two digits of the phone number to which an SMS was sent.
 

--- a/WordPressKit/WebauthChallengeInfo.swift
+++ b/WordPressKit/WebauthChallengeInfo.swift
@@ -14,4 +14,10 @@ import Foundation
     /// Nonce required by Wordpress.com to verify the signed challenge
     ///
     @objc public var twoStepNonce = ""
+
+    init(challenge: String, rpID: String, twoStepNonce: String) {
+        self.challenge = challenge
+        self.rpID = rpID
+        self.twoStepNonce = twoStepNonce
+    }
 }

--- a/WordPressKit/WebauthChallengeInfo.swift
+++ b/WordPressKit/WebauthChallengeInfo.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Type that represents the Webauthn challenge info return by Wordpress.com
+///
+@objc public class WebauthnChallengeInfo: NSObject {
+    /// Challenge to be signed.
+    ///
+    @objc public var challenge = ""
+
+    /// The website this request is for
+    ///
+    @objc public var rpID = ""
+
+    /// Nonce required by Wordpress.com to verify the signed challenge
+    ///
+    @objc public var twoStepNonce = ""
+}

--- a/WordPressKit/WebauthChallengeInfo.swift
+++ b/WordPressKit/WebauthChallengeInfo.swift
@@ -15,9 +15,14 @@ import Foundation
     ///
     @objc public var twoStepNonce = ""
 
-    init(challenge: String, rpID: String, twoStepNonce: String) {
+    /// Allowed credential IDs.
+    ///
+    @objc public var allowedCredentialIDs: [String] = []
+
+    init(challenge: String, rpID: String, twoStepNonce: String, allowedCredentialIDs: [String]) {
         self.challenge = challenge
         self.rpID = rpID
         self.twoStepNonce = twoStepNonce
+        self.allowedCredentialIDs = allowedCredentialIDs
     }
 }

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -386,12 +386,14 @@ public final class WordPressComOAuthClient: NSObject {
                     guard
                         let challenge = responseData["challenge"] as? String,
                         let nonce = responseData["two_step_nonce"] as? String,
-                        let rpID = responseData["rpId"] as? String
+                        let rpID = responseData["rpId"] as? String,
+                        let allowCredentials = responseData["allowCredentials"] as? [[String: Any]]
                     else {
                         return failure(defaultError)
                     }
 
-                    let challengeData = WebauthnChallengeInfo(challenge: challenge, rpID: rpID, twoStepNonce: nonce)
+                    let allowedCredentialIDs = allowCredentials.compactMap { $0["id"] as? String }
+                    let challengeData = WebauthnChallengeInfo(challenge: challenge, rpID: rpID, twoStepNonce: nonce, allowedCredentialIDs: allowedCredentialIDs)
                     success(challengeData)
 
                 case .failure(let error):

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -335,6 +335,11 @@ public final class WordPressComOAuthClient: NSObject {
             nonceInfo.nonceAuthenticator = nonceAuthenticator
         }
 
+        // atm, used for requesting and verifying a security key.
+        if let nonceWebauthn = data["two_step_nonce_webauthn"] as? String {
+            nonceInfo.nonceWebauthn = nonceWebauthn
+        }
+
         // atm, the only use of the more vague "two_step_nonce" key is when requesting a new SMS code
         if let nonce = data["two_step_nonce"] as? String {
             nonceInfo.nonceSMS = nonce

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -456,7 +456,7 @@ public final class WordPressComOAuthClient: NSObject {
             "two_step_nonce": twoStepNonce,
             "client_data": clientDataString,
             "get_bearer_token": true,
-            "create_2fa_cookies_only" : true
+            "create_2fa_cookies_only" : true,
         ]
 
         webauthnSessionManager.request(WordPressComURL.webauthnAuthentication.url(base: wordPressComBaseUrl), method: .post, parameters: parameters)

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -358,7 +358,7 @@ public final class WordPressComOAuthClient: NSObject {
                                                success: @escaping (_ challengeData: WebauthnChallengeInfo) -> Void,
                                                failure: @escaping (_ error: NSError) -> Void ) {
 
-        var parameters: [String: Any] = [
+        let parameters: [String: Any] = [
             "user_id": userID,
             "client_id": clientID,
             "client_secret": secret,
@@ -415,7 +415,7 @@ public final class WordPressComOAuthClient: NSObject {
     ///     - success: block to be called if authentication was successful. The auth token is passed as a parameter.
     ///     - failure: block to be called if authentication failed. The error object is passed as a parameter.
     ///
-    @objc public func authenticateWebauthnSignature(userId: Int64,
+    @objc public func authenticateWebauthnSignature(userID: Int64,
                                                     twoStepNonce: String,
                                                     credentialID: Data,
                                                     clientDataJson: Data,
@@ -449,14 +449,14 @@ public final class WordPressComOAuthClient: NSObject {
               }
 
         let parameters: [String: Any] = [
-            "user_id": userId,
+            "user_id": userID,
             "client_id": clientID,
             "client_secret": secret,
             "auth_type": "webauthn",
             "two_step_nonce": twoStepNonce,
             "client_data": clientDataString,
             "get_bearer_token": true,
-            "create_2fa_cookies_only" : true,
+            "create_2fa_cookies_only": true,
         ]
 
         webauthnSessionManager.request(WordPressComURL.webauthnAuthentication.url(base: wordPressComBaseUrl), method: .post, parameters: parameters)

--- a/WordPressKitTests/Mock Data/WordPressComAuthenticateWithIDToken2FANeededSuccess.json
+++ b/WordPressKitTests/Mock Data/WordPressComAuthenticateWithIDToken2FANeededSuccess.json
@@ -4,6 +4,7 @@
         "two_step_nonce": "two_step_nonce",
         "two_step_nonce_sms": "two_step_nonce_sms",
         "two_step_nonce_backup": "two_step_nonce_backup",
+        "two_step_nonce_webauthn": "two_step_nonce_webauthn",
         "two_step_notification_sent": "two_step_notification_sent",
         "two_step_supported_auth_types": "two_step_supported_auth_types",
         "phone_number": "phone_number",        

--- a/WordPressKitTests/Mock Data/WordPressComOAuthAuthenticateSignature.json
+++ b/WordPressKitTests/Mock Data/WordPressComOAuthAuthenticateSignature.json
@@ -1,0 +1,12 @@
+{
+    "success": true,
+    "data": {
+        "bearer_token": "bearer_token",
+        "token_links": [
+            "https:\/\/jetpack.com\/remote-login.php?wpcom_rem...",
+            "https:\/\/fieldguide.automattic.com\/remote-logi...",
+            "https:\/\/learn.a8c.com\/remote-login.php?wpcom_remote_login...",
+            "https:\/\/a8c.tv\/remote-login.php?wpcom_remote_login=vali..."
+        ]
+    }
+}

--- a/WordPressKitTests/Mock Data/WordPressComOAuthNeedsWebauthnMFA.json
+++ b/WordPressKitTests/Mock Data/WordPressComOAuthNeedsWebauthnMFA.json
@@ -1,0 +1,7 @@
+{
+    "success": true,
+    "data": {
+        "user_id": 1234,
+        "two_step_nonce_webauthn": "two_step_nonce_webauthn",
+    }
+}

--- a/WordPressKitTests/Mock Data/WordPressComOAuthRequestChallenge.json
+++ b/WordPressKitTests/Mock Data/WordPressComOAuthRequestChallenge.json
@@ -1,0 +1,33 @@
+{
+    "success": true,
+    "data": {
+        "challenge": "challenge",
+        "rpId": "wordpress.com",
+        "allowCredentials": [
+            {
+                "type": "public-key",
+                "id": "credential-id",
+                "transports": [
+                    "usb",
+                    "nfc",
+                    "ble",
+                    "hybrid",
+                    "internal"
+                ]
+            },
+            {
+                "type": "public-key",
+                "id": "credential-id-2",
+                "transports": [
+                    "usb",
+                    "nfc",
+                    "ble",
+                    "hybrid",
+                    "internal"
+                ]
+            }
+        ],
+        "timeout": 60000,
+        "two_step_nonce": "two_step_nonce"
+    }
+}

--- a/WordPressKitTests/WordPressComOAuthTests.swift
+++ b/WordPressKitTests/WordPressComOAuthTests.swift
@@ -306,7 +306,7 @@ class WordPressComOAuthTests: XCTestCase {
 
         let expect = self.expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
-        client.authenticateWebauthnSignature(userId: 123,
+        client.authenticateWebauthnSignature(userID: 123,
                                              twoStepNonce: "twoStepNOnce",
                                              credentialID: "credential-id".data(using: .utf8) ?? Data(),
                                              clientDataJson: "{}".data(using: .utf8) ?? Data(),

--- a/WordPressKitTests/WordPressComOAuthTests.swift
+++ b/WordPressKitTests/WordPressComOAuthTests.swift
@@ -181,6 +181,7 @@ class WordPressComOAuthTests: XCTestCase {
             expect.fulfill()
             XCTAssertEqual(userID, 1)
             XCTAssertEqual(nonceInfo.nonceBackup, "two_step_nonce_backup")
+            XCTAssertEqual(nonceInfo.nonceWebauthn, "two_step_nonce_webauthn")
         }, existingUserNeedsConnection: { _ in
             expect.fulfill()
             XCTFail("This call should need multifactor")

--- a/WordPressKitTests/WordPressComOAuthTests.swift
+++ b/WordPressKitTests/WordPressComOAuthTests.swift
@@ -287,7 +287,7 @@ class WordPressComOAuthTests: XCTestCase {
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
         client.requestWebauthnChallenge(userID: 123, twoStepNonce: "twoStepNonce", success: { challengeInfo in
             expect.fulfill()
-            let expectedChallengeInfo = WebauthnChallengeInfo(challenge: "challenge", rpID: "wordpress.com", twoStepNonce: "two_step_nonce")
+            let expectedChallengeInfo = WebauthnChallengeInfo(challenge: "challenge", rpID: "wordpress.com", twoStepNonce: "two_step_nonce", allowedCredentialIDs: ["credential-id, credential-id-2"])
             XCTAssertEqual(challengeInfo.challenge, expectedChallengeInfo.challenge)
             XCTAssertEqual(challengeInfo.rpID, expectedChallengeInfo.rpID)
             XCTAssertEqual(challengeInfo.twoStepNonce, expectedChallengeInfo.twoStepNonce)

--- a/WordPressKitTests/WordPressComOAuthTests.swift
+++ b/WordPressKitTests/WordPressComOAuthTests.swift
@@ -60,7 +60,7 @@ class WordPressComOAuthTests: XCTestCase {
 
         let expect = self.expectation(description: "One callback should be invoked")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
-        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil,  needsMultifactor: { _, _ in
+        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil, needsMultifactor: { _, _ in
             expect.fulfill()
             XCTFail("This call should fail")
         }, success: { (_) in
@@ -82,7 +82,7 @@ class WordPressComOAuthTests: XCTestCase {
 
         let expect = self.expectation(description: "Call should complete")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
-        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil,  needsMultifactor: { _, _ in
+        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil, needsMultifactor: { _, _ in
             expect.fulfill()
             XCTFail("This call should fail")
         }, success: { (_) in
@@ -99,7 +99,7 @@ class WordPressComOAuthTests: XCTestCase {
         client.authenticateWithUsername("fakeUser", password: "fakePassword", multifactorCode: "fakeMultifactor", needsMultifactor: { _, _ in
             expect.fulfill()
             XCTFail("This call should fail")
-        },  success: { (_) in
+        }, success: { (_) in
             expectation2.fulfill()
             XCTFail("This call should fail")
         }, failure: { (error) in
@@ -118,7 +118,7 @@ class WordPressComOAuthTests: XCTestCase {
 
         let expect = self.expectation(description: "Call should complete")
         let client = WordPressComOAuthClient(clientID: "Fake", secret: "Fake")
-        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil,  needsMultifactor: { userID, nonceInfo in
+        client.authenticateWithUsername("fakeUser", password: "wrongPassword", multifactorCode: nil, needsMultifactor: { userID, nonceInfo in
             expect.fulfill()
             XCTAssertEqual(userID, 1234)
             XCTAssertEqual(nonceInfo.nonceWebauthn, "two_step_nonce_webauthn")


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-ios/issues/10854
Part of https://github.com/woocommerce/woocommerce-ios/issues/10855

# Why

This PR adds the necessary endpoints for the security key authentication.

These will be used on `WordpressAuthenticator-IOS` and later on the Woo / Jetpack and / WP apps.

# How

- Update the `oauth/token` endpoint to store the `webauthn` nonce.
- Add the `webauthn-challenge-endpoint` endpoint to request a challenge.
- Add the `webauthn-authentication-endpoint` endpoint to verify a signed challenge

This is all coded to the spec defined pe5pgL-3Nh-p2

# Demo

https://github.com/wordpress-mobile/WordPressKit-iOS/assets/562080/2f69ea2f-b680-4d0a-8840-3a76540f935d

# Testing

You can believe the video 😅 or you can test this [experimental branch](https://github.com/woocommerce/woocommerce-ios/pull/10904)

## Notes

- Compiling the experimental branch may be a bit buggy, Cocoapods doesn't work that well with unreleased versions of a pod.
- You need to have a WordPress.com account with a non-A8C email to test social logins
- Magic links do not work. pe5pgL-3QM-p2

## Steps

- Launch the woo app from the [experimental branch](https://github.com/woocommerce/woocommerce-ios/pull/10904)
- Continue with user name/password OR continue with Google or Apple with a non-A8C email.
- See that the two-factor screen presents a "Use a security key" CTA
- Select that option and select your passkey stored in the iOS keychain.
- See that you are correctly authenticated.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
