### PR TITLE
Fix an issue where the override parameter was ignored

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -57,7 +57,17 @@ final class HTTPRequestBuilder {
     }
 
     func append(query: [URLQueryItem], override: Bool) -> Self {
-        urlComponents.queryItems = (urlComponents.queryItems ?? []) + query
+        var allQuery = urlComponents.queryItems ?? []
+
+        if override {
+            let newKeys = Set(query.map { $0.name })
+            allQuery.removeAll(where: { newKeys.contains($0.name) })
+        }
+
+        allQuery.append(contentsOf: query)
+
+        urlComponents.queryItems = allQuery
+
         return self
     }
 

--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -56,7 +56,7 @@ final class HTTPRequestBuilder {
         append(query: [URLQueryItem(name: name, value: value)], override: override)
     }
 
-    func append(query: [URLQueryItem], override: Bool) -> Self {
+    func append(query: [URLQueryItem], override: Bool = false) -> Self {
         var allQuery = urlComponents.queryItems ?? []
 
         if override {

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -58,6 +58,48 @@ class HTTPRequestBuilderTests: XCTestCase {
         XCTAssertEqual(request.url?.absoluteString, "https://wordpress.org/hello/world")
     }
 
+    func testQueryOverride() {
+        try XCTAssertEqual(
+            HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+                .query(name: "foo", value: "bar", override: true)
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org?foo=bar"
+        )
+
+        try XCTAssertEqual(
+            HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+                .query(name: "foo", value: "bar", override: true)
+                .query(name: "foo", value: "hello", override: true)
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org?foo=hello"
+        )
+    }
+
+    func testQueryOverrideMany() {
+        try XCTAssertEqual(
+            HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+                .query(name: "foo", value: "bar", override: true)
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org?foo=bar"
+        )
+
+        try XCTAssertEqual(
+            HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+                .query(name: "foo", value: "bar", override: true)
+                .append(query: [URLQueryItem(name: "foo", value: "hello")], override: true)
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org?foo=hello"
+        )
+    }
+
     func testJSONBody() throws {
         var request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
             .method(.post)

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -77,6 +77,16 @@ class HTTPRequestBuilderTests: XCTestCase {
                 .absoluteString,
             "https://wordpress.org?foo=hello"
         )
+
+        try XCTAssertEqual(
+            HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+                .query(name: "foo", value: "bar", override: true)
+                .query(name: "foo", value: "hello", override: false)
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org?foo=bar&foo=hello"
+        )
     }
 
     func testQueryOverrideMany() {
@@ -97,6 +107,16 @@ class HTTPRequestBuilderTests: XCTestCase {
                 .url?
                 .absoluteString,
             "https://wordpress.org?foo=hello"
+        )
+
+        try XCTAssertEqual(
+            HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+                .query(name: "foo", value: "bar", override: true)
+                .append(query: [URLQueryItem(name: "foo", value: "hello")], override: false)
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org?foo=bar&foo=hello"
         )
     }
 

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -87,6 +87,16 @@ class HTTPRequestBuilderTests: XCTestCase {
                 .absoluteString,
             "https://wordpress.org?foo=bar&foo=hello"
         )
+
+        try XCTAssertEqual(
+            HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+                .query(name: "foo", value: "bar")
+                .query(name: "foo", value: "hello")
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org?foo=bar&foo=hello"
+        )
     }
 
     func testQueryOverrideMany() {
@@ -113,6 +123,16 @@ class HTTPRequestBuilderTests: XCTestCase {
             HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
                 .query(name: "foo", value: "bar", override: true)
                 .append(query: [URLQueryItem(name: "foo", value: "hello")], override: false)
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org?foo=bar&foo=hello"
+        )
+
+        try XCTAssertEqual(
+            HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+                .query(name: "foo", value: "bar")
+                .append(query: [URLQueryItem(name: "foo", value: "hello")])
                 .build()
                 .url?
                 .absoluteString,


### PR DESCRIPTION
### Description

I noticed the `override` argument in `func append(query: [URLQueryItem], override: Bool)` wasn't used. This PR fixes that.

This bug doesn't have any impact in the existing (which is only a couple of places) usages of `HTTPRequestBuilder`.

### Testing Details

See the added unit tests. Let me know if you think there are more should be added.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
