### PR TITLE
Bump version to 9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ _None._
 
 ### Internal Changes
 
+_None._
+
+## 9.0.1
+
+### Internal Changes
+
 - Fix `WordPressAPIError`'s localized error message. [#662]
 
 ## 9.0.0

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '9.0.0'
+  s.version       = '9.0.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

I will release 9.0.1 to include a bug fix and update the library in the WP and WC iOS apps.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
