### PR TITLE
Support encoding 'Any' query in HTTPRequestBuilder

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -56,6 +56,29 @@ final class HTTPRequestBuilder {
         append(query: [URLQueryItem(name: name, value: value)], override: override)
     }
 
+    func query(_ dict: [String: Any]) -> Self {
+        dict.reduce(self) {
+            $0.query(name: $1.key, value: $1.value)
+        }
+    }
+
+    func query(name: String, value: Any) -> Self {
+        switch value {
+        case let array as [Any]:
+            return array.reduce(self) {
+                $0.query(name: "\(name)[]", value: $1)
+            }
+        case let object as [String: Any]:
+            return object.reduce(self) {
+                $0.query(name: "\(name)[\($1.key)]", value: $1.value)
+            }
+        case let value as Bool:
+            return query(name: name, value: value ? "1" : "0", override: false)
+        default:
+            return query(name: name, value: "\(value)", override: false)
+        }
+    }
+
     func append(query: [URLQueryItem], override: Bool = false) -> Self {
         var allQuery = urlComponents.queryItems ?? []
 

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -140,6 +140,60 @@ class HTTPRequestBuilderTests: XCTestCase {
         )
     }
 
+    @available(iOS 16.0, *)
+    func testSetQueryWithDictionary() throws {
+        // The test data and assertions hre should be kept the same as the ones in `WordPressComRestApiTests.testQuery()`.
+
+        let query = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+            .query(
+                [
+                    "number": 1,
+                    "nsnumbe-true": NSNumber(value: true),
+                    "true": true,
+                    "false": false,
+                    "string": "true",
+                    "dict": ["foo": true, "bar": "string"],
+                    "nested-dict": [
+                        "outter1": [
+                            "inner1": "value1",
+                            "inner2": "value2"
+                        ],
+                        "outter2": [
+                            "inner1": "value1",
+                            "inner2": "value2"
+                        ]
+                    ],
+                    "array": ["true", 1, false]
+                ]
+            )
+            .build()
+            .url?
+            .query(percentEncoded: false)?
+            .split(separator: "&")
+            .reduce(into: Set()) { $0.insert(String($1)) }
+
+        let expected = [
+            "number=1",
+            "nsnumbe-true=1",
+            "true=1",
+            "false=0",
+            "string=true",
+            "dict[foo]=1",
+            "dict[bar]=string",
+            "nested-dict[outter1][inner1]=value1",
+            "nested-dict[outter1][inner2]=value2",
+            "nested-dict[outter2][inner1]=value1",
+            "nested-dict[outter2][inner2]=value2",
+            "array[]=true",
+            "array[]=1",
+            "array[]=0",
+        ]
+
+        for item in expected {
+            XCTAssertTrue(query?.contains(item) == true, "Missing query item: \(item)")
+        }
+    }
+
     func testJSONBody() throws {
         var request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
             .method(.post)


### PR DESCRIPTION
> [!Note]
> This PR is built on top of #688.

### Description

The implementation is the same as the existing query encoding behaviour.

### Testing Details

See the new unit test.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
