### PR TITLE
Add transfer case to DomainType enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ _None._
 ### New Features
 
 - Add `tag` parameter to `PostServiceRemoteOptions` [#634]
+- Add `transfer` case to `DomainType` case [#642]
 
 ## 8.10.0
 

--- a/WordPressKit/RemoteDomain.swift
+++ b/WordPressKit/RemoteDomain.swift
@@ -4,6 +4,7 @@ import Foundation
     case registered
     case mapped
     case siteRedirect
+    case transfer
     case wpCom
 
     public var description: String {
@@ -16,6 +17,8 @@ import Foundation
             return NSLocalizedString("Site Redirect", comment: "Describes a site redirect domain")
         case .wpCom:
             return NSLocalizedString("Included with Site", comment: "Describes a standard *.wordpress.com site domain")
+        case .transfer:
+            return NSLocalizedString("Transferred Domain", comment: "Describes a domain that was transferred from elsewhere to wordpress.com")
         }
     }
 
@@ -30,6 +33,8 @@ import Foundation
     init(type: String?, wpComDomain: Bool?, hasRegistration: Bool?) {
         if type == "redirect" {
             self = .siteRedirect
+        } else if type == "transfer" {
+            self = .transfer
         } else if wpComDomain == true {
             self = .wpCom
         } else if hasRegistration == true {


### PR DESCRIPTION
### Description

This PR adds the enum case `transfer` to `DomainType`.

Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21431

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
