### PR TITLE
Add `authenticateWithUsername` version without `needsMultifactor`

### DIFF
--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -203,7 +203,7 @@ public final class WordPressComOAuthClient: NSObject {
                                 domain: WordPressComOAuthClient.WordPressComOAuthErrorDomain,
                                 code: WordPressComOAuthError.unknown.rawValue,
                                 userInfo: [
-                                    NSLocalizedDescriptionKey: "Response requires handling the MFAN Webauthn flow but handler given ('needsMultifactor' parameter)."
+                                    NSLocalizedDescriptionKey: "Response requires handling the MFA Webauthn flow but handler given ('needsMultifactor' parameter)."
                                 ]
                             )
                         )

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -10,11 +10,6 @@ import Alamofire
     case socialLoginExistingUserUnconnected
     case invalidTwoStepCode
     case unknownUser
-    /// The API response requires handling MFA, but the caller didn't specify a handler.
-    ///
-    /// Use to ensure backwards compatibility in `authenticateWithUsername(...)` calls after support for the MFA closure
-    /// was introduced.
-    case noMultifactorHandlerGiven
 }
 
 /// `WordPressComOAuthClient` encapsulates the pattern of authenticating against WordPress.com OAuth2 service.
@@ -206,8 +201,10 @@ public final class WordPressComOAuthClient: NSObject {
                         failure(
                             NSError(
                                 domain: WordPressComOAuthClient.WordPressComOAuthErrorDomain,
-                                code: WordPressComOAuthError.noMultifactorHandlerGiven.rawValue,
-                                userInfo: nil
+                                code: WordPressComOAuthError.unknown.rawValue,
+                                userInfo: [
+                                    NSLocalizedDescriptionKey: "Response requires handling the MFAN Webauthn flow but handler given ('needsMultifactor' parameter)."
+                                ]
                             )
                         )
                         return

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -120,6 +120,32 @@ public final class WordPressComOAuthClient: NSObject {
 
     /// Authenticates on WordPress.com using the OAuth endpoints.
     ///
+    /// Delegates to `authenticateWithUsername(_:, password:, multifactorCode:, needsMultifactor:, success:, failure:)`.
+    /// Here to provide source-compatibility with the Objective-C layer, where using a default parameter (`needsMultifactor: ... = nil`) doesn't result in a method signature without the parameter.
+    ///
+    /// - Parameters:
+    ///     - username: the account's username.
+    ///     - password: the account's password.
+    ///     - multifactorCode: Multifactor Authentication One-Time-Password. If not needed, can be nil
+    ///     - success: block to be called if authentication was successful. The OAuth2 token is passed as a parameter.
+    ///     - failure: block to be called if authentication failed. The error object is passed as a parameter.
+    @objc public func authenticateWithUsername(_ username: String,
+                                               password: String,
+                                               multifactorCode: String?,
+                                               success: @escaping (_ authToken: String?) -> Void,
+                                               failure: @escaping (_ error: NSError) -> Void ) {
+        authenticateWithUsername(
+            username,
+            password: password,
+            multifactorCode: multifactorCode,
+            needsMultifactor: nil,
+            success: success,
+            failure: failure
+        )
+    }
+
+    /// Authenticates on WordPress.com using the OAuth endpoints.
+    ///
     /// - Parameters:
     ///     - username: the account's username.
     ///     - password: the account's password.

--- a/WordPressKitTests/WordPressComOAuthClientTests.swift
+++ b/WordPressKitTests/WordPressComOAuthClientTests.swift
@@ -279,7 +279,8 @@ class WordPressComOAuthClientTests: XCTestCase {
             failure: { error in
                 expect.fulfill()
                 XCTAssertEqual(error.domain, WordPressComOAuthClient.WordPressComOAuthErrorDomain)
-                XCTAssertEqual(error.code, WordPressComOAuthError.noMultifactorHandlerGiven.rawValue)
+                XCTAssertEqual(error.code, WordPressComOAuthError.unknown.rawValue)
+                XCTAssertEqual(error.localizedDescription, "Response requires handling the MFAN Webauthn flow but handler given ('needsMultifactor' parameter).")
             }
         )
         waitForExpectations(timeout: 2, handler: nil)

--- a/WordPressKitTests/WordPressComOAuthClientTests.swift
+++ b/WordPressKitTests/WordPressComOAuthClientTests.swift
@@ -280,7 +280,7 @@ class WordPressComOAuthClientTests: XCTestCase {
                 expect.fulfill()
                 XCTAssertEqual(error.domain, WordPressComOAuthClient.WordPressComOAuthErrorDomain)
                 XCTAssertEqual(error.code, WordPressComOAuthError.unknown.rawValue)
-                XCTAssertEqual(error.localizedDescription, "Response requires handling the MFAN Webauthn flow but handler given ('needsMultifactor' parameter).")
+                XCTAssertEqual(error.localizedDescription, "Response requires handling the MFA Webauthn flow but handler given ('needsMultifactor' parameter).")
             }
         )
         waitForExpectations(timeout: 2, handler: nil)


### PR DESCRIPTION
### Description 

Turns out #632 didn't fix the breaking change issue it aimed to address. On top of that, adding a new enum case is a source breaking change. See further discussion with @AliSoftware in the PR comments https://github.com/wordpress-mobile/WordPressKit-iOS/pull/632#discussion_r1360320415

![](https://user-images.githubusercontent.com/1218433/275476569-db1ee5a2-46ab-4c46-b199-d00953809031.png)

To address that, this PR:

1. Adds a new method to match the previous version that Objective-C clients (i.e. WordPressAuthenticator) might still be using.
2. Removes the new `case` and throws an error with `unknown` `case` and a detailed localized description.

I considered crashing instead, but decided to stick with erroring because I like the idea of having a test for that behavior. It betters document the expectation of client passing a handler.

### Testing Details

Mindful of my previous changes being ineffective in WordPressAuthenticator, this time I tested the change both during local development (`pod '...', path: '../..'`) and in CI via https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/790

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered updating the `version` in the `.podspec` file.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.