### PR TITLE
Add Remote Feature Flag Params to Dashboard Cards endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-_None._
+- Add `deviceId` param to `DashboardServiceRemote.fetch` method. [#674]
 
 ### New Features
 

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -612,6 +612,7 @@
 		F3FF8A25279C960F00E5C90F /* site-email-followers-get-auth-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = F3FF8A24279C960F00E5C90F /* site-email-followers-get-auth-failure.json */; };
 		F3FF8A27279C967200E5C90F /* site-email-followers-get-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = F3FF8A26279C967200E5C90F /* site-email-followers-get-failure.json */; };
 		F3FF8A29279C991B00E5C90F /* site-email-followers-get-success-more-pages.json in Resources */ = {isa = PBXBuildFile; fileRef = F3FF8A28279C991B00E5C90F /* site-email-followers-get-success-more-pages.json */; };
+		F41D98EA2B48602B004EC050 /* SessionDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41D98E92B48602B004EC050 /* SessionDetails.swift */; };
 		F4B0F4732ACAF498003ABC61 /* DomainsServiceRemote+AllDomains.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B0F4722ACAF498003ABC61 /* DomainsServiceRemote+AllDomains.swift */; };
 		F4B0F47C2ACB4B74003ABC61 /* get-all-domains-response.json in Resources */ = {isa = PBXBuildFile; fileRef = F4B0F47B2ACB4B74003ABC61 /* get-all-domains-response.json */; };
 		F4B0F4802ACB4EA9003ABC61 /* AllDomainsResultDomainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B0F47F2ACB4EA9003ABC61 /* AllDomainsResultDomainTests.swift */; };
@@ -1320,6 +1321,7 @@
 		F3FF8A24279C960F00E5C90F /* site-email-followers-get-auth-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-email-followers-get-auth-failure.json"; sourceTree = "<group>"; };
 		F3FF8A26279C967200E5C90F /* site-email-followers-get-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-email-followers-get-failure.json"; sourceTree = "<group>"; };
 		F3FF8A28279C991B00E5C90F /* site-email-followers-get-success-more-pages.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-email-followers-get-success-more-pages.json"; sourceTree = "<group>"; };
+		F41D98E92B48602B004EC050 /* SessionDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDetails.swift; sourceTree = "<group>"; };
 		F4B0F4722ACAF498003ABC61 /* DomainsServiceRemote+AllDomains.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DomainsServiceRemote+AllDomains.swift"; sourceTree = "<group>"; };
 		F4B0F47B2ACB4B74003ABC61 /* get-all-domains-response.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "get-all-domains-response.json"; sourceTree = "<group>"; };
 		F4B0F47F2ACB4EA9003ABC61 /* AllDomainsResultDomainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllDomainsResultDomainTests.swift; sourceTree = "<group>"; };
@@ -2099,6 +2101,7 @@
 				FEF7419C28085D89002C4203 /* RemoteBloggingPrompt.swift */,
 				FE20A6A3282A96C00025E975 /* RemoteBloggingPromptsSettings.swift */,
 				1DAC3D2529AF4F250068FE13 /* RemoteVideoPressVideo.swift */,
+				F41D98E92B48602B004EC050 /* SessionDetails.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -3381,6 +3384,7 @@
 				82FFBF501F45EFD100F4573F /* RemoteBlogJetpackSettings.swift in Sources */,
 				74650F741F0EA1E200188EDB /* RemoteGravatarProfile.swift in Sources */,
 				40E7FEB4221063480032834E /* StatsTodayInsight.swift in Sources */,
+				F41D98EA2B48602B004EC050 /* SessionDetails.swift in Sources */,
 				436D563C2118E18D00CEAA33 /* WPState.swift in Sources */,
 				439A44DA2107C93000795ED7 /* RemotePlan_ApiVersion1_3.swift in Sources */,
 				93BD27811EE73944002BB00B /* WordPressOrgXMLRPCApi.swift in Sources */,

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -36,12 +36,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
         let cardsParams: [String: AnyObject] = [
             "cards": cards.joined(separator: ",") as NSString
         ]
