### PR TITLE
Change oauth client's url arguments type to `URL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ _None._
 
 - `WordPressComRestApi` initialisers now accept a `baseURL: URL` parameter instead of `baseUrlString: String`. [#691]
 - Removed the async functions in `WordPressComRestApi`. [#692]
+- URL parameters in `WordPressComOAuthClient` initialisers are now declared as `URL` type, instead of `String`. [#698]
 
 ### New Features
 

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -16,10 +16,7 @@ public final class IPLocationRemote {
     /// Fetches the country code from the device ip.
     ///
     public func fetchIPCountryCode(completion: @escaping (Result<String, Error>) -> Void) {
-        let path = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseUrl + "/geo/"
-        guard let url = URL(string: path) else {
-            return completion(.failure(IPLocationError.malformedURL))
-        }
+        let url = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseURL.appendingPathComponent("geo/")
 
         let request = URLRequest(url: url)
         let task = urlSession.dataTask(with: request) { data, _, error in

--- a/WordPressKit/IPLocationRemote.swift
+++ b/WordPressKit/IPLocationRemote.swift
@@ -38,7 +38,6 @@ public final class IPLocationRemote {
 
 public extension IPLocationRemote {
     enum IPLocationError: Error {
-        case malformedURL
         case requestFailure(Error?)
     }
 }

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -85,8 +85,8 @@ public struct AuthenticationFailure: LocalizedError {
 ///
 public final class WordPressComOAuthClient: NSObject {
 
-    @objc public static let WordPressComOAuthDefaultBaseUrl = "https://wordpress.com"
-    @objc public static let WordPressComOAuthDefaultApiBaseUrl = "https://public-api.wordpress.com"
+    @objc public static let WordPressComOAuthDefaultBaseURL = URL(string: "https://wordpress.com")!
+    @objc public static let WordPressComOAuthDefaultApiBaseURL = URL(string: "https://public-api.wordpress.com")!
 
     enum WordPressComURL: String {
         case socialLoginNewSMS2FA = "/wp-login.php?action=send-sms-code-endpoint"
@@ -101,8 +101,8 @@ public final class WordPressComOAuthClient: NSObject {
     private let clientID: String
     private let secret: String
 
-    private let wordPressComBaseUrl: URL
-    private let wordPressComApiBaseUrl: URL
+    private let wordPressComBaseURL: URL
+    private let wordPressComApiBaseURL: URL
 
     // Question: Is it necessary to use these many URLSession instances?
     private let oauth2Session: URLSession = {
@@ -150,12 +150,12 @@ public final class WordPressComOAuthClient: NSObject {
     ///
     @objc public class func client(clientID: String,
                                    secret: String,
-                                   wordPressComBaseUrl: String,
-                                   wordPressComApiBaseUrl: String) -> WordPressComOAuthClient {
+                                   wordPressComBaseURL: URL,
+                                   wordPressComApiBaseURL: URL) -> WordPressComOAuthClient {
         let client = WordPressComOAuthClient(clientID: clientID,
                                              secret: secret,
-                                             wordPressComBaseUrl: wordPressComBaseUrl,
-                                             wordPressComApiBaseUrl: wordPressComApiBaseUrl)
+                                             wordPressComBaseURL: wordPressComBaseURL,
+                                             wordPressComApiBaseURL: wordPressComApiBaseURL)
         return client
     }
 
@@ -169,12 +169,12 @@ public final class WordPressComOAuthClient: NSObject {
     ///
     @objc public init(clientID: String,
                       secret: String,
-                      wordPressComBaseUrl: String = WordPressComOAuthClient.WordPressComOAuthDefaultBaseUrl,
-                      wordPressComApiBaseUrl: String = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseUrl) {
+                      wordPressComBaseURL: URL = WordPressComOAuthClient.WordPressComOAuthDefaultBaseURL,
+                      wordPressComApiBaseURL: URL = WordPressComOAuthClient.WordPressComOAuthDefaultApiBaseURL) {
         self.clientID = clientID
         self.secret = secret
-        self.wordPressComBaseUrl = URL(string: wordPressComBaseUrl)!
-        self.wordPressComApiBaseUrl = URL(string: wordPressComApiBaseUrl)!
+        self.wordPressComBaseURL = wordPressComBaseURL
+        self.wordPressComApiBaseURL = wordPressComApiBaseURL
     }
 
     public enum AuthenticationResult {
@@ -336,7 +336,7 @@ public final class WordPressComOAuthClient: NSObject {
             "wpcom_resend_otp": true
             ] as [String: Any]
 
-        socialNewSMS2FASessionManager.request(WordPressComURL.socialLoginNewSMS2FA.url(base: wordPressComBaseUrl), method: .post, parameters: parameters)
+        socialNewSMS2FASessionManager.request(WordPressComURL.socialLoginNewSMS2FA.url(base: wordPressComBaseURL), method: .post, parameters: parameters)
             .validate()
             .responseJSON(completionHandler: { response in
                 switch response.result {
@@ -813,7 +813,7 @@ extension WordPressComOAuthClient {
 
 private extension WordPressComOAuthClient {
     func tokenRequestBuilder() -> HTTPRequestBuilder {
-        HTTPRequestBuilder(url: wordPressComApiBaseUrl)
+        HTTPRequestBuilder(url: wordPressComApiBaseURL)
             .method(.post)
             .append(path: "/oauth2/token")
     }
@@ -824,7 +824,7 @@ private extension WordPressComOAuthClient {
     }
 
     func webAuthnRequestBuilder(action: WebAuthnAction) -> HTTPRequestBuilder {
-        HTTPRequestBuilder(url: wordPressComBaseUrl)
+        HTTPRequestBuilder(url: wordPressComBaseURL)
             .method(.post)
             .append(path: "/wp-login.php")
             .query(name: "action", value: action.rawValue)
@@ -845,7 +845,7 @@ private extension WordPressComOAuthClient {
     }
 
     func socialSignInRequestBuilder(action: SocialSignInAction) -> HTTPRequestBuilder {
-        HTTPRequestBuilder(url: wordPressComBaseUrl)
+        HTTPRequestBuilder(url: wordPressComBaseURL)
             .method(.post)
             .append(path: "/wp-login.php")
             .append(query: action.queryItems, override: true)

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -164,8 +164,8 @@ public final class WordPressComOAuthClient: NSObject {
     /// - Parameters:
     ///     - clientID: the app oauth clientID
     ///     - secret: the app secret
-    ///     - wordPressComBaseUrl: The base url to use for WordPress.com requests. Defaults to https://wordpress.com
-    ///     - wordPressComApiBaseUrl: The base url to use for WordPress.com API requests. Defaults to https://public-api-wordpress.com
+    ///     - wordPressComBaseURL: The base url to use for WordPress.com requests. Defaults to https://wordpress.com
+    ///     - wordPressComApiBaseURL: The base url to use for WordPress.com API requests. Defaults to https://public-api-wordpress.com
     ///
     @objc public init(clientID: String,
                       secret: String,


### PR DESCRIPTION
### Description

We discussed changing these URL arguments type in one of my previous PRs. This PR does that with the aim of shipping the changes along with 11.0.0 in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/697.

### Testing Details

None needed.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
