### PR TITLE
Get the original url path using percentEncodedPath instead of path

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -121,11 +121,11 @@ final class HTTPRequestBuilder {
     func build(encodeMultipartForm: Bool = false) throws -> URLRequest {
         var components = original
 
-        var newPath = Self.join(components.path, appendedPath)
+        var newPath = Self.join(components.percentEncodedPath, appendedPath)
         if !newPath.isEmpty, !newPath.hasPrefix("/") {
             newPath = "/\(newPath)"
         }
-        components.path = newPath
+        components.percentEncodedPath = newPath
 
         // Add default query items if they don't exist in `appendedQuery`.
         var newQuery = appendedQuery

--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -38,7 +38,10 @@ final class HTTPRequestBuilder {
         return self
     }
 
-    func append(path: String) -> Self {
+    /// Append path to the original URL.
+    ///
+    /// The argument will be appended to the original URL as it is.
+    func append(percentEncodedPath path: String) -> Self {
         assert(!path.contains("?") && !path.contains("#"), "Path should not have query or fragment: \(path)")
 
         appendedPath = Self.join(appendedPath, path)

--- a/WordPressKit/WordPressComOAuthClient.swift
+++ b/WordPressKit/WordPressComOAuthClient.swift
@@ -820,7 +820,7 @@ private extension WordPressComOAuthClient {
     func tokenRequestBuilder() -> HTTPRequestBuilder {
         HTTPRequestBuilder(url: wordPressComApiBaseURL)
             .method(.post)
-            .append(path: "/oauth2/token")
+            .append(percentEncodedPath: "/oauth2/token")
     }
 
     enum WebAuthnAction: String {
@@ -831,7 +831,7 @@ private extension WordPressComOAuthClient {
     func webAuthnRequestBuilder(action: WebAuthnAction) -> HTTPRequestBuilder {
         HTTPRequestBuilder(url: wordPressComBaseURL)
             .method(.post)
-            .append(path: "/wp-login.php")
+            .append(percentEncodedPath: "/wp-login.php")
             .query(name: "action", value: action.rawValue)
     }
 
@@ -852,7 +852,7 @@ private extension WordPressComOAuthClient {
     func socialSignInRequestBuilder(action: SocialSignInAction) -> HTTPRequestBuilder {
         HTTPRequestBuilder(url: wordPressComBaseURL)
             .method(.post)
-            .append(path: "/wp-login.php")
+            .append(percentEncodedPath: "/wp-login.php")
             .append(query: action.queryItems, override: true)
     }
 }

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -75,22 +75,22 @@ class HTTPRequestBuilderTests: XCTestCase {
 
     func testPath() throws {
         var request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
-            .append(path: "hello/world")
+            .append(percentEncodedPath: "hello/world")
             .build()
         XCTAssertEqual(request.url?.absoluteString, "https://wordpress.org/hello/world")
 
         request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
-            .append(path: "/hello/world")
+            .append(percentEncodedPath: "/hello/world")
             .build()
         XCTAssertEqual(request.url?.absoluteString, "https://wordpress.org/hello/world")
 
         request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org/hello")!)
-            .append(path: "world")
+            .append(percentEncodedPath: "world")
             .build()
         XCTAssertEqual(request.url?.absoluteString, "https://wordpress.org/hello/world")
 
         request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org/hello")!)
-            .append(path: "/world")
+            .append(percentEncodedPath: "/world")
             .build()
         XCTAssertEqual(request.url?.absoluteString, "https://wordpress.org/hello/world")
     }
@@ -353,7 +353,7 @@ class HTTPRequestBuilderTests: XCTestCase {
     func testURLEncodedPathInOriginalURL() {
         XCTAssertEqual(
             try HTTPRequestBuilder(url: URL(string: "https://wordpress.org/foo%2Fbar/test")!)
-                .append(path: "new-path")
+                .append(percentEncodedPath: "new-path")
                 .query(name: "arg", value: "value")
                 .build()
                 .url?

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -350,6 +350,19 @@ class HTTPRequestBuilderTests: XCTestCase {
         )
     }
 
+    func testURLEncodedPathInOriginalURL() {
+        XCTAssertEqual(
+            try HTTPRequestBuilder(url: URL(string: "https://wordpress.org/foo%2Fbar/test")!)
+                .append(path: "new-path")
+                .query(name: "arg", value: "value")
+                .build()
+                .url?
+                .absoluteString,
+            "https://wordpress.org/foo%2Fbar/test/new-path?arg=value"
+        )
+
+    }
+
 }
 
 private extension URLRequest {


### PR DESCRIPTION
### Description

This PR fixes an issue in `HTTPRequestBuilder` where the url-encoded part in a path is url-decoded in the final request. For example, `HTTPRequestBuilder(url: "https://wp.org/foo%2Fbar").build()` (%2F is url-encoded '/') returns a request with URL `https://wp.org/foo/bar`.

### Testing Details

See the added unit test.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
