### PR TITLE
Add an API to get a post's latest revision id

### DIFF
--- a/WordPressKit/PostServiceRemoteREST+Revisions.swift
+++ b/WordPressKit/PostServiceRemoteREST+Revisions.swift
@@ -27,6 +27,33 @@ public extension PostServiceRemoteREST {
             failure(error)
         })
     }
+
+    func getPostLatestRevisionID(for postId: NSNumber, success: @escaping (NSNumber?) -> Void, failure: @escaping (Error?) -> Void) {
+        let endpoint = "sites/\(siteID)/posts/\(postId)"
+        let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
+        wordPressComRestApi.GET(
+            path,
+            parameters: [
+                "context": "edit",
+                "fields": "revisions"
+            ] as [String: AnyObject],
+            success: { (response, _) in
+                let latestRevision: NSNumber?
+                if let json = response as? [String: Any],
+                   let revisions = json["revisions"] as? NSArray,
+                   let latest = revisions.firstObject as? NSNumber {
+                    latestRevision = latest
+                } else {
+                    latestRevision = nil
+                }
+                success(latestRevision)
+            },
+            failure: { error, _ in
+                WPKitLogError("\(error)")
+                failure(error)
+            }
+        )
+    }
 }
 
 private extension PostServiceRemoteREST {


### PR DESCRIPTION
### Description

What says in the title.

This new function uses the `sites/%s/posts/%d` endpoint with a `fields=revisions` parameter, so that we get a minimal response body that's needed.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
