### PR TITLE
Remove the xcode-14.2 env from the publish pod step

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,6 +48,7 @@ steps:
   - label: "⬆️ Publish Podspec"
     key: "publish"
     command: .buildkite/publish-pod.sh
+    env: *common_env
     plugins: *common_plugins
     depends_on:
       - "test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,11 +48,6 @@ steps:
   - label: "⬆️ Publish Podspec"
     key: "publish"
     command: .buildkite/publish-pod.sh
-    # Notice Xcode 14.2, so that we can validate the pod using the pre-Xcode
-    # 14.3 toolchain and workaround the outdated Alamofire dependency
-    # deployment target being incompatible with Xcode 14.3+
-    env:
-      IMAGE_ID: xcode-14.2
     plugins: *common_plugins
     depends_on:
       - "test"


### PR DESCRIPTION
### Description

There is no image for Xcode 14.2 on Apple Silicon agents. Plus, the issue mentioned should be fixed by https://github.com/wordpress-mobile/WordPressKit-iOS/pull/652.

### Testing Details

[v9.0.0 was released using this change](https://buildkite.com/automattic/wordpresskit-ios/builds/1181#018c570c-fd08-4af7-b077-065218317a37).

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
