### PR TITLE
Release 8.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,17 @@ _None._
 
 ### Bug Fixes
 
-- Reverted adding `tag` parameter to `PostServiceRemoteOptions`. Breaking change in 8.8.0.
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 8.9.1
+
+### Bug Fixes
+
+- Reverted adding `tag` parameter to `PostServiceRemoteOptions`. Breaking change in 8.8.0. [#639]
 
 ## 8.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,13 @@ _None._
 
 _None._
 
-### Bug Fixes
+### New Features
 
 _None._
+
+### Bug Fixes
+
+- Reverted adding `tag` parameter to `PostServiceRemoteOptions`. Breaking change in 8.8.0.
 
 ### Internal Changes
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.9.0'
+  s.version       = '8.9.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteOptions.h
+++ b/WordPressKit/PostServiceRemoteOptions.h
@@ -77,9 +77,4 @@ typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
  */
 - (NSString *)meta;
 
-/**
- The tag to filter by.
- */
-- (NSString *)tag;
-
 @end

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -17,7 +17,6 @@ static NSString * const RemoteOptionKeyStatus = @"status";
 static NSString * const RemoteOptionKeySearch = @"search";
 static NSString * const RemoteOptionKeyAuthor = @"author";
 static NSString * const RemoteOptionKeyMeta = @"meta";
-static NSString * const RemoteOptionKeyTag = @"tag";
 
 static NSString * const RemoteOptionValueOrderAscending = @"ASC";
 static NSString * const RemoteOptionValueOrderDescending = @"DESC";
@@ -419,10 +418,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     if (options.meta.length > 0) {
         [remoteParams setObject:options.meta forKey:RemoteOptionKeyMeta];
     }
-    if (options.tag.length > 0) {
-        [remoteParams setObject:options.tag forKey:RemoteOptionKeyTag];
-    }
-
+    
     return remoteParams.count ? [NSDictionary dictionaryWithDictionary:remoteParams] : nil;
 }
 


### PR DESCRIPTION
This reverts commit b43fc731b10bb865f14517a600a24dc06e7c9e67 which introduced an accidental breaking change in 8.8.0

See CI build https://buildkite.com/automattic/wordpress-ios/builds/17897#018b7ee3-492f-4d9a-b434-54f9f97a5791:

![](https://user-images.githubusercontent.com/1218433/278933582-25d859a9-df8f-40e6-9098-09e760d30c4d.png)

This version bump PR is part of the code freeze workflow for WordPress iOS [23.6](https://github.com/wordpress-mobile/WordPress-iOS/milestone/260) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.