### PR TITLE
Passkeys: Expose supported auth type

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.10.0'
+  s.version       = '8.10.1-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/SocialLogin2FANonceInfo.swift
+++ b/WordPressKit/SocialLogin2FANonceInfo.swift
@@ -8,7 +8,7 @@ public class SocialLogin2FANonceInfo: NSObject {
     @objc public var nonceWebauthn = ""
     @objc var nonceBackup = ""
     @objc var nonceAuthenticator = ""
-    @objc var supportedAuthTypes = [String]() // backup|authenticator|sms|webauthn
+    @objc public var supportedAuthTypes = [String]() // backup|authenticator|sms|webauthn
     @objc var notificationSent = "" // none|sms
     @objc var phoneNumber = "" // The last two digits of the phone number to which an SMS was sent.
 


### PR DESCRIPTION
### Description

Related to https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/800

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
