### PR TITLE
A couple of minor api changes

### DIFF
--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -44,7 +44,7 @@ extension URLSession {
     func perform<E: LocalizedError>(
         request builder: HTTPRequestBuilder,
         acceptableStatusCodes: [ClosedRange<Int>] = [200...299],
-        fulfillingProgress parentProgress: Progress? = nil,
+        fulfilling parentProgress: Progress? = nil,
         errorType: E.Type = E.self
     ) async -> WordPressAPIResult<HTTPAPIResponse<Data>, E> {
         if let parentProgress {

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -63,8 +63,6 @@ open class WordPressComRestApi: NSObject {
     @objc public static let LocaleKeyDefault        = "locale"  // locale is specified with this for v1 endpoints
     @objc public static let LocaleKeyV2             = "_locale" // locale is prefixed with an underscore for v2
 
-    @objc public static let SessionTaskKey          = "WordPressComRestAPI.sessionTask"
-
     public typealias RequestEnqueuedBlock = (_ taskID: NSNumber) -> Void
     public typealias SuccessResponseBlock = (_ responseObject: AnyObject, _ httpResponse: HTTPURLResponse?) -> Void
     public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> Void
@@ -225,7 +223,6 @@ open class WordPressComRestApi: NSObject {
                 failure(processedError ?? (error as NSError), response.response)
             }
         }).downloadProgress(closure: progressUpdater)
-        progress.sessionTask = dataRequest.task
         progress.cancellationHandler = { [weak dataRequest] in
             dataRequest?.cancel()
         }
@@ -604,25 +601,6 @@ private extension WordPressComRestApi {
                                                userInfo: [NSLocalizedDescriptionKey: NSLocalizedString("Failed to serialize request to the REST API.",
                                                                                                        comment: "Error message to show when wrong URL format is used to access the REST API")])
     }
-}
-
-// MARK: - Progress
-
-@objc extension Progress {
-
-    var sessionTask: URLSessionTask? {
-        get {
-            return userInfo[.sessionTaskKey] as? URLSessionTask
-        }
-
-        set {
-            self.setUserInfoObject(newValue, forKey: .sessionTaskKey)
-        }
-    }
-}
-
-extension ProgressUserInfoKey {
-    public static let sessionTaskKey = ProgressUserInfoKey(rawValue: WordPressComRestApi.SessionTaskKey)
 }
 
 // MARK: - POST encoding

--- a/WordPressKit/WordPressOrgRestApi.swift
+++ b/WordPressKit/WordPressOrgRestApi.swift
@@ -70,7 +70,6 @@ open class WordPressOrgRestApi: NSObject, WordPressRestApi {
             }
 
         }).downloadProgress(closure: progressUpdater)
-        progress.sessionTask = dataRequest.task
         progress.cancellationHandler = {
             dataRequest.cancel()
         }

--- a/WordPressKitTests/Utilities/URLSessionHelperTests.swift
+++ b/WordPressKitTests/Utilities/URLSessionHelperTests.swift
@@ -116,7 +116,7 @@ class URLSessionHelperTests: XCTestCase {
         XCTAssertEqual(progress.completedUnitCount, 0)
         XCTAssertEqual(progress.fractionCompleted, 0)
 
-        let _ = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), fulfillingProgress: progress, errorType: TestError.self)
+        let _ = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), fulfilling: progress, errorType: TestError.self)
         XCTAssertEqual(progress.completedUnitCount, 20)
         XCTAssertEqual(progress.fractionCompleted, 1)
     }
@@ -136,7 +136,7 @@ class URLSessionHelperTests: XCTestCase {
         }
 
         // The result should be an cancellation result
-        let result = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), fulfillingProgress: progress, errorType: TestError.self)
+        let result = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), fulfilling: progress, errorType: TestError.self)
         if case let .failure(.connection(urlError)) = result, urlError.code == .cancelled {
             // Do nothing
         } else {


### PR DESCRIPTION
### Description

There are two changes:
1. Removing `Progress.sessionTask`. Even though this is a public API, but it's not used by the apps. See the test PRs on [WordPress-iOS][WP] and [WooCommerce-iOS][Woo].
1. Changing a parameter label from `fulfillingProgress` to `fulfilling`, because the "progress" part is indicated by the parameter type `Progress`. This is an internal API, thus no affects to the apps.

### Testing Details

None needed.

[WP]: https://github.com/wordpress-mobile/WordPress-iOS/pull/22434
[Woo]: https://github.com/woocommerce/woocommerce-ios/pull/11755

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.