### PR TITLE
Add unit tests for xmlrpc error cases

### DIFF
--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -61,7 +61,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
 
                 XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
                 XCTAssertEqual(error.code, WordPressOrgXMLRPCApiError.httpErrorStatusCode.rawValue)
-                XCTAssertEqual(error.localizedFailureReason, WordPressOrgXMLRPCApiError.httpErrorStatusCode.failureReason)
+                XCTAssertEqual(error.localizedFailureReason, "An HTTP error code 404 was returned.")
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -87,7 +87,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertFalse(error is WordPressOrgXMLRPCApiError)
                 XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
                 XCTAssertEqual(error.code, 403)
-                XCTAssertEqual(error.localizedFailureReason, WordPressOrgXMLRPCApiError.httpErrorStatusCode.failureReason)
+                XCTAssertEqual(error.localizedFailureReason, "An HTTP error code 403 was returned.")
             }
         )
         wait(for: [expect], timeout: 0.1)

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -7,6 +7,7 @@ import wpxmlrpc
 class WordPressOrgXMLRPCApiTests: XCTestCase {
 
     let xmlrpcEndpoint = "http://wordpress.org/xmlrpc.php"
+    let xmlContentTypeHeaders: [String: Any] = ["Content-Type": "application/xml"]
 
     override func setUp() {
         super.setUp()
@@ -26,7 +27,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     func testSuccessfullCall() {
         stub(condition: isXmlRpcAPIRequest()) { _ in
             let stubPath = OHPathForFile("xmlrpc-response-getpost.xml", type(of: self))
-            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+            return fixture(filePath: stubPath!, headers: self.xmlContentTypeHeaders)
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
@@ -44,7 +45,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
 
     func test404() {
         stub(condition: isXmlRpcAPIRequest()) { _ in
-            HTTPStubsResponse(data: Data(), statusCode: 404, headers: ["Content-Type": "application/xml"])
+            HTTPStubsResponse(data: Data(), statusCode: 404, headers: self.xmlContentTypeHeaders)
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
@@ -71,7 +72,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
 
     func test403() {
         stub(condition: isXmlRpcAPIRequest()) { _ in
-            HTTPStubsResponse(data: Data(), statusCode: 403, headers: ["Content-Type": "application/xml"])
+            HTTPStubsResponse(data: Data(), statusCode: 403, headers: self.xmlContentTypeHeaders)
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
@@ -153,7 +154,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     func testFault() throws {
         let responseFile = try XCTUnwrap(OHPathForFile("xmlrpc-bad-username-password-error.xml", WordPressOrgXMLRPCApiTests.self))
         stub(condition: isXmlRpcAPIRequest()) { _ in
-            fixture(filePath: responseFile, headers: ["Content-Type": "application/xml"])
+            fixture(filePath: responseFile, headers: self.xmlContentTypeHeaders)
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
@@ -181,7 +182,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     func testFault401() throws {
         let responseFile = try XCTUnwrap(OHPathForFile("xmlrpc-bad-username-password-error.xml", WordPressOrgXMLRPCApiTests.self))
         stub(condition: isXmlRpcAPIRequest()) { _ in
-            fixture(filePath: responseFile, status: 401, headers: ["Content-Type": "application/xml"])
+            fixture(filePath: responseFile, status: 401, headers: self.xmlContentTypeHeaders)
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
@@ -211,7 +212,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
             HTTPStubsResponse(
                 data: #"<?xml version="1.0" encoding="UTF-8"?><methodRespons"#.data(using: .utf8)!,
                 statusCode: 200,
-                headers: ["Content-Type": "application/xml"]
+                headers: self.xmlContentTypeHeaders
             )
         }
 
@@ -238,7 +239,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     func testInvalidXML() throws {
         let responseFile = try XCTUnwrap(OHPathForFile("xmlrpc-response-invalid.html", WordPressOrgXMLRPCApiTests.self))
         stub(condition: isXmlRpcAPIRequest()) { _ in
-            fixture(filePath: responseFile, headers: ["Content-Type": "application/xml"])
+            fixture(filePath: responseFile, headers: self.xmlContentTypeHeaders)
         }
 
         let expect = self.expectation(description: "One callback should be invoked")
@@ -265,7 +266,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     func testProgressUpdate() {
         stub(condition: isXmlRpcAPIRequest()) { _ in
             let stubPath = OHPathForFile("xmlrpc-response-getpost.xml", type(of: self))
-            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+            return fixture(filePath: stubPath!, headers: self.xmlContentTypeHeaders)
         }
 
         let success = self.expectation(description: "The success callback should be invoked")
@@ -293,7 +294,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     func testProgressUpdateFailure() {
         stub(condition: isXmlRpcAPIRequest()) { _ in
             let stubPath = OHPathForFile("xmlrpc-bad-username-password-error.xml", type(of: self))
-            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+            return fixture(filePath: stubPath!, headers: self.xmlContentTypeHeaders)
         }
 
         let failure = self.expectation(description: "The failure callback should be invoked")
@@ -321,7 +322,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     func testProgressUpdateStreamAPI() {
         stub(condition: isXmlRpcAPIRequest()) { _ in
             let stubPath = OHPathForFile("xmlrpc-response-getpost.xml", type(of: self))
-            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+            return fixture(filePath: stubPath!, headers: self.xmlContentTypeHeaders)
         }
 
         let success = self.expectation(description: "The success callback should be invoked")
@@ -349,7 +350,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
     func testProgressUpdateStreamAPIFailure() {
         stub(condition: isXmlRpcAPIRequest()) { _ in
             let stubPath = OHPathForFile("xmlrpc-bad-username-password-error.xml", type(of: self))
-            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+            return fixture(filePath: stubPath!, headers: self.xmlContentTypeHeaders)
         }
 
         let failure = self.expectation(description: "The failure callback should be invoked")

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -61,6 +61,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
 
                 XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
                 XCTAssertEqual(error.code, WordPressOrgXMLRPCApiError.httpErrorStatusCode.rawValue)
+                XCTAssertEqual(error.localizedFailureReason, WordPressOrgXMLRPCApiError.httpErrorStatusCode.failureReason)
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -86,6 +87,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertFalse(error is WordPressOrgXMLRPCApiError)
                 XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
                 XCTAssertEqual(error.code, 403)
+                XCTAssertEqual(error.localizedFailureReason, WordPressOrgXMLRPCApiError.httpErrorStatusCode.failureReason)
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -111,6 +113,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertTrue(error is WordPressOrgXMLRPCApiError)
                 XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
                 XCTAssertEqual(error.code, WordPressOrgXMLRPCApiError.unknown.rawValue)
+                XCTAssertEqual(error.localizedFailureReason, WordPressOrgXMLRPCApiError.unknown.failureReason)
             }
         )
         wait(for: [expect], timeout: 0.1)

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -62,6 +62,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
                 XCTAssertEqual(error.code, WordPressOrgXMLRPCApiError.httpErrorStatusCode.rawValue)
                 XCTAssertEqual(error.localizedFailureReason, "An HTTP error code 404 was returned.")
+                XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -88,6 +90,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
                 XCTAssertEqual(error.code, 403)
                 XCTAssertEqual(error.localizedFailureReason, "An HTTP error code 403 was returned.")
+                XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -114,6 +118,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
                 XCTAssertEqual(error.code, WordPressOrgXMLRPCApiError.unknown.rawValue)
                 XCTAssertEqual(error.localizedFailureReason, WordPressOrgXMLRPCApiError.unknown.failureReason)
+                XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -165,6 +171,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertEqual(error.domain, WPXMLRPCFaultErrorDomain)
                 // 403 is the 'faultCode' in the HTTP response xml.
                 XCTAssertEqual(error.code, 403)
+                XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -191,6 +199,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertEqual(error.domain, WPXMLRPCFaultErrorDomain)
                 // 403 is the 'faultCode' in the HTTP response xml.
                 XCTAssertEqual(error.code, 403)
+                XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -218,6 +228,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 expect.fulfill()
 
                 XCTAssertEqual(error.domain, XMLParser.errorDomain)
+                XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
         wait(for: [expect], timeout: 0.1)
@@ -243,6 +255,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
 
                 XCTAssertEqual(error.domain, WPXMLRPCErrorDomain)
                 XCTAssertEqual(error.code, WPXMLRPCError.invalidInputError.rawValue)
+                XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
         wait(for: [expect], timeout: 0.1)

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 import OHHTTPStubs
+import wpxmlrpc
 @testable import WordPressKit
 
 class WordPressOrgXMLRPCApiTests: XCTestCase {
@@ -39,6 +40,209 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
             }
         )
         self.waitForExpectations(timeout: 2, handler: nil)
+    }
+
+    func test404() {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            HTTPStubsResponse(data: Data(), statusCode: 404, headers: ["Content-Type": "application/xml"])
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error, _) in
+                expect.fulfill()
+
+                XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
+                XCTAssertEqual(error.code, WordPressOrgXMLRPCApiError.httpErrorStatusCode.rawValue)
+            }
+        )
+        wait(for: [expect], timeout: 0.1)
+    }
+
+    func test403() {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            HTTPStubsResponse(data: Data(), statusCode: 403, headers: ["Content-Type": "application/xml"])
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error, _) in
+                expect.fulfill()
+
+                XCTAssertFalse(error is WordPressOrgXMLRPCApiError)
+                XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
+                XCTAssertEqual(error.code, 403)
+            }
+        )
+        wait(for: [expect], timeout: 0.1)
+    }
+
+    func test403WithoutContentTypeHeader() {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            HTTPStubsResponse(data: Data(), statusCode: 403, headers: nil)
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error, _) in
+                expect.fulfill()
+
+                XCTAssertTrue(error is WordPressOrgXMLRPCApiError)
+                XCTAssertEqual(error.domain, WordPressOrgXMLRPCApiErrorDomain)
+                XCTAssertEqual(error.code, WordPressOrgXMLRPCApiError.unknown.rawValue)
+            }
+        )
+        wait(for: [expect], timeout: 0.1)
+    }
+
+    func testConnectionError() {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            HTTPStubsResponse(error: URLError(.timedOut))
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error, _) in
+                expect.fulfill()
+
+                XCTAssertTrue(error is URLError)
+                XCTAssertEqual(error.domain, URLError.errorDomain)
+                XCTAssertEqual(error.code, URLError.Code.timedOut.rawValue)
+            }
+        )
+        wait(for: [expect], timeout: 0.1)
+    }
+
+    func testFault() throws {
+        let responseFile = try XCTUnwrap(OHPathForFile("xmlrpc-bad-username-password-error.xml", WordPressOrgXMLRPCApiTests.self))
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            fixture(filePath: responseFile, headers: ["Content-Type": "application/xml"])
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error, _) in
+                expect.fulfill()
+
+                XCTAssertEqual(error.domain, WPXMLRPCFaultErrorDomain)
+                // 403 is the 'faultCode' in the HTTP response xml.
+                XCTAssertEqual(error.code, 403)
+            }
+        )
+        wait(for: [expect], timeout: 0.1)
+    }
+
+    func testFault401() throws {
+        let responseFile = try XCTUnwrap(OHPathForFile("xmlrpc-bad-username-password-error.xml", WordPressOrgXMLRPCApiTests.self))
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            fixture(filePath: responseFile, status: 401, headers: ["Content-Type": "application/xml"])
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error, _) in
+                expect.fulfill()
+
+                XCTAssertEqual(error.domain, WPXMLRPCFaultErrorDomain)
+                // 403 is the 'faultCode' in the HTTP response xml.
+                XCTAssertEqual(error.code, 403)
+            }
+        )
+        wait(for: [expect], timeout: 0.1)
+    }
+
+    func testMalformedXML() throws {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            HTTPStubsResponse(
+                data: #"<?xml version="1.0" encoding="UTF-8"?><methodRespons"#.data(using: .utf8)!,
+                statusCode: 200,
+                headers: ["Content-Type": "application/xml"]
+            )
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error, _) in
+                expect.fulfill()
+
+                XCTAssertEqual(error.domain, XMLParser.errorDomain)
+            }
+        )
+        wait(for: [expect], timeout: 0.1)
+    }
+
+    func testInvalidXML() throws {
+        let responseFile = try XCTUnwrap(OHPathForFile("xmlrpc-response-invalid.html", WordPressOrgXMLRPCApiTests.self))
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            fixture(filePath: responseFile, headers: ["Content-Type": "application/xml"])
+        }
+
+        let expect = self.expectation(description: "One callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (responseObject: AnyObject, _: HTTPURLResponse?) in
+                expect.fulfill()
+                XCTFail("This call should fail")
+            },
+            failure: { (error, _) in
+                expect.fulfill()
+
+                XCTAssertEqual(error.domain, WPXMLRPCErrorDomain)
+                XCTAssertEqual(error.code, WPXMLRPCError.invalidInputError.rawValue)
+            }
+        )
+        wait(for: [expect], timeout: 0.1)
     }
 
 }


### PR DESCRIPTION
### Description

Add some unit tests to prepare for an upcoming refactor to `WordPressOrgXMLRPCApiError`.

### Testing Details

None needed.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
