### PR TITLE
Update XMLRPC API progress from the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- XMLRPC API progress is now always updated on the main thread. [#714]
 
 ### Internal Changes
 

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -155,14 +155,15 @@ open class WordPressOrgXMLRPCApi: NSObject {
                 progress.totalUnitCount = requestProgress.totalUnitCount + 1
                 progress.completedUnitCount = requestProgress.completedUnitCount
             }.response(queue: DispatchQueue.global()) { (response) in
-                progress.completedUnitCount = progress.totalUnitCount
                 do {
                     let responseObject = try self.handleResponseWithData(response.data, urlResponse: response.response, error: response.error as NSError?)
                     DispatchQueue.main.async {
+                        progress.completedUnitCount = progress.totalUnitCount
                         success(responseObject, response.response)
                     }
                 } catch let error as NSError {
                     DispatchQueue.main.async {
+                        progress.completedUnitCount = progress.totalUnitCount
                         failure(error, response.response)
                     }
                     return
@@ -208,12 +209,13 @@ open class WordPressOrgXMLRPCApi: NSObject {
                 }.response(queue: DispatchQueue.global()) { (response) in
                     do {
                         let responseObject = try self.handleResponseWithData(response.data, urlResponse: response.response, error: response.error as NSError?)
-                        progress.completedUnitCount = progress.totalUnitCount
                         DispatchQueue.main.async {
+                            progress.completedUnitCount = progress.totalUnitCount
                             success(responseObject, response.response)
                         }
                     } catch let error as NSError {
                         DispatchQueue.main.async {
+                            progress.completedUnitCount = progress.totalUnitCount
                             failure(error, response.response)
                         }
                         return

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -41,4 +41,116 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
         self.waitForExpectations(timeout: 2, handler: nil)
     }
 
+    func testProgressUpdate() {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            let stubPath = OHPathForFile("xmlrpc-response-getpost.xml", type(of: self))
+            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+        }
+
+        let success = self.expectation(description: "The success callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        let progress = api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (_, _) in success.fulfill() },
+            failure: { (_, _) in }
+        )
+
+        let observerCalled = expectation(description: "Progress observer is called")
+        observerCalled.assertForOverFulfill = false
+        let observer = progress?.observe(\.fractionCompleted, options: .new, changeHandler: { _, _ in
+            XCTAssertTrue(Thread.isMainThread)
+            observerCalled.fulfill()
+        })
+
+        wait(for: [success, observerCalled], timeout: 0.1)
+        observer?.invalidate()
+
+        XCTAssertEqual(progress?.fractionCompleted, 1)
+    }
+
+    func testProgressUpdateFailure() {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            let stubPath = OHPathForFile("xmlrpc-bad-username-password-error.xml", type(of: self))
+            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+        }
+
+        let failure = self.expectation(description: "The failure callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        let progress = api.callMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (_, _) in },
+            failure: { (_, _) in failure.fulfill() }
+        )
+
+        let observerCalled = expectation(description: "Progress observer is called")
+        observerCalled.assertForOverFulfill = false
+        let observer = progress?.observe(\.fractionCompleted, options: .new, changeHandler: { _, _ in
+            XCTAssertTrue(Thread.isMainThread)
+            observerCalled.fulfill()
+        })
+
+        wait(for: [failure, observerCalled], timeout: 0.1)
+        observer?.invalidate()
+
+        XCTAssertEqual(progress?.fractionCompleted, 1)
+    }
+
+    func testProgressUpdateStreamAPI() {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            let stubPath = OHPathForFile("xmlrpc-response-getpost.xml", type(of: self))
+            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+        }
+
+        let success = self.expectation(description: "The success callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        let progress = api.streamCallMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (_, _) in success.fulfill() },
+            failure: { (_, _) in }
+        )
+
+        let observerCalled = expectation(description: "Progress observer is called")
+        observerCalled.assertForOverFulfill = false
+        let observer = progress?.observe(\.fractionCompleted, options: .new, changeHandler: { _, _ in
+            XCTAssertTrue(Thread.isMainThread)
+            observerCalled.fulfill()
+        })
+
+        wait(for: [success, observerCalled], timeout: 0.1)
+        observer?.invalidate()
+
+        XCTAssertEqual(progress?.fractionCompleted, 1)
+    }
+
+    func testProgressUpdateStreamAPIFailure() {
+        stub(condition: isXmlRpcAPIRequest()) { _ in
+            let stubPath = OHPathForFile("xmlrpc-bad-username-password-error.xml", type(of: self))
+            return fixture(filePath: stubPath!, headers: ["Content-Type" as NSObject: "application/xml" as AnyObject])
+        }
+
+        let failure = self.expectation(description: "The failure callback should be invoked")
+        let api = WordPressOrgXMLRPCApi(endpoint: URL(string: xmlrpcEndpoint)! as URL)
+        let progress = api.streamCallMethod(
+            "wp.getPost",
+            parameters: nil,
+            success: { (_, _) in },
+            failure: { (_, _) in failure.fulfill() }
+        )
+
+        let observerCalled = expectation(description: "Progress observer is called")
+        observerCalled.assertForOverFulfill = false
+        let observer = progress?.observe(\.fractionCompleted, options: .new, changeHandler: { _, _ in
+            XCTAssertTrue(Thread.isMainThread)
+            observerCalled.fulfill()
+        })
+
+        wait(for: [failure, observerCalled], timeout: 0.1)
+        observer?.invalidate()
+
+        XCTAssertEqual(progress?.fractionCompleted, 1)
+    }
+
 }


### PR DESCRIPTION
### Description

WordPress iOS app (the uploading media part specifically) observes API requests progress and update UI upon progress updates. Updating progress from a background thread causes issues on the app side.

A more proper fix is probably updating the app's code to ensure UI updates happen on the main thread. But it's a bit difficult to find _all_ places that observe the XMLRPC progress instances. So, I decided to change the progress updating logic here, which kind of makes sense: now we have an implicit API that all progress updates from WordPressKit should happen on the main thread.

### Testing Details

You can produce this updating UI from a background thread issue on the WordPress iOS app.
1. Launch the app from Xcode, so that you can catch the issue from Xcode debugger.
2. Sign in to a self hosted WordPress site.
3. Go to Media screen and upload a media.
4. Upon finishing uploading, Xcode debugger should stop at [this observer code](https://github.com/wordpress-mobile/WordPress-iOS/blob/1b0c0a46ae2e3ed681df62e68dbc72030e357199/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCellViewModel.swift#L167-L169).

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
