### PR TITLE
Add a couple of helpers to parse HTTP content

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -157,6 +157,9 @@
 		4A6B4A862B269D0C00802316 /* URLSessionHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6B4A852B269D0C00802316 /* URLSessionHelperTests.swift */; };
 		4AA5A1A32AA68F6B00969464 /* MediaLibraryTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5A1A22AA68F6B00969464 /* MediaLibraryTestSupport.swift */; };
 		4AA5A1A52AA695D700969464 /* LoadMediaLibraryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA5A1A42AA695D700969464 /* LoadMediaLibraryTests.swift */; };
+		4AE278442B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE278432B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift */; };
+		4AE278482B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE278472B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift */; };
+		4AE2784A2B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE278492B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift */; };
 		57BCD3D426209D9500292CB3 /* AppTransportSecuritySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */; };
 		730E869F21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */; };
 		731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */; };
@@ -854,6 +857,9 @@
 		4A6B4A852B269D0C00802316 /* URLSessionHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionHelperTests.swift; sourceTree = "<group>"; };
 		4AA5A1A22AA68F6B00969464 /* MediaLibraryTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLibraryTestSupport.swift; sourceTree = "<group>"; };
 		4AA5A1A42AA695D700969464 /* LoadMediaLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadMediaLibraryTests.swift; sourceTree = "<group>"; };
+		4AE278432B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPProtocolHelpers.swift; sourceTree = "<group>"; };
+		4AE278472B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyEncodingTests.swift; sourceTree = "<group>"; };
+		4AE278492B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPHeaderValueParserTests.swift; sourceTree = "<group>"; };
 		57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTransportSecuritySettings.swift; sourceTree = "<group>"; };
 		6C2A33D76FD1052D6F30466D /* Pods-WordPressKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.debug.xcconfig"; sourceTree = "<group>"; };
 		6F2E0CC4FA01B5475A378DA2 /* Pods-WordPressKitTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -2449,6 +2455,7 @@
 				57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */,
 				465F88A1263B325C00F4C950 /* ChecksumUtil.swift */,
 				3F3195AC266FF94B00397EE7 /* ZendeskMetadata.swift */,
+				4AE278432B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -2641,6 +2648,8 @@
 				4A6B4A832B26974F00802316 /* HTTPRequestBuilderTests.swift */,
 				4A6B4A852B269D0C00802316 /* URLSessionHelperTests.swift */,
 				4A40F6542B2A5A1A0015DA77 /* WordPressAPIErrorTests.swift */,
+				4AE278472B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift */,
+				4AE278492B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -3281,6 +3290,7 @@
 				E1BD95151FD5A2B800CD5CE3 /* PluginDirectoryServiceRemote.swift in Sources */,
 				7430C9D71F1933210051B8E6 /* RemoteReaderCrossPostMeta.swift in Sources */,
 				1DAC3D2629AF4F250068FE13 /* RemoteVideoPressVideo.swift in Sources */,
+				4AE278442B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift in Sources */,
 				FA68CD152993C6CD00FA4C29 /* BlazeServiceRemote.swift in Sources */,
 				4081976F221DDE9B00A298E4 /* StatsTopPostsTimeIntervalData.swift in Sources */,
 				9311A68B1F22625A00704AC9 /* TaxonomyServiceRemoteXMLRPC.m in Sources */,
@@ -3438,6 +3448,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4AE2784A2B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift in Sources */,
 				E1E89C6A1FD6BDB1006E7A33 /* PluginDirectoryTests.swift in Sources */,
 				4A6B4A862B269D0C00802316 /* URLSessionHelperTests.swift in Sources */,
 				9F3E0BAA20873773009CB5BA /* MockServiceRequest.swift in Sources */,
@@ -3535,6 +3546,7 @@
 				FE5096522A13938500DDD071 /* SharingServiceRemoteTests.swift in Sources */,
 				FFA4D4AA2423B10A00BF5180 /* WordPressOrgRestApiTests.swift in Sources */,
 				74A44DD51F13C6D8006CD8F4 /* PushAuthenticationServiceRemoteTests.swift in Sources */,
+				4AE278482B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift in Sources */,
 				731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */,
 				7EC60EBE22DC4F9000FB0336 /* EditorServiceRemoteTests.swift in Sources */,
 				931924241F1662FA0069CBCC /* JSONLoader.swift in Sources */,

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -7,6 +7,18 @@ struct HTTPAPIResponse<Body> {
     var body: Body
 }
 
