### PR TITLE
Use URLSession to send XMLRPC requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- When enabled, `WrodPressOrgXMLRPCApi` sends HTTP requests using URLSession instead of Alamofire. [#719]
 
 ## 13.0.0
 

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -282,6 +282,17 @@ open class WordPressOrgXMLRPCApi: NSObject {
         return progress
     }
 
+    /// Call an XMLRPC method.
+    ///
+    /// ## Error handling
+    ///
+    /// Unlike the closed-based APIs, this method returns a concrete error type. You should consider handle the errors
+    /// as they are, instead of casing them to `NSError` instance. But in case you do need to cast them to `NSError`,
+    /// considering using the `asNSError` function if you need backward compatiblity with existing code,
+    ///
+    /// - Parameters:
+    ///   - streaming: set to true if there are large data (i.e. uploading files) in given `parameters`. `false` by default.
+    /// - Returns: A `Result` type that contains the XMLRPC success or failure result.
     func call(method: String, parameters: [AnyObject]?, fulfilling progress: Progress, streaming: Bool = false) async -> WordPressAPIResult<HTTPAPIResponse<AnyObject>, WordPressOrgXMLRPCApiFault> {
         let session = streaming ? uploadURLSession : urlSession
         let builder = HTTPRequestBuilder(url: endpoint)

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -508,16 +508,21 @@ extension WordPressOrgXMLRPCApiError: LocalizedError {
 }
 
 public struct WordPressOrgXMLRPCApiFault: LocalizedError, HTTPURLResponseProviding {
-    var response: HTTPAPIResponse<Data>
+    public var response: HTTPAPIResponse<Data>
+    public let code: Int?
+    public let message: String?
 
-    var code: Int?
-    var message: String?
+    public init(response: HTTPAPIResponse<Data>, code: Int?, message: String?) {
+        self.response = response
+        self.code = code
+        self.message = message
+    }
 
     public var errorDescription: String? {
         message
     }
 
-    var httpResponse: HTTPURLResponse? {
+    public var httpResponse: HTTPURLResponse? {
         response.response
     }
 }

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -547,7 +547,7 @@ private extension WordPressAPIResult<HTTPAPIResponse<Data>, WordPressOrgXMLRPCAp
                 }
             }
 
-            if ["application/xml", "text/xml"].filter({ (type) -> Bool in return contentType.hasPrefix(type)}).count == 0 {
+            guard contentType.hasPrefix("application/xml") || contentType.hasPrefix("text/xml") else {
                 return .failure(.unparsableResponse(response: response.response, body: response.body, underlyingError: WordPressOrgXMLRPCApiError.unknown))
             }
 

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -286,12 +286,12 @@ open class WordPressOrgXMLRPCApi: NSObject {
     ///
     /// ## Error handling
     ///
-    /// Unlike the closed-based APIs, this method returns a concrete error type. You should consider handle the errors
-    /// as they are, instead of casing them to `NSError` instance. But in case you do need to cast them to `NSError`,
-    /// considering using the `asNSError` function if you need backward compatiblity with existing code,
+    /// Unlike the closure-based APIs, this method returns a concrete error type. You should consider handling the errors
+    /// as they are, instead of casting them to `NSError` instance. But in case you do need to cast them to `NSError`,
+    /// considering using the `asNSError` function if you need backward compatibility with existing code.
     ///
     /// - Parameters:
-    ///   - streaming: set to true if there are large data (i.e. uploading files) in given `parameters`. `false` by default.
+    ///   - streaming: set to `true` if there are large data (i.e. uploading files) in given `parameters`. `false` by default.
     /// - Returns: A `Result` type that contains the XMLRPC success or failure result.
     func call(method: String, parameters: [AnyObject]?, fulfilling progress: Progress, streaming: Bool = false) async -> WordPressAPIResult<HTTPAPIResponse<AnyObject>, WordPressOrgXMLRPCApiFault> {
         let session = streaming ? uploadURLSession : urlSession

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -203,8 +203,8 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
 
                 // The change highlights one difference between the existing Alamofire-backed API and the new
-                // URLSession-backed API: the error returned by the new one may has HTTP response body which may not
-                // be the case exist in the old API. I think this is an acceptable change.
+                // URLSession-backed API: the error returned by the new one has an HTTP response body which is not
+                // the case exist in the old API. I think this is an acceptable change.
                 if WordPressOrgXMLRPCApi.useURLSession {
                     XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
                 } else {

--- a/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
+++ b/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift
@@ -200,8 +200,16 @@ class WordPressOrgXMLRPCApiTests: XCTestCase {
                 XCTAssertEqual(error.domain, WPXMLRPCFaultErrorDomain)
                 // 403 is the 'faultCode' in the HTTP response xml.
                 XCTAssertEqual(error.code, 403)
-                XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
                 XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyStatusCode as String])
+
+                // The change highlights one difference between the existing Alamofire-backed API and the new
+                // URLSession-backed API: the error returned by the new one may has HTTP response body which may not
+                // be the case exist in the old API. I think this is an acceptable change.
+                if WordPressOrgXMLRPCApi.useURLSession {
+                    XCTAssertNotNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                } else {
+                    XCTAssertNil(error.userInfo[WordPressOrgXMLRPCApi.WordPressOrgXMLRPCApiErrorKeyData as String])
+                }
             }
         )
         wait(for: [expect], timeout: 0.3)


### PR DESCRIPTION
### Description

This PR updates the XMLRPC API client to send HTTP requests using URLSession, when `useURLSession` is set to true ([it's false by default](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/13.0.0/WordPressKit/WordPressOrgXMLRPCApi.swift#L10)).

#### Error handling

This PR also changes the error handling in XMLPRC API and the API it surfaces.

When using Alamofire, in most cases, the XMLRPC API client returns `NSError` instances (plain and simple NSError instance, not the ones that are cast from Swift errors). It may return `URLError` too. It's quite different from the WP.com REST API client, which returns `NSError` instances that are cast from Swift errors, which is why I implemented [a custom NSError bridge logic](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/13.0.0/WordPressKit/WordPressAPIError%2BNSErrorBrdige.swift).

Since there is no "bridging" happening in `WordPressOrgXMLRPCApi`, I didn't reuse the custom error bridging code. Instead, I re-used the existing function that creates new `NSError` instances, _for the exiting closure-based APIs_. The new async function `call(method:parameters:...)` returns `WordPressAPIError<WordPressOrgXMLRPCApiFault>` error instances. That means, depending on which method you call, you'll get different kinds of errors.

The new implementation is in the `decodeXMLRPCResult` and `asNSError` functions, which together should work exactly like [the existing `handleResponseWithData` function](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/13.0.0/WordPressKit/WordPressOrgXMLRPCApi.swift#L292). And this "non-change" should be covered by [the existing error case unit tests](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/b0fd9e309b74594c8c5109cb007232b40aa040cd/WordPressKitTests/WordPressOrgXMLRPCApiTests.swift).

### Testing Details

Similar to https://github.com/wordpress-mobile/WordPressKit-iOS/pull/720, the unit tests pass when `useURLSession` is set to true.

https://github.com/wordpress-mobile/WordPress-iOS/pull/22540 can be used to get an app build which enables `useURLSession` by default.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
