### PR TITLE
Add a underlyingError property to a couple of error cases

### DIFF
--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -52,8 +52,11 @@ extension URLSession {
             assert(parentProgress.cancellationHandler == nil, "The progress instance's cancellationHandler property must be nil")
         }
 
-        guard let request = try? builder.build() else {
-            return .failure(.requestEncodingFailure)
+        let request: URLRequest
+        do {
+            request = try builder.build()
+        } catch {
+            return .failure(.requestEncodingFailure(underlyingError: error))
         }
 
         return await withCheckedContinuation { continuation in

--- a/WordPressKit/WordPressAPIError.swift
+++ b/WordPressKit/WordPressAPIError.swift
@@ -10,7 +10,7 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
     }
 
     /// Can't encode the request arguments into a valid HTTP request. This is a programming error.
-    case requestEncodingFailure
+    case requestEncodingFailure(underlyingError: Error)
     /// Error occured in the HTTP connection.
     case connection(URLError)
     /// The API call returned an error result. For example, an OAuth endpoint may return an 'incorrect username or password' error, an upload media endpoint may return an 'unsupported media type' error.

--- a/WordPressKit/WordPressAPIError.swift
+++ b/WordPressKit/WordPressAPIError.swift
@@ -18,9 +18,13 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
     /// The API call returned an status code that's unacceptable to the endpoint.
     case unacceptableStatusCode(response: HTTPURLResponse, body: Data)
     /// The API call returned an HTTP response that WordPressKit can't parse. Receiving this error could be an indicator that there is an error response that's not handled properly by WordPressKit.
-    case unparsableResponse(response: HTTPURLResponse?, body: Data?)
+    case unparsableResponse(response: HTTPURLResponse?, body: Data?, underlyingError: Error)
     /// Other error occured.
     case unknown(underlyingError: Error)
+
+    static func unparsableResponse(response: HTTPURLResponse?, body: Data?) -> Self {
+        return WordPressAPIError<EndpointError>.unparsableResponse(response: response, body: body, underlyingError: URLError(.cannotParseResponse))
+    }
 }
 
 extension WordPressAPIError: LocalizedError {

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -47,12 +47,15 @@ public struct AuthenticationFailure: LocalizedError {
     public var newNonce: String?
     public var originalErrorJSON: [String: AnyObject]
 
-    init?(response: HTTPURLResponse, body: Data) {
-        guard [400, 409, 403].contains(response.statusCode),
-              let responseObject = try? JSONSerialization.jsonObject(with: body, options: .allowFragments),
-              let responseDictionary = responseObject as? [String: AnyObject]
-        else {
-            return nil
+    init(response: HTTPURLResponse, body: Data) throws {
+        guard [400, 409, 403].contains(response.statusCode) else {
+            throw URLError(.cannotParseResponse)
+        }
+
+        let responseObject = try JSONSerialization.jsonObject(with: body, options: .allowFragments)
+
+        guard let responseDictionary = responseObject as? [String: AnyObject] else {
+            throw URLError(.cannotParseResponse)
         }
 
         self.init(apiJSONResponse: responseDictionary)
@@ -212,14 +215,12 @@ public final class WordPressComOAuthClient: NSObject {
             .perform(request:  builder)
             .mapUnacceptableStatusCodeError(AuthenticationFailure.init(response:body:))
             .mapSuccess { response in
-                guard let responseObject = try? JSONSerialization.jsonObject(with: response.body) else {
-                    return nil
-                }
+                let responseObject = try JSONSerialization.jsonObject(with: response.body)
 
                 WPKitLogVerbose("Received OAuth2 response: \(self.cleanedUpResponseForLogging(responseObject as AnyObject? ?? "nil" as AnyObject))")
 
                 guard let responseDictionary = responseObject as? [String: AnyObject] else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 // If we found an access_token, we are authed.
@@ -231,7 +232,7 @@ public final class WordPressComOAuthClient: NSObject {
                 guard let responseData = responseDictionary["data"] as? [String: AnyObject],
                       let userID = responseData["user_id"] as? Int,
                       let _ = responseData["two_step_nonce_webauthn"] else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 let nonceInfo = self.extractNonceInfo(data: responseData)
@@ -343,7 +344,7 @@ public final class WordPressComOAuthClient: NSObject {
                 case .success(let responseObject):
                     guard let responseDictionary = responseObject as? [String: AnyObject],
                         let responseData = responseDictionary["data"] as? [String: AnyObject] else {
-                        return failure(.unparsableResponse(response: response.response, body: response.data), nil)
+                        return failure(.unparsableResponse(response: response.response, body: response.data, underlyingError: URLError(.cannotParseResponse)), nil)
                     }
 
                     let nonceInfo = self.extractNonceInfo(data: responseData)
@@ -393,10 +394,10 @@ public final class WordPressComOAuthClient: NSObject {
                 WPKitLogVerbose("Received Social Login Oauth response.")
 
                 // Make sure we received expected data.
-                guard let responseObject = try? JSONSerialization.jsonObject(with: response.body),
-                    let responseDictionary = responseObject as? [String: AnyObject],
+                let responseObject = try? JSONSerialization.jsonObject(with: response.body)
+                guard let responseDictionary = responseObject as? [String: AnyObject],
                     let responseData = responseDictionary["data"] as? [String: AnyObject] else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 // Check for a bearer token. If one is found then we're authed.
@@ -407,7 +408,7 @@ public final class WordPressComOAuthClient: NSObject {
                 // If there is no bearer token, check for 2fa enabled.
                 guard let userID = responseData["user_id"] as? Int,
                     let _ = responseData["two_step_nonce_backup"] else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 let nonceInfo = self.extractNonceInfo(data: responseData)
@@ -481,10 +482,10 @@ public final class WordPressComOAuthClient: NSObject {
             .mapUnacceptableStatusCodeError(AuthenticationFailure.init(response:body:))
             .mapSuccess { response in
                 // Expect the parent data response object
-                guard let responseObject = try? JSONSerialization.jsonObject(with: response.body),
-                      let responseDictionary = responseObject as? [String: Any],
+                let responseObject = try? JSONSerialization.jsonObject(with: response.body)
+                guard let responseDictionary = responseObject as? [String: Any],
                       let responseData = responseDictionary["data"] as? [String: Any] else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 // Expect the challenge info.
@@ -494,7 +495,7 @@ public final class WordPressComOAuthClient: NSObject {
                     let rpID = responseData["rpId"] as? String,
                     let allowCredentials = responseData["allowCredentials"] as? [[String: Any]]
                 else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 let allowedCredentialIDs = allowCredentials.compactMap { $0["id"] as? String }
@@ -574,16 +575,16 @@ public final class WordPressComOAuthClient: NSObject {
             .perform(request:  builder)
             .mapUnacceptableStatusCodeError(AuthenticationFailure.init(response:body:))
             .mapSuccess { response in
-                guard let responseObject = try? JSONSerialization.jsonObject(with: response.body),
-                      let responseDictionary = responseObject as? [String: Any],
+                let responseObject = try? JSONSerialization.jsonObject(with: response.body)
+                guard let responseDictionary = responseObject as? [String: Any],
                       let successResponse = responseDictionary["success"] as? Bool, successResponse,
                       let responseData = responseDictionary["data"] as? [String: Any] else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 // Check for a bearer token. If one is found then we're authed.
                 guard let authToken = responseData["bearer_token"] as? String else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 return authToken
@@ -702,15 +703,13 @@ public final class WordPressComOAuthClient: NSObject {
             .perform(request: builder)
             .mapUnacceptableStatusCodeError(AuthenticationFailure.init(response:body:))
             .mapSuccess { response in
-                guard let responseObject = try? JSONSerialization.jsonObject(with: response.body) else {
-                    return nil
-                }
+                let responseObject = try JSONSerialization.jsonObject(with: response.body)
 
                 WPKitLogVerbose("Received Social Login Oauth response: \(self.cleanedUpResponseForLogging(responseObject as AnyObject? ?? "nil" as AnyObject))")
                 guard let responseDictionary = responseObject as? [String: AnyObject],
                     let responseData = responseDictionary["data"] as? [String: AnyObject],
                     let authToken = responseData["bearer_token"] as? String else {
-                    return nil
+                    throw URLError(.cannotParseResponse)
                 }
 
                 return authToken


### PR DESCRIPTION
### Description

When encounter URL encoding errors or response parsing errors, we should surface those errors through API, instead of silently swallowing them.

This is another breaking change that is not used by the apps.

### Testing Details

I have added a couple of unit tests. Let me know if you think there are more should be added.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
