### PR TITLE
Add a new 'unacceptableStatusCode' error case to WordPressAPIError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-- Add a new `unacceptableStatusCode` error case to `WordPressAPIError`.
+- Add a new `unacceptableStatusCode` error case to `WordPressAPIError`. [#668]
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-_None._
+- Add a new `unacceptableStatusCode` error case to `WordPressAPIError`.
 
 ### New Features
 

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -58,7 +58,7 @@ extension WordPressAPIResult {
         }
     }
 
-    func mapSuccess<NewSuccess: Decodable, E: LocalizedError>(
+    func decodeSuccess<NewSuccess: Decodable, E: LocalizedError>(
         _ decoder: JSONDecoder = JSONDecoder()
     ) -> WordPressAPIResult<NewSuccess, E> where Success == HTTPAPIResponse<Data>, Failure == WordPressAPIError<E> {
         mapSuccess {

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -66,7 +66,7 @@ extension WordPressAPIResult {
         }
     }
 
-    func mapUnaccpetableStatusCodeError<E: LocalizedError>(
+    func mapUnacceptableStatusCodeError<E: LocalizedError>(
         _ transform: (HTTPURLResponse, Data) -> E?
     ) -> WordPressAPIResult<Success, E> where Failure == WordPressAPIError<E> {
         mapError { error in
@@ -81,10 +81,10 @@ extension WordPressAPIResult {
         }
     }
 
-    func mapUnaccpetableStatusCodeError<E>(
+    func mapUnacceptableStatusCodeError<E>(
         _ decoder: JSONDecoder = JSONDecoder()
     ) -> WordPressAPIResult<Success, E> where E: LocalizedError, E: Decodable, Failure == WordPressAPIError<E> {
-        mapUnaccpetableStatusCodeError { _, body in
+        mapUnacceptableStatusCodeError { _, body in
             try? decoder.decode(E.self, from: body)
         }
     }

--- a/WordPressKit/WordPressAPIError.swift
+++ b/WordPressKit/WordPressAPIError.swift
@@ -15,6 +15,8 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
     case connection(URLError)
     /// The API call returned an error result. For example, an OAuth endpoint may return an 'incorrect username or password' error, an upload media endpoint may return an 'unsupported media type' error.
     case endpointError(EndpointError)
+    /// The API call returned an status code that's unacceptable to the endpoint.
+    case unacceptableStatusCode(response: HTTPURLResponse, body: Data)
     /// The API call returned an HTTP response that WordPressKit can't parse. Receiving this error could be an indicator that there is an error response that's not handled properly by WordPressKit.
     case unparsableResponse(response: HTTPURLResponse?, body: Data?)
     /// Other error occured.
@@ -30,7 +32,7 @@ extension WordPressAPIError: LocalizedError {
         // always returns a non-nil value.
         let localizedErrorMessage: String
         switch self {
-        case .requestEncodingFailure, .unparsableResponse:
+        case .requestEncodingFailure, .unparsableResponse, .unacceptableStatusCode:
             // These are usually programming errors.
             localizedErrorMessage = Self.unknownErrorMessage
         case let .endpointError(error):

--- a/WordPressKitTests/Utilities/URLSessionHelperTests.swift
+++ b/WordPressKitTests/Utilities/URLSessionHelperTests.swift
@@ -35,41 +35,25 @@ class URLSessionHelperTests: XCTestCase {
         let result = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), errorType: TestError.self)
 
         // The result is a successful result. This line should not throw
-        _ = try result.get()
+        let response = try result.get()
 
-        let expectation = expectation(description: "API call returns a successful result")
-        _ = result
-            .assessStatusCode { result in
-                XCTAssertEqual(String(data: result.body, encoding: .utf8), "success")
-                expectation.fulfill()
-                return result
-            } failure: { _ in
-                // Do nothing
-                return nil
-            }
-        await fulfillment(of: [expectation])
+        XCTAssertEqual(String(data: response.body, encoding: .utf8), "success")
     }
 
-    func testUnacceptable500() async throws {
+    func testUnacceptable500() async {
         stub(condition: isPath("/hello")) { _ in
             HTTPStubsResponse(data: "Internal server error".data(using: .utf8)!, statusCode: 500, headers: nil)
         }
 
-        let result = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), errorType: TestError.self)
+        let result = await URLSession.shared
+            .perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), errorType: TestError.self)
 
-        // The result is a successful result. This line should not throw
-        _ = try result.get()
-
-        let expectation = expectation(description: "API call returns server error")
-        _ = result
-            .assessStatusCode { result in
-                return result
-            } failure: { result in
-                XCTAssertEqual(String(data: result.body, encoding: .utf8), "Internal server error")
-                expectation.fulfill()
-                return nil
-            }
-        await fulfillment(of: [expectation])
+        switch result {
+        case let .failure(.unacceptableStatusCode(response, _)):
+            XCTAssertEqual(response.statusCode, 500)
+        default:
+            XCTFail("Got an unexpected result: \(result)")
+        }
     }
 
     func testAcceptable404() async throws {
@@ -77,21 +61,15 @@ class URLSessionHelperTests: XCTestCase {
             HTTPStubsResponse(data: "Not found".data(using: .utf8)!, statusCode: 404, headers: nil)
         }
 
-        let result = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), errorType: TestError.self)
+        let result = await URLSession.shared
+            .perform(
+                request: .init(url: URL(string: "https://wordpress.org/hello")!),
+                acceptableStatusCodes: [200...299, 400...499], errorType: TestError.self
+            )
 
         // The result is a successful result. This line should not throw
-        _ = try result.get()
-
-        let expectation = expectation(description: "API call returns not found")
-        _ = result
-            .assessStatusCode(acceptable: [200...299, 400...499]) { result in
-                XCTAssertEqual(String(data: result.body, encoding: .utf8), "Not found")
-                expectation.fulfill()
-                return result
-            } failure: { result in
-                return nil
-            }
-        await fulfillment(of: [expectation])
+        let response = try result.get()
+        XCTAssertEqual(String(data: response.body, encoding: .utf8), "Not found")
     }
 
     func testParseError() async throws {
@@ -99,32 +77,38 @@ class URLSessionHelperTests: XCTestCase {
             HTTPStubsResponse(data: "Not found".data(using: .utf8)!, statusCode: 404, headers: nil)
         }
 
-        let result = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), errorType: TestError.self)
-
-        // The result is a successful result. This line should not throw
-        _ = try result.get()
-
-        let expectation = expectation(description: "API call returns not found")
-        let parsedResult = result
-            .assessStatusCode { result in
-                return result
-            } failure: { result in
-                expectation.fulfill()
-                if result.response.statusCode == 404 {
-                    return .postNotFound
-                }
-                return nil
+        let result = await URLSession.shared
+            .perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), errorType: TestError.self)
+            .mapUnaccpetableStatusCodeError { response, _ in
+                XCTAssertEqual(response.statusCode, 404)
+                return .postNotFound
             }
