### PR TITLE
Add functions to send requests and decode responses using URLSession

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Calling this class's url related functions (the ones that changes path, query, etc) does not modify the
 /// original URL string. The URL will be perserved in the final result that's returned by the `build` function.
 final class HTTPRequestBuilder {
-    enum Method: String {
+    enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"

--- a/WordPressKit/WordPressAPIError.swift
+++ b/WordPressKit/WordPressAPIError.swift
@@ -25,6 +25,19 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
     static func unparsableResponse(response: HTTPURLResponse?, body: Data?) -> Self {
         return WordPressAPIError<EndpointError>.unparsableResponse(response: response, body: body, underlyingError: URLError(.cannotParseResponse))
     }
+
+    var response: HTTPURLResponse? {
+        switch self {
+        case .requestEncodingFailure, .connection, .unknown:
+            return nil
+        case let .endpointError(error):
+            return (error as? HTTPURLResponseProviding)?.httpResponse
+        case .unacceptableStatusCode(let response, _):
+            return response
+        case .unparsableResponse(let response, _, _):
+            return response
+        }
+    }
 }
 
 extension WordPressAPIError: LocalizedError {
@@ -53,4 +66,8 @@ extension WordPressAPIError: LocalizedError {
         return localizedErrorMessage
     }
 
+}
+
+protocol HTTPURLResponseProviding {
+    var httpResponse: HTTPURLResponse? { get }
 }

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -412,6 +412,21 @@ open class WordPressComRestApi: NSObject {
         return urlComponentsWithLocale?.url?.absoluteString
     }
 
+    private func requestBuilder(URLString: String) throws -> HTTPRequestBuilder {
+        guard let url = URL(string: URLString, relativeTo: baseURL) else {
+            throw URLError(.badURL)
+        }
+
+        var builder = HTTPRequestBuilder(url: url)
+
+        if appendsPreferredLanguageLocale {
+            let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
+            builder = builder.query(defaults: [URLQueryItem(name: localeKey, value: preferredLanguageIdentifier)])
+        }
+
+        return builder
+    }
+
     private func applyLocaleIfNeeded(urlComponents: URLComponents, parameters: [String: AnyObject]? = [:], localeKey: String) -> URLComponents? {
         guard appendsPreferredLanguageLocale else {
             return urlComponents

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -517,6 +517,7 @@ open class WordPressComRestApi: NSObject {
         var builder: HTTPRequestBuilder
         do {
             builder = try requestBuilder(URLString: URLString)
+                .method(method)
         } catch {
             return .failure(.requestEncodingFailure(underlyingError: error))
         }

--- a/WordPressKitTests/ActivityServiceRemoteTests.swift
+++ b/WordPressKitTests/ActivityServiceRemoteTests.swift
@@ -435,6 +435,6 @@ class ActivityServiceRemoteTests: RemoteTestCase, RESTTestable {
             XCTFail("The success block should be called")
         }
 
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 }

--- a/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
+++ b/WordPressKitTests/BlockEditorSettingsServiceRemoteTests.swift
@@ -50,7 +50,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     func testFetchThemeNoGradients() {
@@ -81,7 +81,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     func testFetchThemeNoColors() {
@@ -117,7 +117,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     func testFetchThemeNoThemeSupport() {
@@ -144,7 +144,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     func testFetchThemeFailure() {
@@ -163,7 +163,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
 }
@@ -189,7 +189,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     func testFetchBlockEditorSettingsThemeJSON() {
@@ -214,7 +214,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     func testFetchBlockEditorSettingsNoFSETheme() {
@@ -238,7 +238,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     func testFetchBlockEditorSettingsThemeJSON_ConsistentChecksum() {
@@ -266,7 +266,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     func testFetchBlockEditorSettingsOrgEndpoint() {
@@ -280,7 +280,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     // The only difference between this test and the one above (testFetchBlockEditorSettingsOrgEndpoint) is this
@@ -300,7 +300,7 @@ extension BlockEditorSettingsServiceRemoteTests {
             waitExpectation.fulfill()
         }
 
-        wait(for: [waitExpectation], timeout: 0.1)
+        wait(for: [waitExpectation], timeout: 0.3)
     }
 
     private func validateFetchBlockEditorSettingsResults(_ result: RemoteBlockEditorSettings?) {

--- a/WordPressKitTests/EditorServiceRemoteTests.swift
+++ b/WordPressKitTests/EditorServiceRemoteTests.swift
@@ -33,7 +33,7 @@ class EditorServiceRemoteTests: XCTestCase {
         }
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testPostDesignateMobileEditorSuccessSettingAztec() {
@@ -50,7 +50,7 @@ class EditorServiceRemoteTests: XCTestCase {
         }
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testPostDesignateMobileEditorDoesNotCrashWithBadKeyResponse() {
@@ -70,7 +70,7 @@ class EditorServiceRemoteTests: XCTestCase {
         }
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testPostDesignateMobileEditorThrowsErrorWithBadValueResponse() {
@@ -88,7 +88,7 @@ class EditorServiceRemoteTests: XCTestCase {
         }
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testPostDesignateMobileEditorError() {
@@ -104,7 +104,7 @@ class EditorServiceRemoteTests: XCTestCase {
         mockRemoteApi.failureBlockPassedIn?(errorExpec, nil)
         XCTAssertTrue(mockRemoteApi.postMethodCalled)
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     // MARK: - GET tests
@@ -124,7 +124,7 @@ class EditorServiceRemoteTests: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(mockRemoteApi.getMethodCalled)
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testGetEditorSettingsNotSetForMobile() {
@@ -142,7 +142,7 @@ class EditorServiceRemoteTests: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(mockRemoteApi.getMethodCalled)
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testGetEditorSettingsClassic() {
@@ -160,7 +160,7 @@ class EditorServiceRemoteTests: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(mockRemoteApi.getMethodCalled)
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testGetEditorSettingsFailure() {
@@ -177,7 +177,7 @@ class EditorServiceRemoteTests: XCTestCase {
         mockRemoteApi.failureBlockPassedIn?(errorExpec, nil)
         XCTAssertTrue(mockRemoteApi.getMethodCalled)
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testPostDesignateGutenbergMobileEditorForAllSites() {
@@ -205,7 +205,7 @@ class EditorServiceRemoteTests: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(mockRemoteApi.postMethodCalled)
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 
     func testPostDesignateAztecMobileEditorForAllSites() {
@@ -233,7 +233,7 @@ class EditorServiceRemoteTests: XCTestCase {
         mockRemoteApi.successBlockPassedIn?(response as AnyObject, HTTPURLResponse())
         XCTAssertTrue(mockRemoteApi.postMethodCalled)
 
-        wait(for: [expec], timeout: 0.1)
+        wait(for: [expec], timeout: 0.3)
     }
 }
 

--- a/WordPressKitTests/Utilities/URLSessionHelperTests.swift
+++ b/WordPressKitTests/Utilities/URLSessionHelperTests.swift
@@ -135,7 +135,7 @@ class URLSessionHelperTests: XCTestCase {
         }
 
         let _ = await URLSession.shared.perform(request: .init(url: URL(string: "https://wordpress.org/hello")!), fulfilling: progress, errorType: TestError.self)
-        await fulfillment(of: [progressReported], timeout: 0.1)
+        await fulfillment(of: [progressReported], timeout: 0.3)
         observer.invalidate()
     }
 

--- a/WordPressKitTests/WordPressAPI/CookieNonceAuthenticatorTests.swift
+++ b/WordPressKitTests/WordPressAPI/CookieNonceAuthenticatorTests.swift
@@ -39,7 +39,7 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         let session = SessionManager(configuration: .ephemeral)
         session.adapter = authenticator
         session.retrier = authenticator
-        wait(for: [apiCallShouldSucceed(using: session)], timeout: 0.1)
+        wait(for: [apiCallShouldSucceed(using: session)], timeout: 0.3)
     }
 
     func testUsingRESTNonceAjax() {
@@ -50,7 +50,7 @@ final class CookieNonceAuthenticatorTests: XCTestCase {
         let session = SessionManager(configuration: .ephemeral)
         session.adapter = authenticator
         session.retrier = authenticator
-        wait(for: [apiCallShouldSucceed(using: session)], timeout: 0.1)
+        wait(for: [apiCallShouldSucceed(using: session)], timeout: 0.3)
     }
 
     private func stubLoginRedirect(dest: URL) {

--- a/WordPressKitTests/WordPressAPI/WordPressOrgXMLRPCValidatorTests.swift
+++ b/WordPressKitTests/WordPressAPI/WordPressOrgXMLRPCValidatorTests.swift
@@ -119,7 +119,7 @@ final class WordPressOrgXMLRPCValidatorTests: XCTestCase {
             XCTAssertTrue(validatorError == .invalid || validatorError == .notWordPressError, "Got an error: \(error)")
             failure.fulfill()
         }
-        wait(for: [failure], timeout: 0.1)
+        wait(for: [failure], timeout: 0.3)
     }
 
     func testSuccessWithSiteAddress() {
@@ -141,7 +141,7 @@ final class WordPressOrgXMLRPCValidatorTests: XCTestCase {
         }) {
             XCTFail("Unexpected result: \($0)")
         }
-        wait(for: [success], timeout: 0.1)
+        wait(for: [success], timeout: 0.3)
     }
 
     func testSuccessWithIrregularXMLRPCAddress() {

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -60,6 +60,25 @@ class WordPressComRestApiTests: XCTestCase {
         }
     }
 
+    func testHTTPMethod() async {
+        for method in HTTPRequestBuilder.Method.allCases {
+            let requestReceived = expectation(description: "HTTP request is received")
+
+            var request: URLRequest?
+            stub(condition: { _ in true }) {
+                request = $0
+                requestReceived.fulfill()
+                return HTTPStubsResponse(error: URLError(URLError.Code.networkConnectionLost))
+            }
+
+            let api = WordPressComRestApi(oAuthToken: "fakeToken")
+            _ = await api.perform(method, URLString: "test")
+            await fulfillment(of: [requestReceived], timeout: 0.1)
+
+            XCTAssertEqual(request?.httpMethod?.uppercased(), method.rawValue.uppercased())
+        }
+    }
+
     @available(iOS 16.0, *)
     func testQuery() {
         var requestURL: URL?

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -73,7 +73,7 @@ class WordPressComRestApiTests: XCTestCase {
 
             let api = WordPressComRestApi(oAuthToken: "fakeToken")
             _ = await api.perform(method, URLString: "test")
-            await fulfillment(of: [requestReceived], timeout: 0.1)
+            await fulfillment(of: [requestReceived], timeout: 0.3)
 
             XCTAssertEqual(request?.httpMethod?.uppercased(), method.rawValue.uppercased())
         }
@@ -95,7 +95,7 @@ class WordPressComRestApiTests: XCTestCase {
             success: { _, _ in expect.fulfill() },
             failure: { (_, _) in expect.fulfill() }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
 
         let query = requestURL?
             .query(percentEncoded: false)?
@@ -152,7 +152,7 @@ class WordPressComRestApiTests: XCTestCase {
 
         let api = WordPressComRestApi(oAuthToken: "fakeToken")
         _ = await api.perform(.get, URLString: "test?arg=value")
-        await fulfillment(of: [requestReceived], timeout: 0.1)
+        await fulfillment(of: [requestReceived], timeout: 0.3)
 
         XCTAssertEqual(request?.url?.path, "/test")
         XCTAssertTrue(request?.url?.query?.contains("arg=value") == true)
@@ -417,7 +417,7 @@ class WordPressComRestApiTests: XCTestCase {
             }
         )
 
-        wait(for: [complete], timeout: 0.1)
+        wait(for: [complete], timeout: 0.3)
     }
 
     func testStatusCode502() {
@@ -440,7 +440,7 @@ class WordPressComRestApiTests: XCTestCase {
             }
         )
 
-        wait(for: [complete], timeout: 0.1)
+        wait(for: [complete], timeout: 0.3)
     }
 
     func testTooManyRequestError() {
@@ -467,7 +467,7 @@ class WordPressComRestApiTests: XCTestCase {
             }
         )
 
-        wait(for: [complete], timeout: 0.1)
+        wait(for: [complete], timeout: 0.3)
     }
 
     func testPreconditionFailureError() {
@@ -491,7 +491,7 @@ class WordPressComRestApiTests: XCTestCase {
             }
         )
 
-        wait(for: [complete], timeout: 0.1)
+        wait(for: [complete], timeout: 0.3)
     }
 
     /// Verify that parameters in POST requests are sent as JSON.
@@ -516,7 +516,7 @@ class WordPressComRestApiTests: XCTestCase {
             }
         )
 
-        wait(for: [complete], timeout: 0.1)
+        wait(for: [complete], timeout: 0.3)
 
         let request = try XCTUnwrap(req)
         XCTAssertEqual(request.httpMethod?.uppercased(), "POST")

--- a/WordPressKitTests/WordPressOrgRestApiTests.swift
+++ b/WordPressKitTests/WordPressOrgRestApiTests.swift
@@ -108,7 +108,7 @@ class WordPressOrgRestApiTests: XCTestCase {
             complete.fulfill()
         }
 
-        wait(for: [complete], timeout: 0.1)
+        wait(for: [complete], timeout: 0.3)
 
         let request = try XCTUnwrap(req)
         XCTAssertEqual(request.httpMethod?.uppercased(), "POST")

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -67,7 +67,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 
     func test403() {
@@ -95,7 +95,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 
     func test403WithoutContentTypeHeader() {
@@ -123,7 +123,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 
     func testConnectionError() {
@@ -148,7 +148,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertEqual(error.code, URLError.Code.timedOut.rawValue)
             }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 
     func testFault() throws {
@@ -176,7 +176,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 
     func testFault401() throws {
@@ -204,7 +204,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 
     func testMalformedXML() throws {
@@ -233,7 +233,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 
     func testInvalidXML() throws {
@@ -260,7 +260,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
             }
         )
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 0.3)
     }
 
     func testProgressUpdate() {
@@ -285,7 +285,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
             observerCalled.fulfill()
         })
 
-        wait(for: [success, observerCalled], timeout: 0.1)
+        wait(for: [success, observerCalled], timeout: 0.3)
         observer?.invalidate()
 
         XCTAssertEqual(progress?.fractionCompleted, 1)
@@ -313,7 +313,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
             observerCalled.fulfill()
         })
 
-        wait(for: [failure, observerCalled], timeout: 0.1)
+        wait(for: [failure, observerCalled], timeout: 0.3)
         observer?.invalidate()
 
         XCTAssertEqual(progress?.fractionCompleted, 1)
@@ -341,7 +341,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
             observerCalled.fulfill()
         })
 
-        wait(for: [success, observerCalled], timeout: 0.1)
+        wait(for: [success, observerCalled], timeout: 0.3)
         observer?.invalidate()
 
         XCTAssertEqual(progress?.fractionCompleted, 1)
@@ -369,7 +369,7 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
             observerCalled.fulfill()
         })
 
-        wait(for: [failure, observerCalled], timeout: 0.1)
+        wait(for: [failure, observerCalled], timeout: 0.3)
         observer?.invalidate()
 
         XCTAssertEqual(progress?.fractionCompleted, 1)


### PR DESCRIPTION
### Description

> [!Note]
> This PR is built on top of #709.

This PRs adds functions that sends HTTP requests using URLSession, which will be used (in a upcoming PR) in the existing 'GET', 'POST', and upload files functions.

### Testing Details

None. This PR adds new code that is not used by others just yet.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
