### PR TITLE
Add syntax sugar to execute callbacks on `Result`

### DIFF
--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		32FC1D29255C91ED00CD0A7B /* JetpackScanServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FC1D27255C91ED00CD0A7B /* JetpackScanServiceRemote.swift */; };
 		32FC20CE255DCC6100CD0A7B /* JetpackScanThreat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32FC20CD255DCC6100CD0A7B /* JetpackScanThreat.swift */; };
 		3F3195AD266FF94B00397EE7 /* ZendeskMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3195AC266FF94B00397EE7 /* ZendeskMetadata.swift */; };
+		3F391E1A2B50F3EB007975C4 /* Result+Callback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F391E192B50F3EB007975C4 /* Result+Callback.swift */; };
 		3F3C9E9C289A3E31009A1357 /* TestCollector+Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3C9E9B289A3E31009A1357 /* TestCollector+Constants.swift */; };
 		3F758FD324F6C68200BBA2FC /* AnnouncementServiceRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F758FD224F6C68200BBA2FC /* AnnouncementServiceRemote.swift */; };
 		3F8308A729EE683500354497 /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8308A629EE683500354497 /* ActivityTests.swift */; };
@@ -763,6 +764,7 @@
 		32FC1D27255C91ED00CD0A7B /* JetpackScanServiceRemote.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JetpackScanServiceRemote.swift; sourceTree = "<group>"; };
 		32FC20CD255DCC6100CD0A7B /* JetpackScanThreat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanThreat.swift; sourceTree = "<group>"; };
 		3F3195AC266FF94B00397EE7 /* ZendeskMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZendeskMetadata.swift; sourceTree = "<group>"; };
+		3F391E192B50F3EB007975C4 /* Result+Callback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Result+Callback.swift"; sourceTree = "<group>"; };
 		3F3C9E9B289A3E31009A1357 /* TestCollector+Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TestCollector+Constants.swift"; sourceTree = "<group>"; };
 		3F758FD224F6C68200BBA2FC /* AnnouncementServiceRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementServiceRemote.swift; sourceTree = "<group>"; };
 		3F8308A629EE683500354497 /* ActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTests.swift; sourceTree = "<group>"; };
@@ -2479,6 +2481,7 @@
 				465F88A1263B325C00F4C950 /* ChecksumUtil.swift */,
 				3F3195AC266FF94B00397EE7 /* ZendeskMetadata.swift */,
 				4AE278432B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift */,
+				3F391E192B50F3EB007975C4 /* Result+Callback.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -3309,6 +3312,7 @@
 				B5969E1D20A49AC4005E9DF1 /* NSString+MD5.m in Sources */,
 				FF807251241FB90E00809AF5 /* WordPressOrgRestApi.swift in Sources */,
 				4A68E3E1294076C1004AC3DC /* RemoteReaderSiteInfo.swift in Sources */,
+				3F391E1A2B50F3EB007975C4 /* Result+Callback.swift in Sources */,
 				8236EB4D2024B9F8007C7CF9 /* RemoteBlogJetpackModulesSettings.swift in Sources */,
 				73A2F38A21E7F81E00388609 /* WordPressComServiceRemote+SiteVerticalsPrompt.swift in Sources */,
 				740B23BB1F17EC7300067A2A /* PostServiceRemoteXMLRPC.m in Sources */,

--- a/WordPressKit/Result+Callback.swift
+++ b/WordPressKit/Result+Callback.swift
@@ -1,0 +1,10 @@
+extension Swift.Result {
+
+    // Notice there are no explicit unit tests for this utility because it is implicitly tested via the consuming code's tests.
+    func execute(onSuccess: (Success) -> Void, onFailure: (Failure) -> Void) {
+        switch self {
+        case .success(let value): onSuccess(value)
+        case .failure(let error): onFailure(error)
+        }
+    }
+}

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -308,13 +308,8 @@ public final class WordPressComOAuthClient: NSObject {
         failure: @escaping (_ error: WordPressComOAuthError) -> Void
     ) {
         Task { @MainActor in
-            let result = await requestOneTimeCode(username: username, password: password)
-            switch result {
-            case .success:
-                success()
-            case let .failure(error):
-                failure(error)
-            }
+            await requestOneTimeCode(username: username, password: password)
+                .execute(onSuccess: success, onFailure: failure)
         }
     }
 
@@ -521,13 +516,8 @@ public final class WordPressComOAuthClient: NSObject {
         failure: @escaping (_ error: WordPressComOAuthError) -> Void
     ) {
         Task { @MainActor in
-            let result = await requestWebauthnChallenge(userID: userID, twoStepNonce: twoStepNonce)
-            switch result {
-            case let .success(data):
-                success(data)
-            case let .failure(error):
-                failure(error)
-            }
+            await requestWebauthnChallenge(userID: userID, twoStepNonce: twoStepNonce)
+                .execute(onSuccess: success, onFailure: failure)
         }
     }
 
@@ -624,7 +614,7 @@ public final class WordPressComOAuthClient: NSObject {
         failure: @escaping (_ error: WordPressComOAuthError) -> Void
     ) {
         Task { @MainActor in
-            let result = await authenticateWebauthnSignature(
+            await authenticateWebauthnSignature(
                 userID: userID,
                 twoStepNonce: twoStepNonce,
                 credentialID: credentialID,
@@ -633,12 +623,7 @@ public final class WordPressComOAuthClient: NSObject {
                 signature: signature,
                 userHandle: userHandle
             )
-            switch result {
-            case let .success(token):
-                success(token)
-            case let .failure(error):
-                failure(error)
-            }
+            .execute(onSuccess: success, onFailure: failure)
         }
     }
 
@@ -750,13 +735,13 @@ public final class WordPressComOAuthClient: NSObject {
         failure: @escaping (_ error: WordPressComOAuthError) -> Void
     ) {
         Task { @MainActor in
-            let result = await authenticate(socialLoginUserID: userID, authType: authType, twoStepCode: twoStepCode, twoStepNonce: twoStepNonce)
-            switch result {
-            case let .success(token):
-                success(token)
-            case let .failure(error):
-                failure(error)
-            }
+            await authenticate(
+                socialLoginUserID: userID,
+                authType: authType,
+                twoStepCode: twoStepCode,
+                twoStepNonce: twoStepNonce
+            )
+            .execute(onSuccess: success, onFailure: failure)
         }
     }
 


### PR DESCRIPTION
Seeing those

```swift
            switch result {
            case let .success(data):
                success(data)
            case let .failure(error):
                failure(error)
            }
```

"bothered" me. I feels like a lot of coding to type and read for something so straightforward. 

This is my attempt to be proactive about it instead of just complaining 😄 