### PR TITLE
Add unit tests to verify post requests content type

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -103,7 +103,8 @@ final class HTTPRequestBuilder {
     }
 
     func body(json: @escaping () throws -> Data) -> Self {
-        headers["Content-Type"] = "application/json; charset=utf-8"
+        // 'charset' parmaeter is not required for json body. See https://www.rfc-editor.org/rfc/rfc8259.html#section-11
+        headers["Content-Type"] = "application/json"
         bodyBuilder = { req in
             req.httpBody = try json()
         }

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -352,9 +352,9 @@ class HTTPRequestBuilderTests: XCTestCase {
 
 }
 
-private extension URLRequest {
+extension URLRequest {
     var httpBodyText: String? {
-        guard let data = httpBody else {
+        guard let data = (httpBody ?? httpBodyStream?.readToEnd()) else {
             return nil
         }
 


### PR DESCRIPTION
### Description

API clients for wp.com and wp.org API reuqests both implements POST requests parameters differently. The WP.com API client sends parameters as JSON, whereas the WP.org API client sends them as url-encoded form.

This PR adds a couple of basic unit tests to add test coverage for the current implementation. These new unit tests will ensure this implementation is not changed in upcoming refactors to WP.com and WP.org api clients.

Also, as I written in the code comment, I found out [`application/json` does not have a charset parameter][RFC], which I think is pretty weird. Removing the `charset` here to keep it the same as Alamofire's implementation.

[RFC]: https://www.rfc-editor.org/rfc/rfc8259.html#section-11

### Testing Details

None needed.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