-        let featureFlagParams = try {
-            let params = FeatureFlagRemote.FetchAllEndpointParams(deviceId: deviceId)
-            let encoder = JSONEncoder()
-            let data = try encoder.encode(params)
-            return try JSONSerialization.jsonObject(with: data) as? [String: AnyObject]
-        }()
+        let featureFlagParams = try FeatureFlagRemote.FetchAllEndpointParams(deviceId: deviceId).dictionaryRepresentation()
         return cardsParams.merging(featureFlagParams ?? [:]) { first, second in
             return first
         }

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -1,12 +1,21 @@
 import Foundation
 
 open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
-    open func fetch(cards: [String], forBlogID blogID: Int, success: @escaping (NSDictionary) -> Void, failure: @escaping (Error) -> Void) {
+    open func fetch(
+        cards: [String],
+        forBlogID blogID: Int,
+        deviceId: String,
+        success: @escaping (NSDictionary) -> Void,
+        failure: @escaping (Error) -> Void
+    ) {
         let requestUrl =  self.path(forEndpoint: "sites/\(blogID)/dashboard/cards-data/", withVersion: ._2_0)
+        var params: [String: AnyObject]?
 
-        let params: [String: AnyObject] = [
-            "cards": cards.joined(separator: ",") as NSString
-        ]
+        do {
+            params = try self.makeQueryParams(cards: cards, deviceId: deviceId)
+        } catch {
+            failure(error)
+        }
 
         wordPressComRestApi.GET(requestUrl,
                                 parameters: params,
@@ -21,6 +30,21 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
             failure(error)
             WPKitLogError("Error fetching dashboard cards: \(error)")
         })
+    }
+
+    private func makeQueryParams(cards: [String], deviceId: String) throws -> [String: AnyObject] {
+        let cardsParams: [String: AnyObject] = [
+            "cards": cards.joined(separator: ",") as NSString
+        ]
+        let featureFlagParams = try {
+            let params = FeatureFlagRemote.RemoteFeatureFlagsEndpointParams(deviceId: deviceId)
+            let encoder = JSONEncoder()
+            let data = try encoder.encode(params)
+            return try JSONSerialization.jsonObject(with: data) as? [String: AnyObject]
+        }()
+        return cardsParams.merging(featureFlagParams ?? [:]) { first, second in
+            return first
+        }
     }
 
     enum ResponseError: Error {

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -36,7 +36,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
         let cardsParams: [String: AnyObject] = [
             "cards": cards.joined(separator: ",") as NSString
         ]
-        let featureFlagParams = try FeatureFlagRemote.FetchAllEndpointParams(deviceId: deviceId).dictionaryRepresentation()
+        let featureFlagParams = try SessionDetails(deviceId: deviceId).dictionaryRepresentation()
         return cardsParams.merging(featureFlagParams ?? [:]) { first, second in
             return first
         }

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -37,7 +37,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
             "cards": cards.joined(separator: ",") as NSString
         ]
         let featureFlagParams = try {
-            let params = FeatureFlagRemote.RemoteFeatureFlagsEndpointParams(deviceId: deviceId)
+            let params = FeatureFlagRemote.FetchAllEndpointParams(deviceId: deviceId)
             let encoder = JSONEncoder()
             let data = try encoder.encode(params)
             return try JSONSerialization.jsonObject(with: data) as? [String: AnyObject]

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -2,12 +2,14 @@ import Foundation
 
 open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
     open func fetch(cards: [String], forBlogID blogID: Int, success: @escaping (NSDictionary) -> Void, failure: @escaping (Error) -> Void) {
-        guard let requestUrl = endpoint(for: cards, blogID: blogID) else {
-            return
-        }
+        let requestUrl =  self.path(forEndpoint: "sites/\(blogID)/dashboard/cards-data/", withVersion: ._2_0)
+
+        let params: [String: AnyObject] = [
+            "cards": cards.joined(separator: ",") as NSString
+        ]
 
         wordPressComRestApi.GET(requestUrl,
-                                parameters: nil,
+                                parameters: params,
                                 success: { response, _ in
             guard let cards = response as? NSDictionary else {
                 failure(ResponseError.decodingFailure)
@@ -19,19 +21,6 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
             failure(error)
             WPKitLogError("Error fetching dashboard cards: \(error)")
         })
-    }
-
-    private func endpoint(for cards: [String], blogID: Int) -> String? {
-        var path = URLComponents(string: "sites/\(blogID)/dashboard/cards-data/")
-
-        let cardsEncoded = cards.joined(separator: ",")
-        path?.queryItems = [URLQueryItem(name: "cards", value: cardsEncoded)]
-
-        guard let endpoint = path?.string else {
-            return nil
-        }
-
-        return self.path(forEndpoint: endpoint, withVersion: ._2_0)
     }
 
     enum ResponseError: Error {

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -54,4 +54,23 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
                                     callback(.failure(error))
                                 })
     }
