### PR TITLE
Bump version to 13.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,39 @@ _None._
 
 ### Breaking Changes
 
+_None._
+
+### New Features
+
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## 13.0.0
+
+### Breaking Changes
+
+- Remove `userIP` from `AtomicWebServerLogEntry`. [#711]
+
+### Internal Changes
+
+- Various internal changes in preparation to remove Alamofire.
+
+## 12.0.0
+
+### Breaking Changes
+
 - `WordPressComRestApiError` is renamed to `WordPressRestApiErrorCode`, and no longer conforms to `Swift.Error`. [#696]
 
 ### New Features
 
-- Add `AtomicSiteServiceRemote`
+- Add `AtomicSiteServiceRemote` [#704]
 
 ### Bug Fixes
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '12.0.0'
+  s.version       = '13.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS [24.2](https://github.com/wordpress-mobile/WordPress-iOS/milestone/269) and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.