### PR TITLE
Use hard-coded error domain string in unit tests

### DIFF
--- a/WordPressKitTests/AccountServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/AccountServiceRemoteRESTTests.swift
@@ -90,7 +90,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -111,7 +111,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -208,7 +208,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -229,7 +229,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -250,7 +250,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -271,7 +271,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -352,7 +352,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -373,7 +373,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -426,7 +426,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorizationRequired")
             expect.fulfill()
         })
@@ -448,7 +448,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -516,7 +516,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -554,7 +554,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -606,7 +606,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -643,7 +643,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -664,7 +664,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -685,7 +685,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
 
             expect.fulfill()
@@ -707,7 +707,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -744,7 +744,7 @@ class AccountServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })

--- a/WordPressKitTests/AccountSettingsRemoteTests.swift
+++ b/WordPressKitTests/AccountSettingsRemoteTests.swift
@@ -89,7 +89,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -106,7 +106,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -259,7 +259,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -292,7 +292,7 @@ class AccountSettingsRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.invalidInput.rawValue, "The error code should be 0 - invalid input")
             expect.fulfill()
         })

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -166,7 +166,7 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
                                       expect.fulfill()
                                   }, failure: { error in
                                       let error = error as NSError
-                                      XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+                                      XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
                                       XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
                                       expect.fulfill()
                                   })

--- a/WordPressKitTests/DomainsServiceRemoteRESTTests.swift
+++ b/WordPressKitTests/DomainsServiceRemoteRESTTests.swift
@@ -87,7 +87,7 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -104,7 +104,7 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -236,7 +236,7 @@ class DomainsServiceRemoteRESTTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.invalidQuery.rawValue, "The error code should be 10 - invalid_query")
             expect.fulfill()
         })

--- a/WordPressKitTests/NotificationSyncServiceRemoteTests.swift
+++ b/WordPressKitTests/NotificationSyncServiceRemoteTests.swift
@@ -76,7 +76,7 @@ class NotificationSyncServiceRemoteTests: RemoteTestCase, RESTTestable {
                 return
             }
             XCTAssertNil(notes)
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         }

--- a/WordPressKitTests/PeopleServiceRemoteTests.swift
+++ b/WordPressKitTests/PeopleServiceRemoteTests.swift
@@ -103,7 +103,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -120,7 +120,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -137,7 +137,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.invalidInput.rawValue, "The error code should be 0 - invalid input")
             expect.fulfill()
         })
@@ -169,7 +169,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -203,7 +203,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -220,7 +220,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -252,7 +252,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -326,7 +326,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         }, failure: { error in
             // Then
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization required")
             expect.fulfill()
         })
@@ -346,7 +346,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         }, failure: { error in
             // Then
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -366,7 +366,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         }, failure: { error in
             // Then
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -385,7 +385,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         }, failure: { error in
             // Then
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -420,7 +420,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
         }, failure: { error in
             // Then
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -485,7 +485,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -502,7 +502,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -552,7 +552,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -569,7 +569,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -647,7 +647,7 @@ class PeopleServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })

--- a/WordPressKitTests/PlanServiceRemoteTests.swift
+++ b/WordPressKitTests/PlanServiceRemoteTests.swift
@@ -119,7 +119,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }, failure: { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -247,7 +247,7 @@ class PlanServiceRemoteTests: RemoteTestCase, RESTTestable {
             expect.fulfill()
         }) { error in
             let error = error as NSError
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         }

--- a/WordPressKitTests/SiteManagementServiceRemoteTests.swift
+++ b/WordPressKitTests/SiteManagementServiceRemoteTests.swift
@@ -81,7 +81,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -102,7 +102,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -216,7 +216,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -237,7 +237,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })
@@ -361,7 +361,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.unknown.rawValue, "The error code should be 7 - unknown")
             expect.fulfill()
         })
@@ -382,7 +382,7 @@ class SiteManagementServiceRemoteTests: RemoteTestCase, RESTTestable {
                 expect.fulfill()
                 return
             }
-            XCTAssertEqual(error.domain, String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssertEqual(error.domain, "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssertEqual(error.code, WordPressComRestApiError.authorizationRequired.rawValue, "The error code should be 2 - authorization_required")
             expect.fulfill()
         })

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -102,7 +102,7 @@ class WordPressComRestApiTests: XCTestCase {
             XCTFail("This call should fail")
             }, failure: { (error, _) in
                 expect.fulfill()
-                XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error should a WordPressComRestApiError")
+                XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error should a WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.invalidToken.rawValue), "The error code should be invalid token")
         })
         self.waitForExpectations(timeout: 2, handler: nil)
@@ -138,7 +138,7 @@ class WordPressComRestApiTests: XCTestCase {
             XCTFail("This call should fail")
             }, failure: { (error, _) in
                 expect.fulfill()
-                XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+                XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.invalidInput.rawValue), "The error code should be invalid input")
         })
         self.waitForExpectations(timeout: 2, handler: nil)
@@ -156,7 +156,7 @@ class WordPressComRestApiTests: XCTestCase {
             XCTFail("This call should fail")
             }, failure: { (error, _) in
                 expect.fulfill()
-                XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+                XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.authorizationRequired.rawValue), "The error code should be AuthorizationRequired")
         })
         self.waitForExpectations(timeout: 2, handler: nil)
@@ -174,7 +174,7 @@ class WordPressComRestApiTests: XCTestCase {
             XCTFail("This call should fail")
             }, failure: { (error, _) in
                 expect.fulfill()
-                XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+                XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.uploadFailed.rawValue), "The error code should be AuthorizationRequired")
         })
         self.waitForExpectations(timeout: 2, handler: nil)
@@ -192,7 +192,7 @@ class WordPressComRestApiTests: XCTestCase {
             XCTFail("This call should fail")
         }, failure: { (error, _) in
             expect.fulfill()
-            XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error domain should be WordPressComRestApiError")
+            XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error domain should be WordPressComRestApiError")
             XCTAssert(error.code == Int(WordPressComRestApiError.uploadFailed.rawValue), "The error code should be AuthorizationRequired")
         })
         self.waitForExpectations(timeout: 2, handler: nil)

--- a/WordPressKitTests/WordPressComServiceRemoteRestTests.swift
+++ b/WordPressKitTests/WordPressComServiceRemoteRestTests.swift
@@ -61,7 +61,7 @@ class WordPressComServiceRemoteRestTests: XCTestCase {
             }, failure: { (error) in
                 expect.fulfill()
                 let error = error! as NSError
-                XCTAssert(error.domain == String(reflecting: WordPressComRestApiError.self), "The error should a WordPressComRestApiError")
+                XCTAssert(error.domain == "WordPressKit.WordPressComRestApiError", "The error should a WordPressComRestApiError")
                 XCTAssert(error.code == Int(WordPressComRestApiError.tooManyRequests.rawValue), "The error code should be too many requests")
         })
         self.waitForExpectations(timeout: 2, handler: nil)


### PR DESCRIPTION
### Description

This PR simply replaces all `String(reflecting: WordPressComRestApiError.self)` with its actual value `"WordPressKit.WordPressComRestApiError"`.

The `WordPressComRestApiError` type will be renamed in a upcoming PR. The only purpose of this PR is reducing some noise in the upcoming PR.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