-        await fulfillment(of: [expectation])
 
-        if case .failure(WordPressAPIError<TestError>.endpointError(.postNotFound)) = parsedResult {
+        if case .failure(WordPressAPIError<TestError>.endpointError(.postNotFound)) = result {
             // DO nothing
         } else {
-            XCTFail("Unexpected result: \(parsedResult)")
+            XCTFail("Unexpected result: \(result)")
         }
+    }
+
+    func testParseSuccessAsJSON() async throws {
+        stub(condition: isPath("/hello")) { _ in
+            HTTPStubsResponse(jsonObject: ["title": "Hello Post"], statusCode: 200, headers: nil)
+        }
+
+        struct Post: Decodable {
+            var title: String
+        }
+
+        let result: WordPressAPIResult<Post, TestError> = await URLSession.shared
+            .perform(request: .init(url: URL(string: "https://wordpress.org/hello")!))
+            .mapSuccess()
+
+        try XCTAssertEqual(result.get().title, "Hello Post")
     }
 }
 
-private enum TestError: LocalizedError {
+private enum TestError: LocalizedError, Equatable {
     case postNotFound
+    case serverFailure
 }

--- a/WordPressKitTests/Utilities/URLSessionHelperTests.swift
+++ b/WordPressKitTests/Utilities/URLSessionHelperTests.swift
@@ -102,7 +102,7 @@ class URLSessionHelperTests: XCTestCase {
 
         let result: WordPressAPIResult<Post, TestError> = await URLSession.shared
             .perform(request: .init(url: URL(string: "https://wordpress.org/hello")!))
-            .mapSuccess()
+            .decodeSuccess()
 
         try XCTAssertEqual(result.get().title, "Hello Post")
     }

--- a/WordPressKitTests/Utilities/URLSessionHelperTests.swift
+++ b/WordPressKitTests/Utilities/URLSessionHelperTests.swift
@@ -79,7 +79,7 @@ class URLSessionHelperTests: XCTestCase {
 
         let result = await URLSession.shared
             .perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), errorType: TestError.self)
-            .mapUnaccpetableStatusCodeError { response, _ in
+            .mapUnacceptableStatusCodeError { response, _ in
                 XCTAssertEqual(response.statusCode, 404)
                 return .postNotFound
             }


### PR DESCRIPTION
### Description

This PR is a follow-up to https://github.com/wordpress-mobile/WordPressKit-iOS/pull/658#discussion_r1423315579.

At the moment, when an API call returns an failure result (non-200 status code), the existing URLSession helper returns a `Swift.Result.success` case. After dealing with it a while, I find it too weird... So, this PR changed that by reporting a new `WordPressAPIError.unacceptableStatusCode` error upon unacceptable status code(non-200 by default, but it is customizable).

This PR introduces breaking changes, in terms of compile time backwards compatibility: swift-case statements on `WordPressAPIError` may fail. However, I don't think our apps/libraries actually have such statements.

### Testing Details

See the updated unit tests.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
