### PR TITLE
Merge 8.11.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ _None._
 
 _None._
 
+### New Features
+
+_None._
+
 ### Bug Fixes
 
 _None._
@@ -43,6 +47,8 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 8.11.0
 
 ### New Features
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '8.10.0'
+  s.version       = '8.11.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION

This version bump PR is part of the code freeze workflow for WordPress iOS 23.7 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.