### PR TITLE
Add WordPressAPIError

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		46ABD0E0262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46ABD0DF262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift */; };
 		46ABD0E6262EEDAB00C7FF24 /* FakeInfoDictionaryObjectProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46ABD0E5262EEDAB00C7FF24 /* FakeInfoDictionaryObjectProvider.swift */; };
 		46ABD0EA262EEE0400C7FF24 /* AppTransportSecuritySettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46ABD0E9262EEE0400C7FF24 /* AppTransportSecuritySettingsTests.swift */; };
+		4A11239A2B19269A004690CF /* WordPressAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1123992B19269A004690CF /* WordPressAPIError.swift */; };
 		4A1DEF44293051BC00322608 /* LoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1DEF43293051BC00322608 /* LoggingTests.swift */; };
 		4A1DEF46293051C600322608 /* LoggingTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A1DEF45293051C600322608 /* LoggingTests.m */; };
 		4A68E3CD29404181004AC3DC /* RemoteBlog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A68E3CC29404181004AC3DC /* RemoteBlog.swift */; };
@@ -830,6 +831,7 @@
 		46ABD0DF262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressOrgXMLRPCValidatorTests.swift; sourceTree = "<group>"; };
 		46ABD0E5262EEDAB00C7FF24 /* FakeInfoDictionaryObjectProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FakeInfoDictionaryObjectProvider.swift; sourceTree = "<group>"; };
 		46ABD0E9262EEE0400C7FF24 /* AppTransportSecuritySettingsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppTransportSecuritySettingsTests.swift; sourceTree = "<group>"; };
+		4A1123992B19269A004690CF /* WordPressAPIError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WordPressAPIError.swift; sourceTree = "<group>"; };
 		4A1DEF43293051BC00322608 /* LoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggingTests.swift; sourceTree = "<group>"; };
 		4A1DEF45293051C600322608 /* LoggingTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LoggingTests.m; sourceTree = "<group>"; };
 		4A68E3CC29404181004AC3DC /* RemoteBlog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RemoteBlog.swift; sourceTree = "<group>"; };
@@ -2418,6 +2420,7 @@
 				93BD27791EE73944002BB00B /* WordPressOrgXMLRPCApi.swift */,
 				93BD277A1EE73944002BB00B /* WordPressOrgXMLRPCValidator.swift */,
 				93BD277B1EE73944002BB00B /* WordPressRSDParser.swift */,
+				4A1123992B19269A004690CF /* WordPressAPIError.swift */,
 			);
 			name = WordPressAPI;
 			sourceTree = "<group>";
@@ -3317,6 +3320,7 @@
 				82FFBF561F460DD400F4573F /* BlogJetpackSettingsServiceRemote.swift in Sources */,
 				3297E15625645C7D00287D21 /* JetpackCredentials.swift in Sources */,
 				F1B7F4FC272376A8004215CD /* NSCharacterSet+URLEncode.swift in Sources */,
+				4A11239A2B19269A004690CF /* WordPressAPIError.swift in Sources */,
 				404057C9221B789B0060250C /* StatsTopAuthorsTimeIntervalData.swift in Sources */,
 				FEFFD99326C141A800F34231 /* RemoteShareAppContent.swift in Sources */,
 				74BA04F61F06DC0A00ED5CD8 /* CommentServiceRemoteXMLRPC.m in Sources */,

--- a/WordPressKit/WordPressAPIError.swift
+++ b/WordPressKit/WordPressAPIError.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+public enum WordPressAPIError<EndpointError>: Error where EndpointError: LocalizedError {
+    static var unknownErrorMessage: String {
+        NSLocalizedString(
+            "wordpress-api.error.unknown",
+            value: "Something went wrong, please try again later.",
+            comment: "Error message that describes an unknown error had occured"
+        )
+    }
+
+    /// Can't encode the request arguments into a valid HTTP request. This is a programming error.
+    case requestEncodingFailure
+    /// Error occured in the HTTP connection.
+    case connection(URLError)
+    /// The API call returned an error result. For example, an OAuth endpoint may returns an 'incorrect username or password' error, an upload media endpoint may return an 'unsupported media type' error.
+    case endpointError(EndpointError)
+    /// WordPress.com returned an HTTP response that WordPressKit can't parse.
+    case unparsableResponse(response: HTTPURLResponse?, body: Data?)
+    /// Other error occured.
+    case unknown(underlyingError: Error)
+}
+
+extension WordPressComOAuthError: LocalizedError {
+
+    public var errorDescription: String? {
+        switch self {
+        case .requestEncodingFailure, .unparsableResponse:
+            // This is a programming error
+            return Self.unknownErrorMessage
+        case let .endpointError(error):
+            return error.errorDescription
+        case let .connection(error):
+            return error.localizedDescription
+        case let .unknown(underlyingError):
+            if let msg = (underlyingError as? LocalizedError)?.errorDescription {
+                return msg
+            }
+            return Self.unknownErrorMessage
+        }
+    }
+
+}

--- a/WordPressKit/WordPressAPIError.swift
+++ b/WordPressKit/WordPressAPIError.swift
@@ -15,7 +15,7 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
     case connection(URLError)
     /// The API call returned an error result. For example, an OAuth endpoint may returns an 'incorrect username or password' error, an upload media endpoint may return an 'unsupported media type' error.
     case endpointError(EndpointError)
-    /// WordPress.com returned an HTTP response that WordPressKit can't parse.
+    /// The API call returned an HTTP response that WordPressKit can't parse.
     case unparsableResponse(response: HTTPURLResponse?, body: Data?)
     /// Other error occured.
     case unknown(underlyingError: Error)


### PR DESCRIPTION
### Description

> [!Note]
> This PR targets the https://github.com/wordpress-mobile/WordPressKit-iOS/pull/650 PR branch.

In https://github.com/wordpress-mobile/WordPressKit-iOS/pull/650, I've refactored [`WordPressComOAuthError` into a Swift error type][Diff-Link]. You'll see there is only one case (out of its five enum cases) that's related to the OAuth domain: `case authenticationFailure(AuthenticationFailure)`. It'd makes sense to further abstract this error type to make it apply to all API endpoints in WordPressKit. This PR did exactly that.

It's not entirely related to this PR, but here is a bit it more context: I have added some helpers around URLSession in [this branch][URLSession-Branch], to make it easier to call in the specific endpoint implementations. This PR's new error is used in those helpers.

### Testing Details

This PR contains only syntactical changes. No extra testing required.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.


[Diff-Link]: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/650/files#diff-10c71f00f75a60cd8268a53f9bd665522ccfd106243f9cf46aedd2b988aaa807R4
[URLSession-Branch]: https://github.com/wordpress-mobile/WordPressKit-iOS/tree/url-session-helpers-bye-bye-alamofire