### PR TITLE
Bump version to 11.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,7 @@ _None._
 
 ### Breaking Changes
 
-- `WordPressComRestApi` initialisers now accept a `baseURL: URL` parameter instead of `baseUrlString: String`. [#691]
-- Removed the async functions in `WordPressComRestApi`. [#692]
-- URL parameters in `WordPressComOAuthClient` initialisers are now declared as `URL` type, instead of `String`. [#698]
+_None._
 
 ### New Features
 
@@ -45,6 +43,18 @@ _None._
 ### Bug Fixes
 
 _None._
+
+### Internal Changes
+
+_None._
+
+## 11.0.0
+
+### Breaking Changes
+
+- `WordPressComRestApi` initialisers now accept a `baseURL: URL` parameter instead of `baseUrlString: String`. [#691]
+- Removed the async functions in `WordPressComRestApi`. [#692]
+- URL parameters in `WordPressComOAuthClient` initialisers are now declared as `URL` type, instead of `String`. [#698]
 
 ### Internal Changes
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '10.0.0'
+  s.version       = '11.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

What says in the title.

@mokagio There is another breaking change coming in #696. I don't want to include it in this release, because I intend to integrate this release into the apps tomorrow, before the next rc is cut. And I want #696 to go out in the following rc, to give it more testing time on the apps. That means, we'll soon get another major version 12.0.0, unfortunately...

### Testing Details

None.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.