### PR TITLE
Add a couple of unit tests for WordPressComRestApi error cases

### DIFF
--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OHHTTPStubs
 import XCTest
 @testable import WordPressKit
 
@@ -417,5 +418,23 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                    expect.fulfill()
                                })
         waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    func testNotConnectedToJetpack() {
+        let expect = expectation(description: "Check rewind status")
+
+        stub(condition: { $0.url?.path.contains(self.rewindStatusEndpoint) ?? false }) { _ in
+            HTTPStubsResponse(jsonObject: ["code": "no_connected_jetpack"], statusCode: 412, headers: nil)
+        }
+
+        remote.getRewindStatus(siteID) {
+            expect.fulfill()
+            XCTAssertEqual($0.state, .unavailable)
+        } failure: { error in
+            expect.fulfill()
+            XCTFail("The success block should be called")
+        }
+
+        wait(for: [expect], timeout: 0.1)
     }
 }


### PR DESCRIPTION
What says in the title.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
