### PR TITLE
Add XMLRPC request support to HTTPRequestBuilder

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -1,4 +1,5 @@
 import Foundation
+import wpxmlrpc
 
 /// A builder type that appends HTTP request data to a URL.
 ///
@@ -25,6 +26,7 @@ final class HTTPRequestBuilder {
     private var appendedQuery: [URLQueryItem] = []
     private var bodyBuilder: ((inout URLRequest) throws -> Void)?
     private(set) var multipartForm: [MultipartFormField]?
+    private(set) var xmlrpcRequest: XMLRPCRequest?
 
     init(url: URL) {
         assert(url.scheme == "http" || url.scheme == "https")
@@ -115,14 +117,14 @@ final class HTTPRequestBuilder {
     }
 
     func body(xml: @escaping () throws -> Data) -> Self {
-        headers["Content-Type"] = "application/xml; charset=utf-8"
+        headers["Content-Type"] = "text/xml; charset=utf-8"
         bodyBuilder = { req in
             req.httpBody = try xml()
         }
         return self
     }
 
-    func build(encodeMultipartForm: Bool = false) throws -> URLRequest {
+    func build(encodeBody: Bool = false) throws -> URLRequest {
         var components = original
 
         var newPath = Self.join(components.percentEncodedPath, appendedPath)
@@ -156,13 +158,15 @@ final class HTTPRequestBuilder {
             request.addValue(value, forHTTPHeaderField: header)
         }
 
-        if encodeMultipartForm {
-            let encoded = try self.encodeMultipartForm(request: &request, forceWriteToFile: false)
-            switch encoded {
-            case let .left(data):
-                request.httpBody = data
-            case let .right(url):
-                request.httpBodyStream = InputStream(url: url)
+        if encodeBody {
+            let body = try encodeMultipartForm(request: &request, forceWriteToFile: false) ?? encodeXMLRPC(request: &request, forceWriteToFile: false)
+            if let body {
+                switch body {
+                case let .left(data):
+                    request.httpBody = data
+                case let .right(url):
+                    request.httpBodyStream = InputStream(url: url)
+                }
             }
         }
 
@@ -174,30 +178,48 @@ final class HTTPRequestBuilder {
         return request
     }
 
-    func encodeMultipartForm(request: inout URLRequest, forceWriteToFile: Bool) throws -> Either<Data, URL> {
+    func encodeMultipartForm(request: inout URLRequest, forceWriteToFile: Bool) throws -> Either<Data, URL>? {
         guard let multipartForm, !multipartForm.isEmpty else {
-            return .left(Data())
+            return nil
         }
 
         let boundery = String(format: "wordpresskit.%08x", Int.random(in: Int.min..<Int.max))
         request.setValue("multipart/form-data; boundary=\(boundery)", forHTTPHeaderField: "Content-Type")
         return try multipartForm
             .multipartFormDataStream(boundary: boundery, forceWriteToFile: forceWriteToFile)
+    }
 
+    func encodeXMLRPC(request: inout URLRequest, forceWriteToFile: Bool) throws -> Either<Data, URL>? {
+        guard let xmlrpcRequest else {
+            return nil
+        }
+
+        request.setValue("text/xml", forHTTPHeaderField: "Content-Type")
+        let encoder = WPXMLRPCEncoder(method: xmlrpcRequest.method, andParameters: xmlrpcRequest.parameters)
+        if forceWriteToFile {
+            let fileName = "\(ProcessInfo.processInfo.globallyUniqueString)_file.xmlrpc"
+            let fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
+            try encoder.encode(toFile: fileURL.path)
+
+            var fileSize: AnyObject?
+            try (fileURL as NSURL).getResourceValue(&fileSize, forKey: .fileSizeKey)
+            if let fileSize = fileSize as? NSNumber {
+                request.setValue(fileSize.stringValue, forHTTPHeaderField: "Content-Length")
+            }
+
+            return .right(fileURL)
+        } else {
+            let data = try encoder.dataEncoded()
+            request.setValue("\(data.count)", forHTTPHeaderField: "Content-Length")
+            return try .left(encoder.dataEncoded())
+        }
     }
 }
 
 extension HTTPRequestBuilder {
-    // FIXME: Not implemented yet
-    func body(xmlrpc: Any /* XMLRPCRequest */) -> Self {
-        body(xml: {
-            fatalError("To be implemented")
-        })
-    }
-
-    // FIXME: Not implemented yet
-    func appendXMLRPCArgument(value: Any) -> Self {
-        fatalError("To be implemented")
+    func body(xmlrpc method: String, parameters: [Any]? = nil) -> Self {
+        self.xmlrpcRequest = XMLRPCRequest(method: method, parameters: parameters)
+        return self
     }
 }
 
@@ -277,4 +299,9 @@ extension Array where Element == URLQueryItem {
         .joined(separator: "&")
     }
 
+}
+
+struct XMLRPCRequest {
+    var method: String
+    var parameters: [Any]?
 }

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import XCTest
+import wpxmlrpc
 
 @testable import WordPressKit
 
@@ -348,6 +349,18 @@ class HTTPRequestBuilderTests: XCTestCase {
                 .build(encodeBody: false)
                 .httpBodyStream
         )
+    }
+
+    func testXMLRPCRequest() throws {
+        let request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
+            .method(.post)
+            .body(xmlrpc: "wp.getPost", parameters: ["username", "password", 100])
+            .build(encodeBody: true)
+            .httpBody
+
+        let decoder = WPXMLRPCEncoder(method: "wp.getPost", andParameters: ["username", "password", 100])
+        let expected = try decoder.dataEncoded()
+        XCTAssertEqual(request, expected)
     }
 
     func testURLEncodedPathInOriginalURL() {

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -329,7 +329,7 @@ class HTTPRequestBuilderTests: XCTestCase {
             try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
                 .method(.post)
                 .body(form: [MultipartFormField(text: "123456", name: "site")])
-                .build(encodeMultipartForm: true)
+                .build(encodeBody: true)
                 .httpBody
         )
 
@@ -337,7 +337,7 @@ class HTTPRequestBuilderTests: XCTestCase {
             try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
                 .method(.post)
                 .body(form: [MultipartFormField(text: "123456", name: "site")])
-                .build(encodeMultipartForm: false)
+                .build(encodeBody: false)
                 .httpBody
         )
 
@@ -345,7 +345,7 @@ class HTTPRequestBuilderTests: XCTestCase {
             try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
                 .method(.post)
                 .body(form: [MultipartFormField(text: "123456", name: "site")])
-                .build(encodeMultipartForm: false)
+                .build(encodeBody: false)
                 .httpBodyStream
         )
     }


### PR DESCRIPTION
### Description

What says in the title. Plus, this PR extra kind of unifies building multipart form and XMLPRC request, because their requests are very similar, just have different kinds of content.

### Testing Details

See the added unit tests.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
