### PR TITLE
Rest Comments: Removes the hard coded force=wpcom parameter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- No longer pass `force=wpcom` parameter when fetching a blogs comments. [#643]
 
 ### Internal Changes
 

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -29,7 +29,6 @@
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
-                                 @"force": @"wpcom", // Force fetching data from shadow site on Jetpack sites
                                  @"number": @(maximumComments)
                                  }];
 


### PR DESCRIPTION
### Description

Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/21737

This PR removes the hard-coded "force=wpcom" parameter that was included when fetching a blogs list of comments. In the [linked issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/21737) it was discovered that including the parameter resulted in no comments being returned from the `v1.1/sites/[site]/comments/` endpoint, however omitting the parameter yielded the expected results. 

This suggests that something may have (recently?) changed in the API that makes including the parameter necessary, but it isn't clear at this time what that might be. (Perhaps improvements related to Jetpack Sync?)

There are other endpoints that include the force=wpcom parameter. I have not made any changes to those as we're currently unaware of any issues with them.  It might be nice to follow up at a later point and either confirm the param is still needed and remove it if not, but it's out of scope for this change.

If we find special cases where the `force=wpcom` parameter is needed when fetching comments, we can include this as part of the options dictionary passed to `getCommentsWithMaximumCount` in those cases.


### Testing Details
**Set up**
- Create a new self-hosted test site.  (I used the internal tool for creating ephemeral test sites, and used the extra option to configure the site with pergenerated test data.)
- In the test site, connect Jetpack to a wpcom test account. 
- In your test site, go to it's wp-admin/edit-comments.php page and confirm there are comments present.
- Log into the WordPress app with your test account.

**Confirm the issue**
- In the My Sites tab, select the test site you created.
- Tap on the comments option in the menu to view the list of comments for the site. 
- Confirm that no comments appear.

**Confirm the fix**
- Checkout the branch from this WPiOS draft PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/21971 
- Build and launch the WPiOS branch in the simulator or on a device.
- In the My Sites tab, select the test site you created.
- Tap on the comments option in the menu to view the list of comments for the site. 
- Confirm that the list of comments is now populated.

![Simulator Screenshot - iPhone SE (3rd generation) - 2023-11-04 at 12 41 42](https://github.com/wordpress-mobile/WordPressKit-iOS/assets/1435271/b08edded-e4a4-4463-9646-c89b2f592d49)


---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
