### PR TITLE
Make deviceId a required parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ _None._
 ### Breaking Changes
 
 - Add a new `unacceptableStatusCode` error case to `WordPressAPIError`. [#668]
+- The `deviceId` parameter in `DashboardServiceRemote` is now non-optional. [#678]
 
 ### New Features
 

--- a/WordPressKit/DashboardServiceRemote.swift
+++ b/WordPressKit/DashboardServiceRemote.swift
@@ -4,7 +4,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
     open func fetch(
         cards: [String],
         forBlogID blogID: Int,
-        deviceId: String? = nil,
+        deviceId: String,
         success: @escaping (NSDictionary) -> Void,
         failure: @escaping (Error) -> Void
     ) {
@@ -32,16 +32,11 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
         })
     }
 
-    private func makeQueryParams(cards: [String], deviceId: String?) throws -> [String: AnyObject] {
+    private func makeQueryParams(cards: [String], deviceId: String) throws -> [String: AnyObject] {
         let cardsParams: [String: AnyObject] = [
             "cards": cards.joined(separator: ",") as NSString
         ]
-        let featureFlagParams: [String: AnyObject]? = try {
-            guard let deviceId else {
-                return nil
-            }
-            return try SessionDetails(deviceId: deviceId).dictionaryRepresentation()
-        }()
+        let featureFlagParams: [String: AnyObject]? = try SessionDetails(deviceId: deviceId).dictionaryRepresentation()
         return cardsParams.merging(featureFlagParams ?? [:]) { first, second in
             return first
         }

--- a/WordPressKitTests/DashboardServiceRemoteTests.swift
+++ b/WordPressKitTests/DashboardServiceRemoteTests.swift
@@ -49,36 +49,6 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
-    // Validates the request's path and query items when the `deviceId` param is `nil`.
-    //
-    func testRequestCardsParamWithoutDeviceId() {
-        let expect = expectation(description: "Dashboard endpoint should contain query params")
-        let expectedPath = "/wpcom/v2/sites/165243437/dashboard/cards-data"
-        let expectedQueryParams: Set<String> = ["cards", "locale"]
-
-        stubRemoteResponse({ req in
-            let url = req.url?.absoluteString ?? ""
-            let containsQueryParams = self.queryParams(expectedQueryParams, containedInRequest: req)
-            let matchesPath = isPath(expectedPath)(req)
-            XCTAssertTrue(matchesPath, "The URL '\(url)' doesn't match the expected path.")
-            XCTAssertTrue(containsQueryParams, "The URL '\(url)' doesn't contain the expected query params.")
-            return containsQueryParams && matchesPath
-        }, filename: "dashboard-200-with-drafts-and-scheduled-posts.json", contentType: .ApplicationJSON)
-
-        dashboardServiceRemote.fetch(
-            cards: ["posts", "todays_stats"],
-            forBlogID: 165243437,
-            deviceId: nil
-        ) { _ in
-            expect.fulfill()
-        } failure: { error in
-            XCTFail("Dashboard cards request failed: \(error.localizedDescription)")
-            expect.fulfill()
-        }
-
-        waitForExpectations(timeout: timeout, handler: nil)
-    }
-
     // Return the cards when the request succeeds
     //
     func testRequestCards() {


### PR DESCRIPTION
The parameter was [initially designed to be non-optional][PR-1]. Later it's [changed to be optional][PR-2], under [this proposal][comment-1].

This commit simply reverts the parameter to be non-optional, to ship it along with other breaking changes.

[PR-1]: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/674
[PR-2]: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/676
[comment-1]: https://github.com/wordpress-mobile/WordPress-iOS/pull/22320#issuecomment-1882125134

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
