### PR TITLE
Make WordPressOrgXMLRPCValidatorError conforms to LocalizedError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- `WordPressOrgXMLRPCValidatorError` now conforms to `LocalizedError` [#649]
 
 ### Bug Fixes
 

--- a/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -35,6 +35,12 @@ import Foundation
     }
 }
 
+extension WordPressOrgXMLRPCValidatorError: LocalizedError {
+    public var errorDescription: String? {
+        localizedDescription
+    }
+}
+
 /// An WordPressOrgXMLRPCValidator is able to validate and check if user provided site urls are
 /// WordPress XMLRPC sites.
 open class WordPressOrgXMLRPCValidator: NSObject {


### PR DESCRIPTION
### Description

This change makes it okay to cast `WordPressOrgXMLRPCValidatorError` as `NSError` and display its error message to users, which will help a separate change I'll make to the WordPressAuthenticator library.

### Testing Details

I can't see anything that needs to be tested here...

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
