### PR TITLE
Return upon failure result

### DIFF
--- a/WordPressKit/WordPressOrgXMLRPCValidator.swift
+++ b/WordPressKit/WordPressOrgXMLRPCValidator.swift
@@ -97,6 +97,7 @@ open class WordPressOrgXMLRPCValidator: NSObject {
             }
         } else {
             failure(WordPressOrgXMLRPCValidatorError.invalidScheme as NSError)
+            return
         }
 
         tryGuessXMLRPCURLForSites(sitesToTry, userAgent: userAgent, success: success, failure: failure)


### PR DESCRIPTION
### Description

A simple one line change: I don't see why we need to continue sending the request if the URL is not an HTTP URL.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
