### PR TITLE
Update WP.com login URL to use login.php

### DIFF
--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.10.0'
+  s.version       = '8.10.1-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.10.1-beta.1'
+  s.version       = '9.0.0-beta.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -184,18 +184,18 @@ public final class WordPressComOAuthClient: NSObject {
                                                code: WordPressComOAuthError.unknown.rawValue,
                                                userInfo: nil)
 
-                    guard let responseDictionary = responseObject as? [String: AnyObject] else {
+                    guard let responseDictionary = responseObject as? [String: AnyObject],
+                          let responseData = responseDictionary["data"] as? [String: AnyObject] else {
                         return failure(defaultError)
                     }
 
-                    // If we found an access_token, we are authed.
-                    if let authToken = responseDictionary["access_token"] as? String {
+                    // If we found a bearer token, we are authed.
+                    if let authToken = responseData["bearer_token"] as? String {
                         return success(authToken)
                     }
 
-                    // If there is no access token, check for two-step auth types
-                    guard let responseData = responseDictionary["data"] as? [String: AnyObject],
-                          let userID = responseData["user_id"] as? Int,
+                    // If there is no bearer token, check for two-step auth types
+                    guard let userID = responseData["user_id"] as? Int,
                           let twoStepAuthTypes = responseData["two_step_supported_auth_types"] as? [String],
                           !twoStepAuthTypes.isEmpty else {
                         failure(defaultError)

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -28,6 +28,7 @@ public final class WordPressComOAuthClient: NSObject {
 
     enum WordPressComURL: String {
         case oAuthBase = "/oauth2/token"
+        case loginBase = "wp-login.php?action=login-endpoint"
         case webauthnChallenge = "wp-login.php?action=webauthn-challenge-endpoint"
         case webauthnAuthentication = "wp-login.php?action=webauthn-authentication-endpoint"
         case socialLogin = "/wp-login.php?action=social-login-endpoint&version=1.0"
@@ -163,14 +164,16 @@ public final class WordPressComOAuthClient: NSObject {
             "client_id": clientID as AnyObject,
             "client_secret": secret as AnyObject,
             "wpcom_supports_2fa": true as AnyObject,
-            "with_auth_types": true as AnyObject
+            "get_bearer_token": true as AnyObject
         ]
 
         if let multifactorCode = multifactorCode, !multifactorCode.isEmpty {
             parameters["wpcom_otp"] = multifactorCode as AnyObject?
         }
 
-        oauth2SessionManager.request(WordPressComURL.oAuthBase.url(base: wordPressComApiBaseUrl), method: .post, parameters: parameters)
+        let url = WordPressComURL.loginBase.url(base: WordPressComOAuthClient.WordPressComOAuthDefaultBaseUrl)
+
+        oauth2SessionManager.request(url, method: .post, parameters: parameters)
             .validate()
             .responseJSON(completionHandler: { response in
                 switch response.result {

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -193,10 +193,11 @@ public final class WordPressComOAuthClient: NSObject {
                         return success(authToken)
                     }
 
-                    // If there is no access token, check for a security key nonce
+                    // If there is no access token, check for two-step auth types
                     guard let responseData = responseDictionary["data"] as? [String: AnyObject],
                           let userID = responseData["user_id"] as? Int,
-                          let _ = responseData["two_step_nonce_webauthn"] else {
+                          let twoStepAuthTypes = responseData["two_step_supported_auth_types"] as? [String],
+                          !twoStepAuthTypes.isEmpty else {
                         failure(defaultError)
                         return
                     }


### PR DESCRIPTION
### Description

This change allows the app to receive a list of supported 2FA types such as SMS OTPs, authenticator-based OTPs, and passkeys.

### Testing Details

Test via https://github.com/wordpress-mobile/WordPress-iOS/pull/22001

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
