### PR TITLE
Add tag parameter (again)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ _None._
 
 _None._
 
+### New Features
+
+- Add `tag` parameter to `PostServiceRemoteOptions` [#634]
+
 ## 8.9.1
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,6 @@ _None._
 
 _None._
 
-### New Features
-
-_None._
-
 ### Bug Fixes
 
 _None._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 - Add `tag` parameter to `PostServiceRemoteOptions` [#634]
 
+## 8.10.0
+
+### New Features
+
+- Add optional `tag` parameter to `PostServiceRemoteOptions` [#640]
+
 ## 8.9.1
 
 ### Bug Fixes

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.9.1'
+  s.version       = '8.10.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/PostServiceRemoteOptions.h
+++ b/WordPressKit/PostServiceRemoteOptions.h
@@ -77,4 +77,9 @@ typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
  */
 - (NSString *)meta;
 
+/**
+ The tag to filter by.
+ */
+- (NSString *)tag;
+
 @end

--- a/WordPressKit/PostServiceRemoteOptions.h
+++ b/WordPressKit/PostServiceRemoteOptions.h
@@ -80,6 +80,7 @@ typedef NS_ENUM(NSUInteger, PostServiceResultsOrdering) {
 /**
  The tag to filter by.
  */
+@optional
 - (NSString *)tag;
 
 @end

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -17,6 +17,7 @@ static NSString * const RemoteOptionKeyStatus = @"status";
 static NSString * const RemoteOptionKeySearch = @"search";
 static NSString * const RemoteOptionKeyAuthor = @"author";
 static NSString * const RemoteOptionKeyMeta = @"meta";
+static NSString * const RemoteOptionKeyTag = @"tag";
 
 static NSString * const RemoteOptionValueOrderAscending = @"ASC";
 static NSString * const RemoteOptionValueOrderDescending = @"DESC";
@@ -418,7 +419,10 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     if (options.meta.length > 0) {
         [remoteParams setObject:options.meta forKey:RemoteOptionKeyMeta];
     }
-    
+    if (options.tag.length > 0) {
+        [remoteParams setObject:options.tag forKey:RemoteOptionKeyTag];
+    }
+
     return remoteParams.count ? [NSDictionary dictionaryWithDictionary:remoteParams] : nil;
 }
 

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -419,7 +419,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     if (options.meta.length > 0) {
         [remoteParams setObject:options.meta forKey:RemoteOptionKeyMeta];
     }
-    if (options.tag.length > 0) {
+    if ([options respondsToSelector:@selector(tag)] && options.tag.length > 0) {
         [remoteParams setObject:options.tag forKey:RemoteOptionKeyTag];
     }
 


### PR DESCRIPTION
Same as https://github.com/wordpress-mobile/WordPressKit-iOS/pull/634, but with `tag` now optional.

Test using the following PR https://github.com/wordpress-mobile/WordPress-iOS/pull/21933