### PR TITLE
Add support for no-site carts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ _None._
 ### New Features
 
 - Add optional `tag` parameter to `PostServiceRemoteOptions` [#640]
+- Add support for creating a shopping cart that's not tied to a specific site. [#644]
 
 ## 8.9.1
 

--- a/WordPressKit/TransactionsServiceRemote.swift
+++ b/WordPressKit/TransactionsServiceRemote.swift
@@ -151,12 +151,12 @@ public enum TransactionsServiceProduct {
 
 public struct CartResponse {
     let blogID: Int
-    let cartKey: Any
+    let cartKey: Any // cart key can be either Int or String
     let products: [Product]
 
     init?(jsonDictionary: [String: AnyObject]) {
         guard
-            let cartKey = jsonDictionary["cart_key"] as? Any,
+            let cartKey = jsonDictionary["cart_key"],
             let blogID = jsonDictionary["blog_id"] as? Int,
             let products = jsonDictionary["products"] as? [[String: AnyObject]]
             else {

--- a/WordPressKit/TransactionsServiceRemote.swift
+++ b/WordPressKit/TransactionsServiceRemote.swift
@@ -41,13 +41,13 @@ import WordPressShared
     ///   - siteID: id of the current site
     ///   - products: an array of products to be added to the newly created cart
     ///   - temporary: true if the card is temporary, false otherwise
-    public func createShoppingCart(siteID: Int,
+    public func createShoppingCart(siteID: Int?,
                                    products: [TransactionsServiceProduct],
                                    temporary: Bool,
                                    success: @escaping (CartResponse) -> Void,
                                    failure: @escaping (Error) -> Void) {
-
-        let endPoint = "me/shopping-cart/\(siteID)"
+        let siteIDString = siteID != nil ? "\(siteID ?? 0)" : "no-site"
+        let endPoint = "me/shopping-cart/\(siteIDString)"
         let urlPath = path(forEndpoint: endPoint, withVersion: ._1_1)
 
         var productsDictionary: [[String: AnyObject]] = []
@@ -151,12 +151,12 @@ public enum TransactionsServiceProduct {
 
 public struct CartResponse {
     let blogID: Int
-    let cartKey: Int
+    let cartKey: Any
     let products: [Product]
 
     init?(jsonDictionary: [String: AnyObject]) {
         guard
-            let cartKey = jsonDictionary["cart_key"] as? Int,
+            let cartKey = jsonDictionary["cart_key"] as? Any,
             let blogID = jsonDictionary["blog_id"] as? Int,
             let products = jsonDictionary["products"] as? [[String: AnyObject]]
             else {


### PR DESCRIPTION
### Description

This PR adds support for creating a shopping cart that's not tied to a specific site.

Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/21780

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