+extension HTTPAPIResponse where Body == Data {
+    var bodyText: String? {
+        var encoding: String.Encoding?
+        if let charset = response.textEncodingName {
+            encoding = String.Encoding(ianaCharsetName: charset)
+        }
+
+        let defaultEncoding = String.Encoding.isoLatin1
+        return String(data: body, encoding: encoding ?? defaultEncoding)
+    }
+}
+
 extension URLSession {
 
     func perform<E: LocalizedError>(

--- a/WordPressKit/HTTPProtocolHelpers.swift
+++ b/WordPressKit/HTTPProtocolHelpers.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 extension String.Encoding {
+    /// See: https://www.iana.org/assignments/character-sets/character-sets.xhtml
     init?(ianaCharsetName: String) {
         let encoding: CFStringEncoding = CFStringConvertIANACharSetNameToEncoding(ianaCharsetName as CFString)
         guard encoding != kCFStringEncodingInvalidId,

--- a/WordPressKit/HTTPProtocolHelpers.swift
+++ b/WordPressKit/HTTPProtocolHelpers.swift
@@ -47,7 +47,7 @@ extension HTTPURLResponse {
     /// Return parameter value in a header field.
     ///
     /// For example, you can use this method to get "charset" value from a 'Content-Type' header like
-    /// `Content-Type: applicaions/json; charset=utf-8`.
+    /// `Content-Type: applications/json; charset=utf-8`.
     func value(ofParameter parameterName: String, inHeaderField headerName: String, stripQuotes: Bool = true) -> String? {
         guard let headerValue = value(forHTTPHeaderField: headerName) else {
             return nil

--- a/WordPressKit/HTTPProtocolHelpers.swift
+++ b/WordPressKit/HTTPProtocolHelpers.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+extension String.Encoding {
+    init?(ianaCharsetName: String) {
+        let encoding: CFStringEncoding = CFStringConvertIANACharSetNameToEncoding(ianaCharsetName as CFString)
+        guard encoding != kCFStringEncodingInvalidId,
+              let builtInEncoding = CFStringBuiltInEncodings(rawValue: encoding)
+        else {
+            return nil
+        }
+
+        switch builtInEncoding {
+        case .macRoman:
+            self = .macOSRoman
+        case .windowsLatin1:
+            self = .windowsCP1252
+        case .isoLatin1:
+            self = .isoLatin1
+        case .nextStepLatin:
+            self = .nextstep
+        case .ASCII:
+            self = .ascii
+        case .unicode:
+            self = .unicode
+        case .UTF8:
+            self = .utf8
+        case .nonLossyASCII:
+            self = .nonLossyASCII
+        case .UTF16BE:
+            self = .utf16BigEndian
+        case .UTF16LE:
+            self = .utf16LittleEndian
+        case .UTF32:
+            self = .utf32
+        case .UTF32BE:
+            self = .utf32BigEndian
+        case .UTF32LE:
+            self = .utf32LittleEndian
+        @unknown default:
+            return nil
+        }
+    }
+}
+
+extension HTTPURLResponse {
+
+    /// Return parameter value in a header field.
+    ///
+    /// For example, you can use this method to get "charset" value from a 'Content-Type' header like
+    /// `Content-Type: applicaions/json; charset=utf-8`.
+    func value(ofParameter parameterName: String, inHeaderField headerName: String, stripQuotes: Bool = true) -> String? {
+        guard let headerValue = value(forHTTPHeaderField: headerName) else {
+            return nil
+        }
+
+        return Self.value(ofParameter: parameterName, inHeaderValue: headerValue, stripQuotes: stripQuotes)
+    }
+
+    static func value(ofParameter parameterName: String, inHeaderValue headerValue: String, stripQuotes: Bool = true) -> String? {
+        // Find location of '<parameter>=' string in the header.
+        guard let location = headerValue.range(of: parameterName + "=", options: .caseInsensitive) else {
+            return nil
+        }
+
+        let parameterValueStart = location.upperBound
+        let parameterValueEnd: String.Index
+
+        // ';' marks the end of the parameter value.
+        if let found = headerValue.range(of: ";", range: parameterValueStart..<headerValue.endIndex)?.lowerBound {
+            parameterValueEnd = found
+        } else {
+            // No ';' found. The parameter must be the last one.
+            parameterValueEnd = headerValue.endIndex
+        }
+
+        let parameterValueRange = parameterValueStart..<parameterValueEnd
+        var value = String(headerValue[parameterValueRange])
+
+        if stripQuotes {
+            value.removePrefix("\"")
+            value.removeSuffix("\"")
+        }
+
+        return value
+    }
+
+}

--- a/WordPressKitTests/Utilities/HTTPBodyEncodingTests.swift
+++ b/WordPressKitTests/Utilities/HTTPBodyEncodingTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XCTest
+@testable import WordPressKit
+
+class HTTPBodyEncodingTests: XCTestCase {
+
+    func testRoundTrip() throws {
+        // The test strings are generated using the following command line:
+        // $ echo -n "👋" | iconv -f UTF-8 -t <charset> | base64
+
+        XCTAssertEqual(try decode(base64EncodedBody: "8J+Riw==", charset: "UTF-8"), "👋")
+        XCTAssertEqual(try decode(base64EncodedBody: "2D3cSw==", charset: "UTF-16BE"), "👋")
+        XCTAssertEqual(try decode(base64EncodedBody: "PdhL3A==", charset: "UTF-16LE"), "👋")
+    }
+
+    private func decode(base64EncodedBody: String, charset: String, file: StaticString = #file, line: UInt = #line) throws -> String? {
+        let response = try XCTUnwrap(HTTPURLResponse(url: URL(string: "https://wordpress.org")!, statusCode: 200, httpVersion: "2", headerFields: [
+            "Content-Type": "text/html; charset=\(charset)"
+        ]))
+        let originalBodyData = try XCTUnwrap(Data(base64Encoded: base64EncodedBody))
+        return HTTPAPIResponse(response: response, body: originalBodyData).bodyText
+    }
+
+}

--- a/WordPressKitTests/Utilities/HTTPHeaderValueParserTests.swift
+++ b/WordPressKitTests/Utilities/HTTPHeaderValueParserTests.swift
@@ -35,7 +35,7 @@ class HTTPHeaderValueParserTests: XCTestCase {
 
     func testLastParameter() {
         XCTAssertEqual(
-            HTTPURLResponse.value(ofParameter: "CharSet", inHeaderValue: "application/json; charset=utf-8;"),
+            HTTPURLResponse.value(ofParameter: "CharSet", inHeaderValue: "application/json; foo=bar; charset=utf-8;"),
             "utf-8"
         )
     }

--- a/WordPressKitTests/Utilities/HTTPHeaderValueParserTests.swift
+++ b/WordPressKitTests/Utilities/HTTPHeaderValueParserTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import XCTest
+
+@testable import WordPressKit
+
+class HTTPHeaderValueParserTests: XCTestCase {
+
+    func testReturnOriginalCase() {
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "charset", inHeaderValue: "application/json; charset=UtF-8"),
+            "UtF-8"
+        )
+    }
+
+    func testCaseInsensitiveParameter() {
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "CharSet", inHeaderValue: "application/json; charset=utf-8"),
+            "utf-8"
+        )
+    }
+
+    func testFirstParameter() {
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "CharSet", inHeaderValue: "application/json; charset=utf-8;"),
+            "utf-8"
+        )
+    }
+
+    func testMiddleParameter() {
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "CharSet", inHeaderValue: "application/json; charset=utf-8; foo=bar"),
+            "utf-8"
+        )
+    }
+
+    func testLastParameter() {
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "CharSet", inHeaderValue: "application/json; charset=utf-8;"),
+            "utf-8"
+        )
+    }
+
+    func testLastParameterWithoutSemicolon() {
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "CharSet", inHeaderValue: "application/json; charset=utf-8"),
+            "utf-8"
+        )
+    }
+
+    func testNoSpaceBetweenParameters() {
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "CharSet", inHeaderValue: "application/json;charset=utf-8;foo=bar"),
+            "utf-8"
+        )
+    }
+
+    func testParameterValueWithQuotes() {
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "rel", inHeaderValue: "https://wordpress.org/wp-json; rel=\"https://api.w.org\""),
+            "https://api.w.org"
+        )
+
+        XCTAssertEqual(
+            HTTPURLResponse.value(ofParameter: "rel", inHeaderValue: "https://wordpress.org/wp-json; rel=\"https://api.w.org\"", stripQuotes: false),
+            "\"https://api.w.org\""
+        )
+    }
+
+}


### PR DESCRIPTION
### Description

The helpers are for
1. Parsing HTTP response body as plain text.
2. Getting value of HTTP header parameters. For example, `charset` of `Content-Type: text/html; charset=utf-8`.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
