### PR TITLE
Make the deviceId argument optional in the DashboardServiceRemote.deviceId method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,11 @@ _None._
 
 ### Breaking Changes
 
-- Add `deviceId` param to `DashboardServiceRemote.fetch` method. [#674]
+_None._
 
 ### New Features
 
-_None._
+- Add `deviceId` param to `DashboardServiceRemote.fetch` method. [#674]
 
 ### Bug Fixes
 

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -4,7 +4,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
     open func fetch(
         cards: [String],
         forBlogID blogID: Int,
-        deviceId: String,
+        deviceId: String? = nil,
         success: @escaping (NSDictionary) -> Void,
         failure: @escaping (Error) -> Void
     ) {
@@ -32,11 +32,16 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 
-    private func makeQueryParams(cards: [String], deviceId: String) throws -> [String: AnyObject] {
+    private func makeQueryParams(cards: [String], deviceId: String?) throws -> [String: AnyObject] {
         let cardsParams: [String: AnyObject] = [
             "cards": cards.joined(separator: ",") as NSString
         ]
-        let featureFlagParams = try SessionDetails(deviceId: deviceId).dictionaryRepresentation()
+        let featureFlagParams: [String: AnyObject]? = try {
+            guard let deviceId else {
+                return nil
+            }
+            return try SessionDetails(deviceId: deviceId).dictionaryRepresentation()
+        }()
         return cardsParams.merging(featureFlagParams ?? [:]) { first, second in
             return first
         }

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -49,6 +49,36 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
+    // Validates the request's path and query items when the `deviceId` param is `nil`.
+    //
+    func testRequestCardsParamWithoutDeviceId() {
+        let expect = expectation(description: "Dashboard endpoint should contain query params")
+        let expectedPath = "/wpcom/v2/sites/165243437/dashboard/cards-data"
+        let expectedQueryParams: Set<String> = ["cards", "locale"]
+
+        stubRemoteResponse({ req in
+            let url = req.url?.absoluteString ?? ""
+            let containsQueryParams = self.queryParams(expectedQueryParams, containedInRequest: req)
+            let matchesPath = isPath(expectedPath)(req)
+            XCTAssertTrue(matchesPath, "The URL '\(url)' doesn't match the expected path.")
+            XCTAssertTrue(containsQueryParams, "The URL '\(url)' doesn't contain the expected query params.")
+            return containsQueryParams && matchesPath
+        }, filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
+
+        dashboardServiceRemote.fetch(
+            cards: ["posts", "todays_stats"],
+            forBlogID: 165243437,
+            deviceId: nil
+        ) { _ in
+            expect.fulfill()
+        } failure: { error in
+            XCTFail("Dashboard cards request failed: \(error.localizedDescription)")
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
     // Return the cards when the request succeeds
     //
     func testRequestCards() {

--- a/WordPressKitTests/RemoteTestCase.swift
+++ b/WordPressKitTests/RemoteTestCase.swift
@@ -197,7 +197,7 @@ extension RemoteTestCase {
         guard let url = request.url else {
             return false
         }
-        return queryParamsContained(queryParams, containedInURL: url)
+        return self.queryParams(queryParams, containedInURL: url)
     }
 
     /// Checks if the specified set of query parameter names are all present in a given `URL`.
@@ -207,7 +207,7 @@ extension RemoteTestCase {
     ///   - queryParams: A set of query parameter names to check for in the URL.
     ///   - url: The `URL` to inspect for the presence of query parameter names.
     /// - Returns: A Boolean value indicating whether all specified query parameter names are present in the URL's query string.
-    func queryParamsContained(_ queryParams: Set<String>, containedInURL url: URL) -> Bool {
+    func queryParams(_ queryParams: Set<String>, containedInURL url: URL) -> Bool {
         guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
               let queryItems = components.queryItems?.map({ $0.name })
         else {


### PR DESCRIPTION
### Description

Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/22320#issuecomment-1882125134

This PR updates the `DashboardServiceRemote.deviceId` method to make the `deviceId` argument optional to prevent breaking users of this library.

### Testing Details
N/A

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
