### PR TITLE
Merge 9.0.3 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-- Add `deviceId` param to `DashboardServiceRemote.fetch` method. [#674]
+_None._
 
 ### Bug Fixes
 
@@ -47,6 +47,16 @@ _None._
 ### Internal Changes
 
 _None._
+
+## 9.0.3
+
+_Note: This version should have been 9.1.0, because it introduces a new feature._
+_However, WordPressAuthenticator currently depends on WordPressKit via `~> 9.0.0` which would result in this version being incompatible._
+_In the interest of minimizing changes in the WordPress [24.0](https://github.com/wordpress-mobile/WordPress-iOS/milestone/265) release, we shipped this as 9.0.3 and decided to follow up in WordPressAuthenticator separately._
+
+### New Features
+
+- Add `deviceId` param to `DashboardServiceRemote.fetch` method. [#674]
 
 ## 9.0.2
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '9.0.2'
+  s.version       = '9.0.3'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION

This version bump PR is part of the code freeze workflow for WordPress iOS [24.0](https://github.com/wordpress-mobile/WordPress-iOS/milestone/265), in particular related to https://github.com/wordpress-mobile/WordPress-iOS/pull/22320, and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.