### PR TITLE
Change baseUrlString to baseURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-_None._
+- `WordPressComRestApi` initialisers now accept a `baseURL: URL` parameter instead of `baseUrlString: String`. [#691]
 
 ### New Features
 

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -181,7 +181,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
 
     NSString *endpoint = [NSString stringWithFormat:@"read/search?q=%@", [phrase stringByUrlEncoding]];
     NSString *absolutePath = [self pathForEndpoint:endpoint withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
-    NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:[NSURL URLWithString:self.wordPressComRestApi.baseURLString]];
+    NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:self.wordPressComRestApi.baseURL];
     return [url absoluteString];
 }
 

--- a/WordPressKit/ReaderTopicServiceRemote+Interests.swift
+++ b/WordPressKit/ReaderTopicServiceRemote+Interests.swift
@@ -50,6 +50,6 @@ extension ReaderTopicServiceRemote {
     public func pathForTopic(slug: String) -> String {
         let endpoint = path(forEndpoint: "read/tags/\(slug)/posts", withVersion: ._1_2)
 
-        return wordPressComRestApi.baseURLString.appending(endpoint)
+        return wordPressComRestApi.baseURL.appendingPathComponent(endpoint).absoluteString
     }
 }

--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -221,7 +221,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 - (NSString *)endpointUrlForPath:(NSString *)endpoint
 {
     NSString *absolutePath = [self pathForEndpoint:endpoint withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
-    NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:[NSURL URLWithString:self.wordPressComRestApi.baseURLString]];
+    NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:self.wordPressComRestApi.baseURL];
     return [url absoluteString];
 }
 

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -53,7 +53,7 @@ open class WordPressComRestApi: NSObject {
     public typealias SuccessResponseBlock = (_ responseObject: AnyObject, _ httpResponse: HTTPURLResponse?) -> Void
     public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> Void
 
-    @objc public static let apiBaseURLString: String = "https://public-api.wordpress.com/"
+    @objc public static let apiBaseURL: URL = URL(string: "https://public-api.wordpress.com/")!
 
     @objc public static let defaultBackgroundSessionIdentifier = "org.wordpress.wpcomrestapi"
 
@@ -69,7 +69,7 @@ open class WordPressComRestApi: NSObject {
 
     private let localeKey: String
 
-    @objc public let baseURLString: String
+    @objc public let baseURL: URL
 
     private var invalidTokenHandler: (() -> Void)?
 
@@ -116,8 +116,8 @@ open class WordPressComRestApi: NSObject {
         self.init(oAuthToken: oAuthToken, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressComRestApi.defaultBackgroundSessionIdentifier)
     }
 
-    @objc convenience public init(oAuthToken: String? = nil, userAgent: String? = nil, baseUrlString: String = WordPressComRestApi.apiBaseURLString) {
-        self.init(oAuthToken: oAuthToken, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressComRestApi.defaultBackgroundSessionIdentifier, baseUrlString: baseUrlString)
+    @objc convenience public init(oAuthToken: String? = nil, userAgent: String? = nil, baseURL: URL = WordPressComRestApi.apiBaseURL) {
+        self.init(oAuthToken: oAuthToken, userAgent: userAgent, backgroundUploads: false, backgroundSessionIdentifier: WordPressComRestApi.defaultBackgroundSessionIdentifier, baseURL: baseURL)
     }
 
     /// Creates a new API object to connect to the WordPress Rest API.
@@ -141,14 +141,14 @@ open class WordPressComRestApi: NSObject {
                 backgroundSessionIdentifier: String = WordPressComRestApi.defaultBackgroundSessionIdentifier,
                 sharedContainerIdentifier: String? = nil,
                 localeKey: String = WordPressComRestApi.LocaleKeyDefault,
-                baseUrlString: String = WordPressComRestApi.apiBaseURLString) {
+                baseURL: URL = WordPressComRestApi.apiBaseURL) {
         self.oAuthToken = oAuthToken
         self.userAgent = userAgent
         self.backgroundUploads = backgroundUploads
         self.backgroundSessionIdentifier = backgroundSessionIdentifier
         self.sharedContainerIdentifier = sharedContainerIdentifier
         self.localeKey = localeKey
-        self.baseURLString = baseUrlString
+        self.baseURL = baseURL
 
         super.init()
     }
@@ -381,9 +381,6 @@ open class WordPressComRestApi: NSObject {
     /// - Returns: a request URL if successful, `nil` otherwise.
     ///
     func buildRequestURLFor(path: String, parameters: [String: AnyObject]? = [:]) -> String? {
-
-        let baseURL = URL(string: self.baseURLString)
-
         guard let requestURLString = URL(string: path, relativeTo: baseURL)?.absoluteString,
             let urlComponents = URLComponents(string: requestURLString) else {
 

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -129,7 +129,7 @@ open class WordPressComRestApi: NSObject {
     ///   - backgroundSessionIdentifier: The session identifier to use for the background session. This must be unique in the system.
     ///   - sharedContainerIdentifier: An optional string used when setting up background sessions for use in an app extension. Default is nil.
     ///   - localeKey: The key with which to specify locale in the parameters of a request.
-    ///   - baseUrlString: The base url to use for API requests. Default is https://public-api.wordpress.com/
+    ///   - baseURL: The base url to use for API requests. Default is https://public-api.wordpress.com/
     ///
     /// - Discussion: When backgroundUploads are activated any request done by the multipartPOST method will use background session. This background session is shared for all multipart
     ///   requests and the identifier used must be unique in the system, Apple recomends to use invert DNS base on your bundle ID. Keep in mind these requests will continue even

--- a/WordPressKitTests/ReaderTopicServiceRemote+InterestsTests.swift
+++ b/WordPressKitTests/ReaderTopicServiceRemote+InterestsTests.swift
@@ -68,4 +68,15 @@ class ReaderTopicServiceRemoteInterestsTests: RemoteTestCase, RESTTestable {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
+    func testPathForTopic() {
+        XCTAssertEqual(
+            ReaderTopicServiceRemote(wordPressComRestApi: .init(baseUrlString: "https://public-api.wordpress.com")).pathForTopic(slug: "foo"),
+            "https://public-api.wordpress.com/rest/v1.2/read/tags/foo/posts"
+        )
+        XCTAssertEqual(
+            ReaderTopicServiceRemote(wordPressComRestApi: .init(baseUrlString: "https://public-api.wordpress.com/")).pathForTopic(slug: "foo"),
+            "https://public-api.wordpress.com/rest/v1.2/read/tags/foo/posts"
+        )
+    }
+
 }

--- a/WordPressKitTests/ReaderTopicServiceRemote+InterestsTests.swift
+++ b/WordPressKitTests/ReaderTopicServiceRemote+InterestsTests.swift
@@ -69,6 +69,8 @@ class ReaderTopicServiceRemoteInterestsTests: RemoteTestCase, RESTTestable {
     }
 
     func testPathForTopic() {
+        XCTExpectFailure("This test fails at the moment. The failure will be addressed later")
+
         XCTAssertEqual(
             ReaderTopicServiceRemote(wordPressComRestApi: .init(baseUrlString: "https://public-api.wordpress.com")).pathForTopic(slug: "foo"),
             "https://public-api.wordpress.com/rest/v1.2/read/tags/foo/posts"

--- a/WordPressKitTests/ReaderTopicServiceRemote+InterestsTests.swift
+++ b/WordPressKitTests/ReaderTopicServiceRemote+InterestsTests.swift
@@ -69,14 +69,15 @@ class ReaderTopicServiceRemoteInterestsTests: RemoteTestCase, RESTTestable {
     }
 
     func testPathForTopic() {
-        XCTExpectFailure("This test fails at the moment. The failure will be addressed later")
+        let urlWithoutTrailingSlash = URL(string: "https://public-api.wordpress.com")!
+        let urlWithTrailingSlash = URL(string: "https://public-api.wordpress.com/")!
 
         XCTAssertEqual(
-            ReaderTopicServiceRemote(wordPressComRestApi: .init(baseUrlString: "https://public-api.wordpress.com")).pathForTopic(slug: "foo"),
+            ReaderTopicServiceRemote(wordPressComRestApi: .init(baseURL: urlWithoutTrailingSlash)).pathForTopic(slug: "foo"),
             "https://public-api.wordpress.com/rest/v1.2/read/tags/foo/posts"
         )
         XCTAssertEqual(
-            ReaderTopicServiceRemote(wordPressComRestApi: .init(baseUrlString: "https://public-api.wordpress.com/")).pathForTopic(slug: "foo"),
+            ReaderTopicServiceRemote(wordPressComRestApi: .init(baseURL: urlWithTrailingSlash)).pathForTopic(slug: "foo"),
             "https://public-api.wordpress.com/rest/v1.2/read/tags/foo/posts"
         )
     }

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -17,7 +17,7 @@ extension WordPressComRestApiTests {
 
         // Then
         XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: api.baseURLString))
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
         XCTAssertNotNil(actualURL)
 
         let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
@@ -61,7 +61,7 @@ extension WordPressComRestApiTests {
 
         // Then
         XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: api.baseURLString))
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
         XCTAssertNotNil(actualURL)
 
         let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
@@ -96,7 +96,7 @@ extension WordPressComRestApiTests {
 
         // Then
         XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: api.baseURLString))
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
         XCTAssertNotNil(actualURL)
 
         let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
@@ -154,7 +154,7 @@ extension WordPressComRestApiTests {
 
         // Then
         XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: api.baseURLString))
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
         XCTAssertNotNil(actualURL)
 
         let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
@@ -179,7 +179,7 @@ extension WordPressComRestApiTests {
 
         // Then
         XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: api.baseURLString))
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
         XCTAssertNotNil(actualURL)
 
         let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
@@ -214,7 +214,7 @@ extension WordPressComRestApiTests {
 
         // Then
         XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: api.baseURLString))
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
         XCTAssertNotNil(actualURL)
 
         let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
@@ -256,7 +256,7 @@ extension WordPressComRestApiTests {
 
         // Then
         XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: URL(string: api.baseURLString))
+        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
         XCTAssertNotNil(actualURL)
 
         let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -81,11 +81,11 @@ class WordPressComRestApiTests: XCTestCase {
 
     func testBaseUrl() {
         let defaultApi = WordPressComRestApi()
-        XCTAssertEqual(defaultApi.baseURLString, "https://public-api.wordpress.com/")
+        XCTAssertEqual(defaultApi.baseURL.absoluteString, "https://public-api.wordpress.com/")
         XCTAssertTrue(defaultApi.buildRequestURLFor(path: "/path")!.hasPrefix("https://public-api.wordpress.com/path"))
 
-        let localhostApi = WordPressComRestApi(baseUrlString: "http://localhost:8080")
-        XCTAssertEqual(localhostApi.baseURLString, "http://localhost:8080")
+        let localhostApi = WordPressComRestApi(baseURL: URL(string: "http://localhost:8080")!)
+        XCTAssertEqual(localhostApi.baseURL.absoluteString, "http://localhost:8080")
         XCTAssertTrue(localhostApi.buildRequestURLFor(path: "/path")!.hasPrefix("http://localhost:8080/path"))
     }
 


### PR DESCRIPTION
### Description

This PR changes the base url variable in `WordPressComRestApi` from `String` to `URL`.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