+
+    struct GetRemoteFeatureFlagsEndpointParams {
+        let deviceId: String
+        let platform: String
+        let buildNumber: String
+        let marketingVersion: String
+        let identifier: String
+    }
+}
+
+extension FeatureFlagRemote.GetRemoteFeatureFlagsEndpointParams: Decodable {
+
+    enum CodingKeys: String, CodingKey {
+        case deviceId = "device_id"
+        case platform = "platform"
+        case buildNumber = "build_number"
+        case marketingVersion = "marketing_version"
+        case identifier = "identifier"
+    }
 }

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -9,10 +9,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
     }
 
     open func getRemoteFeatureFlags(forDeviceId deviceId: String, callback: @escaping FeatureFlagResponseCallback) {
-        self.getRemoteFeatureFlags(params: .init(deviceId: deviceId), callback: callback)
-    }
-
-    open func getRemoteFeatureFlags(params: RemoteFeatureFlagsEndpointParams, callback: @escaping FeatureFlagResponseCallback) {
+        let params = RemoteFeatureFlagsEndpointParams(deviceId: deviceId)
         let endpoint = "mobile/feature-flags"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
         var parameters: [String: AnyObject]?

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -9,7 +9,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
     }
 
     open func getRemoteFeatureFlags(forDeviceId deviceId: String, callback: @escaping FeatureFlagResponseCallback) {
-        let params = FetchAllEndpointParams(deviceId: deviceId)
+        let params = SessionDetails(deviceId: deviceId)
         let endpoint = "mobile/feature-flags"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
         var dictionary: [String: AnyObject]?
@@ -53,38 +53,5 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
 
                                     callback(.failure(error))
                                 })
-    }
-
-    public struct FetchAllEndpointParams {
-        let deviceId: String
-        let platform: String
-        let buildNumber: String
-        let marketingVersion: String
-        let identifier: String
-    }
-}
-
-extension FeatureFlagRemote.FetchAllEndpointParams: Encodable {
-
-    enum CodingKeys: String, CodingKey {
-        case deviceId = "device_id"
-        case platform = "platform"
-        case buildNumber = "build_number"
-        case marketingVersion = "marketing_version"
-        case identifier = "identifier"
-    }
-
-    init(deviceId: String, bundle: Bundle = .main) {
-        self.deviceId = deviceId
-        self.platform = "ios"
-        self.buildNumber = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
-        self.marketingVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-        self.identifier = bundle.bundleIdentifier ?? "Unknown"
-    }
-
-    func dictionaryRepresentation() throws -> [String: AnyObject]? {
-        let encoder = JSONEncoder()
-        let data = try encoder.encode(self)
-        return try JSONSerialization.jsonObject(with: data) as? [String: AnyObject]
     }
 }

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -9,7 +9,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
     }
 
     open func getRemoteFeatureFlags(forDeviceId deviceId: String, callback: @escaping FeatureFlagResponseCallback) {
-        let params = RemoteFeatureFlagsEndpointParams(deviceId: deviceId)
+        let params = FetchAllEndpointParams(deviceId: deviceId)
         let endpoint = "mobile/feature-flags"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
         var dictionary: [String: AnyObject]?
@@ -55,7 +55,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
                                 })
     }
 
-    public struct RemoteFeatureFlagsEndpointParams {
+    public struct FetchAllEndpointParams {
         let deviceId: String
         let platform: String
         let buildNumber: String
@@ -64,7 +64,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
     }
 }
 
