### PR TITLE
Bump version to 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,7 @@ _None._
 
 ### Breaking Changes
 
-- Add a new `unacceptableStatusCode` error case to `WordPressAPIError`. [#668]
-- The `deviceId` parameter in `DashboardServiceRemote` is now non-optional. [#678]
+_None._
 
 ### New Features
 
@@ -43,11 +42,22 @@ _None._
 
 ### Bug Fixes
 
-- Fix a bug in parsing XMLRPC link from a RSD Link. [#671]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 10.0.0
+
+### Breaking Changes
+
+- Add a new `unacceptableStatusCode` error case to `WordPressAPIError`. [#668]
+- The `deviceId` parameter in `DashboardServiceRemote` is now non-optional. [#678]
+
+### Bug Fixes
+
+- Fix a bug in parsing XMLRPC link from a RSD Link. [#671]
 
 ## 9.0.3
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '9.0.3'
+  s.version       = '10.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

Release a major version now, so that we can update WordPressAuthenticator's dependency declaration and update both libraries in the apps.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
