### PR TITLE
Add a test case for the existing URL query encoding behaviour

### DIFF
--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -60,6 +60,66 @@ class WordPressComRestApiTests: XCTestCase {
         }
     }
 
+    @available(iOS 16.0, *)
+    func testQuery() {
+        var requestURL: URL?
+        stub(condition: isRestAPIRequest()) {
+            requestURL = $0.url
+            return HTTPStubsResponse(error: URLError(URLError.Code.networkConnectionLost))
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressComRestApi(oAuthToken: "fakeToken")
+        api.GET(
+            wordPressMediaRoutePath,
+            parameters: [
+                "number": 1,
+                "true": true,
+                "false": false,
+                "string": "true",
+                "dict": ["foo": true, "bar": "string"],
+                "nested-dict": [
+                    "outter1": [
+                        "inner1": "value1",
+                        "inner2": "value2"
+                    ],
+                    "outter2": [
+                        "inner1": "value1",
+                        "inner2": "value2"
+                    ]
+                ],
+                "array": ["true", 1, false]
+            ] as [String: AnyObject],
+            success: { _, _ in expect.fulfill() },
+            failure: { (_, _) in expect.fulfill() }
+        )
+        wait(for: [expect], timeout: 0.1)
+
+        let query = requestURL?
+            .query(percentEncoded: false)?
+            .split(separator: "&")
+            .reduce(into: Set()) { $0.insert(String($1)) }
+        let expected = [
+            "number=1",
+            "true=1",
+            "false=0",
+            "string=true",
+            "dict[foo]=1",
+            "dict[bar]=string",
+            "nested-dict[outter1][inner1]=value1",
+            "nested-dict[outter1][inner2]=value2",
+            "nested-dict[outter2][inner1]=value1",
+            "nested-dict[outter2][inner2]=value2",
+            "array[]=true",
+            "array[]=1",
+            "array[]=0",
+        ]
+
+        for item in expected {
+            XCTAssertTrue(query?.contains(item) == true, "Missing query item: \(item)")
+        }
+    }
+
     func testSuccessfullCall() {
         stub(condition: isRestAPIRequest()) { _ in
             let stubPath = OHPathForFile("WordPressComRestApiMedia.json", type(of: self))


### PR DESCRIPTION
### Description

Adding this test to ensure an upcoming refactor to `WordPressComRestApi` doesn't break how URL query is encoded into API URLs.

### Testing Details

None needed.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
