### PR TITLE
Bump version to 9.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 9.0.2
+
+### Bug Fixes
+
+- Improve XML-RPC error messages to suggest contacting the host. [#655]
+
 ## 9.0.1
 
 ### Internal Changes

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '9.0.1'
+  s.version       = '9.0.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS [24.0](https://github.com/wordpress-mobile/WordPress-iOS/milestone/265) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

Notice that this PR is not based off the latest `trunk` but https://github.com/wordpress-mobile/WordPressKit-iOS/pull/655. See details in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/674#issuecomment-1880241165 