-extension FeatureFlagRemote.RemoteFeatureFlagsEndpointParams: Encodable {
+extension FeatureFlagRemote.FetchAllEndpointParams: Encodable {
 
     enum CodingKeys: String, CodingKey {
         case deviceId = "device_id"

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -86,4 +86,10 @@ extension FeatureFlagRemote.RemoteFeatureFlagsEndpointParams: Encodable {
         self.marketingVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
         self.identifier = bundle.bundleIdentifier ?? "Unknown"
     }
+
+    func dictionaryRepresentation() throws -> [String: AnyObject]? {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        return try JSONSerialization.jsonObject(with: data) as? [String: AnyObject]
+    }
 }

--- a/WordPressKit/FeatureFlagRemote.swift
+++ b/WordPressKit/FeatureFlagRemote.swift
@@ -82,8 +82,8 @@ extension FeatureFlagRemote.RemoteFeatureFlagsEndpointParams: Encodable {
     init(deviceId: String, bundle: Bundle = .main) {
         self.deviceId = deviceId
         self.platform = "ios"
-        self.buildNumber = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
-        self.marketingVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
-        self.identifier = Bundle.main.bundleIdentifier ?? "Unknown"
+        self.buildNumber = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+        self.marketingVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        self.identifier = bundle.bundleIdentifier ?? "Unknown"
     }
 }

--- a/WordPressKit/SessionDetails.swift
+++ b/WordPressKit/SessionDetails.swift
@@ -1,0 +1,33 @@
+public struct SessionDetails {
+    
+    let deviceId: String
+    let platform: String
+    let buildNumber: String
+    let marketingVersion: String
+    let identifier: String
+}
+
+extension SessionDetails: Encodable {
+
+    enum CodingKeys: String, CodingKey {
+        case deviceId = "device_id"
+        case platform = "platform"
+        case buildNumber = "build_number"
+        case marketingVersion = "marketing_version"
+        case identifier = "identifier"
+    }
+
+    init(deviceId: String, bundle: Bundle = .main) {
+        self.deviceId = deviceId
+        self.platform = "ios"
+        self.buildNumber = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
+        self.marketingVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
+        self.identifier = bundle.bundleIdentifier ?? "Unknown"
+    }
+
+    func dictionaryRepresentation() throws -> [String: AnyObject]? {
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(self)
+        return try JSONSerialization.jsonObject(with: data) as? [String: AnyObject]
+    }
+}

--- a/WordPressKit/SessionDetails.swift
+++ b/WordPressKit/SessionDetails.swift
@@ -1,5 +1,4 @@
 public struct SessionDetails {
-    
     let deviceId: String
     let platform: String
     let buildNumber: String

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -23,7 +23,7 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
             "marketing_version",
             "device_id",
             "cards",
-            "locale",
+            "locale"
         ]
 
         stubRemoteResponse({ req in

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -17,6 +17,11 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get cards successfully")
 
         let expectedQueryParams = [
+//            "identifier": "com.apple.dt.xctest.tool",
+//            "platform": "ios",
+//            "build_number": "22516",
+//            "marketing_version": "15.1",
+//            "device_id": "Test",
             "cards": "posts,todays_stats",
             "locale": "en"
         ]

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -17,11 +17,11 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get cards successfully")
 
         let expectedQueryParams = [
-//            "identifier": "com.apple.dt.xctest.tool",
-//            "platform": "ios",
-//            "build_number": "22516",
-//            "marketing_version": "15.1",
-//            "device_id": "Test",
+            "identifier": "com.apple.dt.xctest.tool",
+            "platform": "ios",
+            "build_number": "22516",
+            "marketing_version": "15.1",
+            "device_id": "Test",
             "cards": "posts,todays_stats",
             "locale": "en"
         ]
@@ -34,7 +34,11 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
             return matchesURL
         }, filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
 
-        dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
+        dashboardServiceRemote.fetch(
+            cards: ["posts", "todays_stats"],
+            forBlogID: 165243437,
+            deviceId: "Test"
+        ) { _ in
             expect.fulfill()
         } failure: { _ in }
 
@@ -45,9 +49,18 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
     //
     func testRequestCards() {
         let expect = expectation(description: "Get cards successfully")
-        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards-data/?cards=posts,todays_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
 
-        dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { cards in
+        stubRemoteResponse(
+            isPath("/wpcom/v2/sites/165243437/dashboard/cards-data"),
+            filename: "dashboard-200-with-drafts-and-scheduled-posts.json",
+            contentType: .ApplicationJSON
+        )
+
+        dashboardServiceRemote.fetch(
+            cards: ["posts", "todays_stats"],
+            forBlogID: 165243437,
+            deviceId: "Test"
+        ) { cards in
             XCTAssertTrue((cards["posts"] as! NSDictionary)["has_published"] as! Bool)
             XCTAssertEqual((cards["todays_stats"] as! NSDictionary)["views"] as! Int, 0)
             expect.fulfill()
@@ -62,7 +75,11 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get cards successfully")
         stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards-data/?cards=posts,todays_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON, status: 503)
 
-        dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
+        dashboardServiceRemote.fetch(
+            cards: ["posts", "todays_stats"],
+            forBlogID: 165243437,
+            deviceId: "Test"
+        ) { _ in
             XCTFail("This call should not suceed")
         } failure: { error in
             expect.fulfill()
@@ -77,7 +94,11 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get cards successfully")
         stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards-data/?cards=invalid_card", filename: "dashboard-400-invalid-card.json", contentType: .ApplicationJSON, status: 400)
 
-        dashboardServiceRemote.fetch(cards: ["invalid_card"], forBlogID: 165243437) { _ in
+        dashboardServiceRemote.fetch(
+            cards: ["invalid_card"],
+            forBlogID: 165243437,
+            deviceId: "Test"
+        ) { _ in
             XCTFail("This call should not suceed")
         } failure: { error in
             expect.fulfill()
@@ -92,7 +113,11 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         let expect = expectation(description: "Get cards successfully")
         stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards-data/?cards=posts,todays_stats", data: "foo".data(using: .utf8)!, contentType: .ApplicationJSON)
 
-        dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
+        dashboardServiceRemote.fetch(
+            cards: ["posts", "todays_stats"],
+            forBlogID: 165243437,
+            deviceId: "Test"
+        ) { _ in
             XCTFail("This call should not suceed")
         } failure: { error in
             expect.fulfill()

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import OHHTTPStubs
 
 @testable import WordPressKit
 
@@ -14,7 +15,19 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
     //
     func testRequestCardsParam() {
         let expect = expectation(description: "Get cards successfully")
-        stubRemoteResponse("wpcom/v2/sites/165243437/dashboard/cards-data/?cards=posts,todays_stats", filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
+
+        let expectedQueryParams = [
+            "cards": "posts,todays_stats",
+            "locale": "en"
+        ]
+
+        stubRemoteResponse({ req in
+            let containsQueryParams = containsQueryParams(expectedQueryParams)(req)
+            let matchesPath = isPath("/wpcom/v2/sites/165243437/dashboard/cards-data")(req)
+            let matchesURL = containsQueryParams && matchesPath
+            XCTAssertTrue(matchesURL)
+            return matchesURL
+        }, filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
 
         dashboardServiceRemote.fetch(cards: ["posts", "todays_stats"], forBlogID: 165243437) { _ in
             expect.fulfill()

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -23,7 +23,7 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
             "marketing_version",
             "device_id",
             "cards",
-            "locale"
+            "locale",
         ]
 
         stubRemoteResponse({ req in

--- a/WordPressKitTests/RemoteTestCase.swift
+++ b/WordPressKitTests/RemoteTestCase.swift
@@ -43,6 +43,31 @@ extension RemoteTestCase {
     /// Helper function that creates a stub which uses a file for the response body.
     ///
     /// - Parameters:
+    ///     - condition: The endpoint matcher block that determines if the request will be stubbed
+    ///     - filename: The name of the file to use for the response
+    ///     - contentType: The Content-Type returned in the response header
+    ///     - status: The status code to use for the response. Defaults to 200.
+    ///
+    func stubRemoteResponse(
+        _ condition: @escaping (URLRequest) -> Bool,
+        filename: String,
+        contentType: ResponseContentType,
+        status: Int32 = 200
+    ) {
+        stub(condition: condition) { _ in
+            let stubPath = OHPathForFile(filename, type(of: self))
+            var headers: [NSObject: AnyObject]?
+
+            if contentType != .NoContentType {
+                headers = ["Content-Type" as NSObject: contentType.rawValue as AnyObject]
+            }
+            return OHHTTPStubs.fixture(filePath: stubPath!, status: status, headers: headers)
+        }
+    }
+
+    /// Helper function that creates a stub which uses a file for the response body.
+    ///
+    /// - Parameters:
     ///     - endpoint: The endpoint matcher block that determines if the request will be stubbed
     ///     - filename: The name of the file to use for the response
     ///     - contentType: The Content-Type returned in the response header

--- a/WordPressKitTests/RemoteTestCase.swift
+++ b/WordPressKitTests/RemoteTestCase.swift
@@ -185,4 +185,34 @@ extension RemoteTestCase {
             print("Unable to clear cache: \(error)")
         }
     }
+
+    /// Checks if the specified set of query parameter names are all present in a given `URLRequest`.
+    /// This method verifies the presence of query parameter names in the request's URL without evaluating their values.
+    ///
+    /// - Parameters:
+    ///   - queryParams: A set of query parameter names to check for in the request.
+    ///   - request: The `URLRequest` to inspect for the presence of query parameter names.
+    /// - Returns: A Boolean value indicating whether all specified query parameter names are present in the request's URL.
+    func queryParams(_ queryParams: Set<String>, containedInRequest request: URLRequest) -> Bool {
+        guard let url = request.url else {
+            return false
+        }
+        return queryParamsContained(queryParams, containedInURL: url)
+    }
+
+    /// Checks if the specified set of query parameter names are all present in a given `URL`.
+    /// This method verifies the presence of query parameter names in the URL's query string without evaluating their values.
+    ///
+    /// - Parameters:
+    ///   - queryParams: A set of query parameter names to check for in the URL.
+    ///   - url: The `URL` to inspect for the presence of query parameter names.
+    /// - Returns: A Boolean value indicating whether all specified query parameter names are present in the URL's query string.
+    func queryParamsContained(_ queryParams: Set<String>, containedInURL url: URL) -> Bool {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+              let queryItems = components.queryItems?.map({ $0.name })
+        else {
+            return false
+        }
+        return queryParams.intersection(queryItems) == queryParams
+    }
 }

--- a/WordPressKitTests/Utilities/FeatureFlagRemoteTests.swift
+++ b/WordPressKitTests/Utilities/FeatureFlagRemoteTests.swift
@@ -10,16 +10,16 @@ class FeatureFlagRemoteTests: RemoteTestCase, RESTTestable {
         let expectation = expectation(description: "Get Remote Feature Flags Endpoint should contain query params")
 
         let response = try makeResponse()
-        let expectedQueryParams = [
-            "identifier": "com.apple.dt.xctest.tool",
-            "platform": "ios",
-            "build_number": "22516",
-            "marketing_version": "15.1",
-            "device_id": "Test"
+        let expectedQueryParams: Set<String> = [
+            "identifier",
+            "platform",
+            "build_number",
+            "marketing_version",
+            "device_id"
         ]
 
         stub { req -> Bool in
-            let containsQueryParams = containsQueryParams(expectedQueryParams)(req)
+            let containsQueryParams = self.queryParams(expectedQueryParams, containedInRequest: req)
             let matchesPath = isPath(self.endpoint)(req)
             let matchesURL = containsQueryParams && matchesPath
             XCTAssertTrue(matchesURL)


### PR DESCRIPTION
### Description

Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/22315

This PR passes the following params to the dashboard cards endpoint: 
* `device_id`
* `platform`
* `build_number`
* `marketing_version`
* `identifier`

### Testing Details
See https://github.com/wordpress-mobile/WordPress-iOS/pull/22320

## Note 
Please remove the `[Status] DO NOT MERGE` label and merge after:
* the backend change is deployed D133371-code
* the WPiOS PR is approved so that the two PRs are merged together and no breakages is introduced in `trunk`

---
- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
