### PR TITLE
Report progress on the main queue

### DIFF
--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -198,8 +198,8 @@ extension Progress {
         let start = self.completedUnitCount
         return progress.publisher(for: \.fractionCompleted, options: .new)
             .receive(on: queue)
-            .sink { fraction in
-                self.completedUnitCount = start + Int64(fraction * Double(totoalUnit))
+            .sink { [weak self] fraction in
+                self?.completedUnitCount = start + Int64(fraction * Double(totoalUnit))
             }
     }
 }


### PR DESCRIPTION
### Description

After testing in the WP/JP app, I found out there is code in the app that [updates UI within a progress update observer][Link].

By default, Alamofire updates its progresses ([download][AF-1] and [upload][AF-2]) on the main thread. This PR carries that behaviour to the new URLSession implementation.

[Link]: https://github.com/wordpress-mobile/WordPress-iOS/blob/d786b201759165dae9fd9d1e9e1cc99be2ca42b2/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift#L167-L169

[AF-1]: https://github.com/Alamofire/Alamofire/blob/4.9.1/Source/Request.swift#L409
[AF-2]: https://github.com/Alamofire/Alamofire/blob/4.9.1/Source/Request.swift#L628

### Testing Details

See the added unit tests.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
