### PR TITLE
Add asserts for debugging flaky LoadMediaLibraryTests

### DIFF
--- a/WordPressKitTests/MediaLibraryTestSupport.swift
+++ b/WordPressKitTests/MediaLibraryTestSupport.swift
@@ -95,13 +95,15 @@ extension MediaLibraryTestSupport {
         } else if let body = request.httpBody {
             parser = XMLParser(data: body)
         } else {
+            XCTFail("The request doesn't have a request body: \(request)")
             return .init(error: URLError(.cannotDecodeContentData))
         }
 
         let delegate = RequestParser()
         parser.delegate = delegate
         guard parser.parse() else {
-            return .init(data: Data(), statusCode: 200, headers: nil)
+            XCTFail("Unexpected error: \(String(describing: parser.parserError))")
+            return .init(error: URLError(.cannotDecodeContentData))
         }
 
         XCTAssertEqual(delegate.methodName, "wp.getMediaLibrary")


### PR DESCRIPTION
### Description

`LoadMediaLibraryRPCTests` occasionally fails on CI, but never locally fro me. I can't find any useful information in the xcresult file from CI jobs. This PR adds more assertions, which hopefully will help us debugging the failure.

### Testing Details

None.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
