### PR TITLE
Remove update podspec check from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,4 @@ Fixes #
 ---
 
 - [ ] Please check here if your pull request includes additional test coverage.
-- [ ] I have considered updating the `version` in the `.podspec` file.
 - [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.


### PR DESCRIPTION
Following this [discussion](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/626#issuecomment-1772038023), this PR removes the following from the PR remplate:

> I have considered updating the `version` in the `.podspec` file.