### PR TITLE
Use URLSession in WordPressOAuthClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Refactor WP.com authentication API requests. [#660]
 
 ## 10.0.0
 

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -689,3 +689,16 @@ extension WordPressComOAuthClient {
         }
     }
 }
+
+private extension WordPressComOAuthClient {
+    static func processError(_ response: HTTPAPIResponse<Data>) -> AuthenticationFailure? {
+        guard [400, 409, 403].contains(response.response.statusCode),
+              let responseObject = try? JSONSerialization.jsonObject(with: response.body, options: .allowFragments),
+              let responseDictionary = responseObject as? [String: AnyObject]
+        else {
+            return nil
+        }
+
+        return .init(apiJSONResponse: responseDictionary)
+    }
+}

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -102,10 +102,6 @@ public final class WordPressComOAuthClient: NSObject {
         WordPressComOAuthClient.urlSession()
     }()
 
-    private let oauth2SessionManager: SessionManager = {
-        return WordPressComOAuthClient.sessionManager()
-    }()
-
     private let webauthnSessionManager: SessionManager = {
         return WordPressComOAuthClient.sessionManager()
     }()

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -85,8 +85,8 @@ public final class WordPressComOAuthClient: NSObject {
         case socialLogin2FA = "/wp-login.php?action=two-step-authentication-endpoint&version=1.0"
         case socialLoginNewSMS2FA = "/wp-login.php?action=send-sms-code-endpoint"
 
-        func url(base: String) -> URL {
-            return URL(string: self.rawValue, relativeTo: URL(string: base))!
+        func url(base: URL) -> URL {
+            return URL(string: self.rawValue, relativeTo: base)!
         }
     }
 
@@ -95,8 +95,8 @@ public final class WordPressComOAuthClient: NSObject {
     private let clientID: String
     private let secret: String
 
-    private let wordPressComBaseUrl: String
-    private let wordPressComApiBaseUrl: String
+    private let wordPressComBaseUrl: URL
+    private let wordPressComApiBaseUrl: URL
 
     private let oauth2SessionManager: SessionManager = {
         return WordPressComOAuthClient.sessionManager()
@@ -160,8 +160,8 @@ public final class WordPressComOAuthClient: NSObject {
                       wordPressComApiBaseUrl: String = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseUrl) {
         self.clientID = clientID
         self.secret = secret
-        self.wordPressComBaseUrl = wordPressComBaseUrl
-        self.wordPressComApiBaseUrl = wordPressComApiBaseUrl
+        self.wordPressComBaseUrl = URL(string: wordPressComBaseUrl)!
+        self.wordPressComApiBaseUrl = URL(string: wordPressComApiBaseUrl)!
     }
 
     /// Authenticates on WordPress.com using the OAuth endpoints.


### PR DESCRIPTION
### Description

This PR replaces some usages of Alamofire in `WordPressOAuthClient`, with `URLSession`. There will be more similar PRs later for other usages.

I noticed there are many `Alamofire.SessionManager` instances are used. I don't understand why, but at the same time I'm too afraid to change it. For now, I'll follow the existing pattern and continue using many `URLSession` instances too.

### Testing Details

The refactored features are: login with WP.com username password and request code via SMS. You can use https://github.com/wordpress-mobile/WordPress-iOS/pull/22215 to test this change. Here are some test scenarios I can think of:
1. Login with username and password. The app presents 2FA code screen if the account enables 2FA.
2. The app shows appropriate error messages if password is incorrect, or 2fa code is incorrect.
3. Request one time code via SMS works.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
