### PR TITLE
Add URLSession instances to WordPressXMLRPCApi

### DIFF
--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -90,7 +90,10 @@ open class WordPressOrgXMLRPCApi: NSObject {
         return URLSession(configuration: sessionConfiguration, delegate: sessionDelegate, delegateQueue: nil)
     }
 
+    // swiftlint:disable weak_delegate
+    /// `URLSessionDelegate` for the URLSession instances in this class.
     private let sessionDelegate = SessionDelegate()
+    // swiftlint:enable weak_delegate
 
     /// Creates a new API object to connect to the WordPress XMLRPC API for the specified endpoint.
     ///

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -7,6 +7,8 @@ open class WordPressOrgXMLRPCApi: NSObject {
     public typealias SuccessResponseBlock = (AnyObject, HTTPURLResponse?) -> Void
     public typealias FailureReponseBlock = (_ error: NSError, _ httpResponse: HTTPURLResponse?) -> Void
 
+    public static var useURLSession = false
+
     private let endpoint: URL
     private let userAgent: String?
     private var backgroundUploads: Bool
@@ -25,6 +27,14 @@ open class WordPressOrgXMLRPCApi: NSObject {
     /// Minimum WordPress.org Supported Version.
     ///
     @objc public static let minimumSupportedVersion = "4.0"
+
+    private lazy var urlSession: URLSession = makeSession(configuration: .default)
+    private lazy var uploadURLSession: URLSession = {
+        if self.backgroundUploads {
+            return makeSession(configuration: .background(withIdentifier: self.backgroundSessionIdentifier))
+        }
+        return urlSession
+    }()
 
     private var _sessionManager: Alamofire.SessionManager?
     private var sessionManager: Alamofire.SessionManager {
@@ -71,6 +81,15 @@ open class WordPressOrgXMLRPCApi: NSObject {
         return sessionManager
     }
 
+    private func makeSession(configuration sessionConfiguration: URLSessionConfiguration) -> URLSession {
+        var additionalHeaders: [String: AnyObject] = ["Accept-Encoding": "gzip, deflate" as AnyObject]
+        if let userAgent = self.userAgent {
+            additionalHeaders["User-Agent"] = userAgent as AnyObject?
+        }
+        sessionConfiguration.httpAdditionalHeaders = additionalHeaders
+        return URLSession(configuration: sessionConfiguration, delegate: sessionDelegate, delegateQueue: nil)
+    }
+
     private let sessionDelegate = SessionDelegate()
 
     /// Creates a new API object to connect to the WordPress XMLRPC API for the specified endpoint.
@@ -98,16 +117,18 @@ open class WordPressOrgXMLRPCApi: NSObject {
     }
 
     deinit {
-        _sessionManager?.session.finishTasksAndInvalidate()
-        _uploadSessionManager?.session.finishTasksAndInvalidate()
+        for session in [urlSession, uploadURLSession, sessionManager.session, uploadSessionManager.session] {
+            session.finishTasksAndInvalidate()
+        }
     }
 
     /**
      Cancels all ongoing and makes the session so the object will not fullfil any more request
      */
     @objc open func invalidateAndCancelTasks() {
-        sessionManager.session.invalidateAndCancel()
-        uploadSessionManager.session.invalidateAndCancel()
+        for session in [urlSession, uploadURLSession, sessionManager.session, uploadSessionManager.session] {
+            session.invalidateAndCancel()
+        }
     }
 
     // MARK: - Network requests

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -30,10 +30,9 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
     private lazy var urlSession: URLSession = makeSession(configuration: .default)
     private lazy var uploadURLSession: URLSession = {
-        if self.backgroundUploads {
-            return makeSession(configuration: .background(withIdentifier: self.backgroundSessionIdentifier))
-        }
-        return urlSession
+        backgroundUploads
+            ? makeSession(configuration: .background(withIdentifier: self.backgroundSessionIdentifier))
+            : urlSession
     }()
 
     private var _sessionManager: Alamofire.SessionManager?

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -74,7 +74,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
         }
         sessionManager.delegate.sessionDidReceiveChallengeWithCompletion = sessionDidReceiveChallengeWithCompletion
 
-        let  taskDidReceiveChallengeWithCompletion: ((URLSession, URLSessionTask, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [sessionDelegate] session, task, authenticationChallenge, completionHandler in
+        let taskDidReceiveChallengeWithCompletion: ((URLSession, URLSessionTask, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [sessionDelegate] session, task, authenticationChallenge, completionHandler in
             sessionDelegate.urlSession(session, task: task, didReceive: authenticationChallenge, completionHandler: completionHandler)
         }
         sessionManager.delegate.taskDidReceiveChallengeWithCompletion = taskDidReceiveChallengeWithCompletion

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -357,9 +357,11 @@ open class WordPressOrgXMLRPCApi: NSObject {
 
 private class SessionDelegate: NSObject, URLSessionDelegate {
 
-    @objc public func urlSession(_ session: URLSession,
-                           didReceive challenge: URLAuthenticationChallenge,
-                           completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    @objc func urlSession(
+        _ session: URLSession,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
 
         switch challenge.protectionSpace.authenticationMethod {
         case NSURLAuthenticationMethodServerTrust:
@@ -391,10 +393,12 @@ private class SessionDelegate: NSObject, URLSessionDelegate {
         }
     }
 
-    @objc public func urlSession(_ session: URLSession,
-                           task: URLSessionTask,
-                           didReceive challenge: URLAuthenticationChallenge,
-                           completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    @objc func urlSession(
+        _ session: URLSession,
+        task: URLSessionTask,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
 
         switch challenge.protectionSpace.authenticationMethod {
         case NSURLAuthenticationMethodHTTPBasic:

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -59,17 +59,19 @@ open class WordPressOrgXMLRPCApi: NSObject {
         sessionConfiguration.httpAdditionalHeaders = additionalHeaders
         let sessionManager = Alamofire.SessionManager(configuration: sessionConfiguration)
 
-        let sessionDidReceiveChallengeWithCompletion: ((URLSession, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [weak self] session, authenticationChallenge, completionHandler in
-            self?.urlSession(session, didReceive: authenticationChallenge, completionHandler: completionHandler)
+        let sessionDidReceiveChallengeWithCompletion: ((URLSession, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [sessionDelegate] session, authenticationChallenge, completionHandler in
+            sessionDelegate.urlSession(session, didReceive: authenticationChallenge, completionHandler: completionHandler)
         }
         sessionManager.delegate.sessionDidReceiveChallengeWithCompletion = sessionDidReceiveChallengeWithCompletion
 
-        let  taskDidReceiveChallengeWithCompletion: ((URLSession, URLSessionTask, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [weak self] session, task, authenticationChallenge, completionHandler in
-            self?.urlSession(session, task: task, didReceive: authenticationChallenge, completionHandler: completionHandler)
+        let  taskDidReceiveChallengeWithCompletion: ((URLSession, URLSessionTask, URLAuthenticationChallenge, @escaping(URLSession.AuthChallengeDisposition, URLCredential?) -> Void) -> Void) = { [sessionDelegate] session, task, authenticationChallenge, completionHandler in
+            sessionDelegate.urlSession(session, task: task, didReceive: authenticationChallenge, completionHandler: completionHandler)
         }
         sessionManager.delegate.taskDidReceiveChallengeWithCompletion = taskDidReceiveChallengeWithCompletion
         return sessionManager
     }
+
+    private let sessionDelegate = SessionDelegate()
 
     /// Creates a new API object to connect to the WordPress XMLRPC API for the specified endpoint.
     ///
@@ -329,7 +331,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     }
 }
 
-extension WordPressOrgXMLRPCApi {
+private class SessionDelegate: NSObject, URLSessionDelegate {
 
     @objc public func urlSession(_ session: URLSession,
                            didReceive challenge: URLAuthenticationChallenge,


### PR DESCRIPTION
### Description

What says in the title. The new URLSessions will be used to send request in upcoming PRs.

### Testing Details

None.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
