### PR TITLE
Allow special characters in url-encoded form

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -64,9 +64,11 @@ final class HTTPRequestBuilder {
     func body(form: [String: String]) -> Self {
         headers["Content-Type"] = "application/x-www-form-urlencoded; charset=utf-8"
         bodyBuilder = { req in
-            var url = URLComponents(string: "https://wordpress.com")!
-            url.queryItems = form.map { URLQueryItem(name: $0, value: $1) }
-            req.httpBody = url.percentEncodedQuery?.data(using: .utf8)
+            let content = form.map {
+                    "\(HTTPRequestBuilder.urlEncode($0))=\(HTTPRequestBuilder.urlEncode($1))"
+                }
+                .joined(separator: "&")
+            req.httpBody = content.data(using: .utf8)
         }
         return self
     }
@@ -131,5 +133,13 @@ extension HTTPRequestBuilder {
     // FIXME: Not implemented yet
     func appendXMLRPCArgument(value: Any) -> Self {
         fatalError("To be implemented")
+    }
+}
+
+private extension HTTPRequestBuilder {
+    static func urlEncode(_ text: String) -> String {
+        let specialCharacters = ":#[]@!$&'()*+,;="
+        let allowed = CharacterSet.urlQueryAllowed.subtracting(.init(charactersIn: specialCharacters))
+        return text.addingPercentEncoding(withAllowedCharacters: allowed) ?? text
     }
 }

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -104,6 +104,45 @@ class HTTPRequestBuilderTests: XCTestCase {
         try XCTAssertEqual(XCTUnwrap(request.httpBodyText), "text=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D")
     }
 
+    func testFormWithRandomSpecialCharacters() throws {
+        let asciis = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+        let unicodes = "表情符号😇🤔✅😎"
+        let randomText: () -> String = {
+            let chars = (1...10).map { _ in (asciis + unicodes).randomElement()! }
+            return String(chars)
+        }
+        // Generate a form (key-value pairs) with random characters.
+        let form = [
+            randomText(): randomText(),
+            randomText(): randomText(),
+            randomText(): randomText(),
+        ]
+
+        let request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+            .method(.post)
+            .body(form: form)
+            .build()
+        let encoded = try XCTUnwrap(request.httpBodyText)
+
+        // Decoding the url-encoded form, whose format should be "<key>=<value>&<key>=<value>&...".
+        let keyValuePairs = try encoded.split(separator: "&").map { pair in
+            XCTAssertEqual(pair.firstIndex(of: "="), pair.lastIndex(of: "="), "There should be only one '=' in a key-value pair")
+
+            let firstIndex = try XCTUnwrap(pair.firstIndex(of: "="))
+            let key = pair[pair.startIndex..<firstIndex]
+            let value = pair[pair.index(firstIndex, offsetBy: 1)..<pair.endIndex]
+
+            return try (
+                XCTUnwrap(String(key).removingPercentEncoding),
+                XCTUnwrap(String(value).removingPercentEncoding)
+            )
+        }
+
+        // The decoded form should be the same the original form.
+        let decodedForm: [String: String] = Dictionary(uniqueKeysWithValues: keyValuePairs)
+        XCTAssertEqual(form, decodedForm)
+    }
+
 }
 
 private extension URLRequest {

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -96,6 +96,14 @@ class HTTPRequestBuilderTests: XCTestCase {
         try XCTAssertEqual(XCTUnwrap(request.httpBodyText), #"name=Foo%20Bar"#)
     }
 
+    func testFormWithSpecialCharacters() throws {
+        let request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+            .method(.post)
+            .body(form: ["text": ":#[]@!$&'()*+,;="])
+            .build()
+        try XCTAssertEqual(XCTUnwrap(request.httpBodyText), "text=%3A%23%5B%5D%40%21%24%26%27%28%29%2A%2B%2C%3B%3D")
+    }
+
 }
 
 private extension URLRequest {


### PR DESCRIPTION
### Description

The existing function that encodes key-value pair as url-encoded form is too loss. I should have included more special characters in the first implementation.

The special characters that are added in this PR are the same ones used by [Alamofire](https://github.com/Alamofire/Alamofire/blob/827a879ae2dcc473dfcae8ae188b992f66cd07d6/Source/URLEncodedFormEncoder.swift#L1144-L1150). But please note, unlike Alamofire, here in this library, these special characters are only taken into consideration for url-encoded form, not URL queries. We'll continue to use iOS's API (`URLComponent`) to build URL queries.

### Testing Details

I have added a test case. Let me know if there are more tests you think I should add.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
