### PR TITLE
Set RemotePostCategory.parent to zero when the JSON property is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- `RemotePostCategory.parent` is set to zero when API returns `"parent": null` [#630]
 
 ### Bug Fixes
 

--- a/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -293,7 +293,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
     RemotePostCategory *category = [RemotePostCategory new];
     category.categoryID = [jsonCategory numberForKey:TaxonomyRESTIDParameter];
     category.name = [jsonCategory stringForKey:TaxonomyRESTNameParameter];
-    category.parentID = [jsonCategory numberForKey:TaxonomyRESTParentParameter];
+    category.parentID = [jsonCategory numberForKey:TaxonomyRESTParentParameter] ?: @0;
     return category;
 }
 


### PR DESCRIPTION
### Description

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/21138.

The above issue is a site related issue and doesn't affect many users. The `parent` JSON property should be `0` if the category is at top level, and non-zero if it's at child level. But `parent` should never be nil. 

However, in very rare cases, it appears WordPress REST API does return `nil` which causes the app attempts to store an invalid nil value. I tried to look into the backend code and WordPress site settings to see if I can reproduce this behaviour. But I couldn't figure out how.

This PR assigns a default value `0` to the `RemotePostCategory.parent` property, essentially treating a `"parent": null` response same as `"parent": 0` (a.k.a a top level category).

### Testing Details

I have added an unit test to verify the new behaviour.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
