### PR TITLE
Support tracking HTTP request overall progress and cancellation

### DIFF
--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -11,13 +11,14 @@ extension URLSession {
 
     /// Send a HTTP request and return its response as a `WordPressAPIResult` instance.
     ///
-    /// ## Progress Tracking
+    /// ## Progress Tracking and Cancellation
     ///
     /// You can track the HTTP request's overall progress by passing a `Progress` instance to the `fulfillingProgress`
     /// parameter, which must satisify following requirements:
     /// - `totalUnitCount` must not be zero.
     /// - `completedUnitCount` must be zero.
     /// - It's used exclusivity for tracking the HTTP request overal progress: No children in its progress tree.
+    /// - `cancellationHandler` must be nil. You can call `fulfillingProgress.cancel()` to cancel the ongoing HTTP request.
     ///
     ///  Upon completion, the HTTP request's progress fulfills the `fulfillingProgress`.
     ///
@@ -58,6 +59,10 @@ extension URLSession {
             if let parentProgress, parentProgress.totalUnitCount > parentProgress.completedUnitCount {
                 let pending = parentProgress.totalUnitCount - parentProgress.completedUnitCount
                 parentProgress.addChild(task.progress, withPendingUnitCount: pending)
+
+                parentProgress.cancellationHandler = { [weak task] in
+                    task?.cancel()
+                }
             }
         }
     }

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -9,37 +9,86 @@ struct HTTPAPIResponse<Body> {
 
 extension URLSession {
 
+    /// Send a HTTP request and return its response as a `WordPressAPIResult` instance.
+    ///
+    /// ## Progress Tracking
+    ///
+    /// You can track the HTTP request's overall progress by passing a `Progress` instance to the `fulfillingProgress`
+    /// parameter, which must satisify following requirements:
+    /// - `totalUnitCount` must not be zero.
+    /// - `completedUnitCount` must be zero.
+    /// - It's used exclusivity for tracking the HTTP request overal progress: No children in its progress tree.
+    ///
+    ///  Upon completion, the HTTP request's progress fulfills the `fulfillingProgress`.
+    ///
+    /// - Parameters:
+    ///   - builder: A `HTTPRequestBuilder` instance that represents an HTTP request to be sent.
+    ///   - acceptableStatusCodes: HTTP status code ranges that are considered a successful response. Responses with
+    ///         a status code outside of these ranges are returned as a `WordPressAPIResult.unacceptableStatusCode` instance.
+    ///   - parentProgress: A `Progress` instance that will be used as the parent progress of the HTTP request's overall
+    ///         progress. See the function documentation regarding requirements on this argument.
+    ///   - errorType: The concret endpoint error type.
     func perform<E: LocalizedError>(
         request builder: HTTPRequestBuilder,
         acceptableStatusCodes: [ClosedRange<Int>] = [200...299],
+        fulfillingProgress parentProgress: Progress? = nil,
         errorType: E.Type = E.self
     ) async -> WordPressAPIResult<HTTPAPIResponse<Data>, E> {
+        if let parentProgress  {
+            assert(parentProgress.completedUnitCount == 0 && parentProgress.totalUnitCount > 0, "Invalid parent progress")
+        }
+
         guard let request = try? builder.build() else {
             return .failure(.requestEncodingFailure)
         }
 
-        let result: (Data, URLResponse)
-        do {
-            result = try await data(for: request)
-        } catch {
+        return await withCheckedContinuation { continuation in
+            let task = dataTask(with: request) { data, response, error in
+                let result: WordPressAPIResult<HTTPAPIResponse<Data>, E> = Self.parseResponse(
+                    data: data,
+                    response: response,
+                    error: error,
+                    acceptableStatusCodes: acceptableStatusCodes
+                )
+
+                continuation.resume(returning: result)
+            }
+            task.resume()
+
+            if let parentProgress, parentProgress.totalUnitCount > parentProgress.completedUnitCount {
+                let pending = parentProgress.totalUnitCount - parentProgress.completedUnitCount
+                parentProgress.addChild(task.progress, withPendingUnitCount: pending)
+            }
+        }
+    }
+
+    private static func parseResponse<E: LocalizedError>(
+        data: Data?,
+        response: URLResponse?,
+        error: Error?,
+        acceptableStatusCodes: [ClosedRange<Int>]
+    ) -> WordPressAPIResult<HTTPAPIResponse<Data>, E> {
+        let result: WordPressAPIResult<HTTPAPIResponse<Data>, E>
+
+        if let error {
             if let urlError = error as? URLError {
-                return .failure(.connection(urlError))
+                result = .failure(.connection(urlError))
             } else {
-                return .failure(.unknown(underlyingError: error))
+                result = .failure(.unknown(underlyingError: error))
+            }
+        } else {
+            if let httpResponse = response as? HTTPURLResponse {
+                if acceptableStatusCodes.contains(where: { $0 ~= httpResponse.statusCode }) {
+                    result = .success(HTTPAPIResponse(response: httpResponse, body: data ?? Data()))
+                } else {
+                    result = .failure(.unacceptableStatusCode(response: httpResponse, body: data ?? Data()))
+                }
+            } else {
+                result = .failure(.unparsableResponse(response: nil, body: data))
             }
         }
 
-        let (body, response) = result
-
-        guard let response = response as? HTTPURLResponse else {
-            return .failure(.unparsableResponse(response: nil, body: body))
-        }
-
-        guard acceptableStatusCodes.contains(where: { $0 ~= response.statusCode }) else {
-            return .failure(.unacceptableStatusCode(response: response, body: body))
-        }
-
-        return .success(.init(response: response, body: body))
+        return result
     }
 
 }

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -35,8 +35,9 @@ extension URLSession {
         fulfillingProgress parentProgress: Progress? = nil,
         errorType: E.Type = E.self
     ) async -> WordPressAPIResult<HTTPAPIResponse<Data>, E> {
-        if let parentProgress  {
+        if let parentProgress {
             assert(parentProgress.completedUnitCount == 0 && parentProgress.totalUnitCount > 0, "Invalid parent progress")
+            assert(parentProgress.cancellationHandler == nil, "The progress instance's cancellationHandler property must be nil")
         }
 
         guard let request = try? builder.build() else {

--- a/WordPressKitTests/Utilities/URLSessionHelperTests.swift
+++ b/WordPressKitTests/Utilities/URLSessionHelperTests.swift
@@ -120,6 +120,29 @@ class URLSessionHelperTests: XCTestCase {
         XCTAssertEqual(progress.completedUnitCount, 20)
         XCTAssertEqual(progress.fractionCompleted, 1)
     }
+
+    func testCancellation() async throws {
+        // Give a slow HTTP request that takes 0.5 second to complete
+        stub(condition: isPath("/hello")) { _ in
+            let response = HTTPStubsResponse(data: "success".data(using: .utf8)!, statusCode: 200, headers: nil)
+            response.responseTime = 0.5
+            return response
+        }
+
+        // and cancelling it (in 0.1 second) before it completes
+        let progress = Progress.discreteProgress(totalUnitCount: 20)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+            progress.cancel()
+        }
+
+        // The result should be an cancellation result
+        let result = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), fulfillingProgress: progress, errorType: TestError.self)
+        if case let .failure(.connection(urlError)) = result, urlError.code == .cancelled {
+            // Do nothing
+        } else {
+            XCTFail("Unexpected result: \(result)")
+        }
+    }
 }
 
 private enum TestError: LocalizedError, Equatable {

--- a/WordPressKitTests/Utilities/URLSessionHelperTests.swift
+++ b/WordPressKitTests/Utilities/URLSessionHelperTests.swift
@@ -106,6 +106,20 @@ class URLSessionHelperTests: XCTestCase {
 
         try XCTAssertEqual(result.get().title, "Hello Post")
     }
+
+    func testProgressTracking() async throws {
+        stub(condition: isPath("/hello")) { _ in
+            HTTPStubsResponse(data: "success".data(using: .utf8)!, statusCode: 200, headers: nil)
+        }
+
+        let progress = Progress.discreteProgress(totalUnitCount: 20)
+        XCTAssertEqual(progress.completedUnitCount, 0)
+        XCTAssertEqual(progress.fractionCompleted, 0)
+
+        let _ = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), fulfillingProgress: progress, errorType: TestError.self)
+        XCTAssertEqual(progress.completedUnitCount, 20)
+        XCTAssertEqual(progress.fractionCompleted, 1)
+    }
 }
 
 private enum TestError: LocalizedError, Equatable {


### PR DESCRIPTION
### Description

> [!Note]
> This PR is built on top of https://github.com/wordpress-mobile/WordPressKit-iOS/pull/668

There are many existing APIs that returns a `Progress` instance, which can be used to track progress and some can be used to perform cancellation. This PR implements these features in the new URLSession helper.

The existing APIs return a `Progress` as function return value. We can't do the same, because the new helper is an `async` function: the `Progress` will be no use if it's used as a return value. I used a parent progress instance instead. The caller now needs to pass in a valid `Progress` instance that's created exclusively for the HTTP request, and it'll be completed upon the completion of the HTTP request.

Another approach I tried is using a `inout Progress` argument, so that we don't need to create a duplicated progress instance. I envisioned it can be used as below, but ended up getting a compiler error.

```swift
var progress = Progress(totalUnitCount: 100)
Task {
    // Compiler error. The `progress` reference can't be captured in this closure.
    let _ = await perform(request, &progress)
}
// Use the progress to track the HTTP request.
track(progress)
```

### Testing Details

See the added unit tests.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
