### PR TITLE
Use URLSession to send WP.com REST API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-- When enabled, send WP.com REST API requests using URLSession, instead of Alamofire. [#720]
+- When enabled, `WordPressComRestApi` sends HTTP requests using URLSession instead of Alamofire. [#720]
 - When enabled, `WrodPressOrgXMLRPCApi` sends HTTP requests using URLSession instead of Alamofire. [#719]
 
 ## 13.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- When enabled, send WP.com REST API requests using URLSession, instead of Alamofire. [#720]
 
 ## 13.0.0
 

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -45,6 +45,7 @@ extension URLSession {
     func perform<E: LocalizedError>(
         request builder: HTTPRequestBuilder,
         acceptableStatusCodes: [ClosedRange<Int>] = [200...299],
+        taskCreated: ((Int) -> Void)? = nil,
         fulfilling parentProgress: Progress? = nil,
         errorType: E.Type = E.self
     ) async -> WordPressAPIResult<HTTPAPIResponse<Data>, E> {
@@ -75,6 +76,7 @@ extension URLSession {
             }
 
             task.resume()
+            taskCreated?(task.taskIdentifier)
 
             if let parentProgress, parentProgress.totalUnitCount > parentProgress.completedUnitCount {
                 let pending = parentProgress.totalUnitCount - parentProgress.completedUnitCount

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -301,7 +301,7 @@ open class WordPressComRestApi: NSObject {
             case let .success(response):
                 success(response.body, response.response)
             case let .failure(error):
-                failure(error as NSError, error.response)
+                failure(error.asNSError(), error.response)
             }
         }
 
@@ -360,7 +360,7 @@ open class WordPressComRestApi: NSObject {
             case let .success(response):
                success(response.body, response.response)
             case let .failure(error):
-               failure(error as NSError, error.response)
+               failure(error.asNSError(), error.response)
             }
         }
 
@@ -397,7 +397,7 @@ open class WordPressComRestApi: NSObject {
                 case let .success(response):
                     success(response.body, response.response)
                 case let .failure(error):
-                    failure(error as NSError, error.response)
+                    failure(error.asNSError(), error.response)
                 }
             }
 
@@ -863,4 +863,15 @@ private extension CharacterSet {
         allowed.remove(charactersIn: "\(generalDelimitersToEncode)\(subDelimitersToEncode)")
         return allowed
     }()
+}
+
+private extension WordPressAPIError<WordPressComRestApiEndpointError> {
+    func asNSError() -> NSError {
+        // When encoutering `URLError`, return `URLError` to avoid potentially breaking existing error handling code in the apps.
+        if case let .connection(urlError) = self {
+            return urlError as NSError
+        }
+
+        return self as NSError
+    }
 }

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -394,7 +394,7 @@ open class WordPressComRestApi: NSObject {
             let progress = Progress.discreteProgress(totalUnitCount: 100)
 
             Task { @MainActor in
-                let result = await upload(URLString, parameters: parameters, fileParts: fileParts, requestEnqueued: requestEnqueued, fulfilling: progress)
+                let result = await upload(URLString: URLString, parameters: parameters, fileParts: fileParts, requestEnqueued: requestEnqueued, fulfilling: progress)
                 switch result {
                 case let .success(response):
                     success(response.body, response.response)
@@ -642,7 +642,7 @@ open class WordPressComRestApi: NSObject {
     }
 
     public func upload(
-        _ URLString: String,
+        URLString: String,
         parameters: [String: AnyObject]?,
         fileParts: [FilePart],
         requestEnqueued: RequestEnqueuedBlock? = nil,

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -182,14 +182,14 @@ open class WordPressComRestApi: NSObject {
     }
 
     deinit {
-        for session in [urlSession, sessionManager.session, uploadSessionManager.session] {
+        for session in [urlSession, uploadURLSession, sessionManager.session, uploadSessionManager.session] {
             session.finishTasksAndInvalidate()
         }
     }
 
     /// Cancels all outgoing tasks asynchronously without invalidating the session.
     public func cancelTasks() {
-        for session in [urlSession, sessionManager.session, uploadSessionManager.session] {
+        for session in [urlSession, uploadURLSession, sessionManager.session, uploadSessionManager.session] {
             session.getAllTasks { tasks in
                 tasks.forEach({ $0.cancel() })
             }
@@ -200,7 +200,7 @@ open class WordPressComRestApi: NSObject {
      Cancels all ongoing taks and makes the session invalid so the object will not fullfil any more request
      */
     @objc open func invalidateAndCancelTasks() {
-        for session in [urlSession, sessionManager.session, uploadSessionManager.session] {
+        for session in [urlSession, uploadURLSession, sessionManager.session, uploadSessionManager.session] {
             session.invalidateAndCancel()
         }
     }
@@ -388,6 +388,21 @@ open class WordPressComRestApi: NSObject {
                               requestEnqueued: RequestEnqueuedBlock? = nil,
                               success: @escaping SuccessResponseBlock,
                               failure: @escaping FailureReponseBlock) -> Progress? {
+        guard !WordPressComRestApi.useURLSession else {
+            let progress = Progress.discreteProgress(totalUnitCount: 100)
+
+            Task { @MainActor in
+                let result = await upload(URLString, parameters: parameters, fileParts: fileParts, requestEnqueued: requestEnqueued, fulfilling: progress)
+                switch result {
+                case let .success(response):
+                    success(response.body, response.response)
+                case let .failure(error):
+                    failure(error as NSError, error.response)
+                }
+            }
+
+            return progress
+        }
 
         guard let URLString = buildRequestURLFor(path: URLString, parameters: parameters) else {
             failure(Constants.buildRequestError, nil)
@@ -515,7 +530,17 @@ open class WordPressComRestApi: NSObject {
     // MARK: - Async
 
     private lazy var urlSession: URLSession = {
-        let configuration = URLSessionConfiguration.default
+        URLSession(configuration: sessionConfiguration(background: false))
+    }()
+
+    private lazy var uploadURLSession: URLSession = {
+        let configuration = sessionConfiguration(background: backgroundUploads)
+        configuration.sharedContainerIdentifier = self.sharedContainerIdentifier
+        return URLSession(configuration: configuration)
+    }()
+
+    private func sessionConfiguration(background: Bool) -> URLSessionConfiguration {
+        let configuration = background ? URLSessionConfiguration.background(withIdentifier: self.backgroundSessionIdentifier) : URLSessionConfiguration.default
 
         var additionalHeaders: [String: AnyObject] = [:]
         if let oAuthToken = self.oAuthToken {
@@ -527,8 +552,8 @@ open class WordPressComRestApi: NSObject {
 
         configuration.httpAdditionalHeaders = additionalHeaders
 
-        return URLSession(configuration: configuration)
-    }()
+        return configuration
+    }
 
     func perform(
         _ method: HTTPRequestBuilder.Method,
@@ -584,10 +609,12 @@ open class WordPressComRestApi: NSObject {
     private func perform<T>(
         request: HTTPRequestBuilder,
         fulfilling progress: Progress?,
-        decoder: @escaping (Data) throws -> T
+        decoder: @escaping (Data) throws -> T,
+        taskCreated: ((Int) -> Void)? = nil,
+        session: URLSession? = nil
     ) async -> APIResult<T> {
-        await self.urlSession
-            .perform(request: request, fulfilling: progress, errorType: WordPressComRestApiEndpointError.self)
+        await (session ?? self.urlSession)
+            .perform(request: request, taskCreated: taskCreated, fulfilling: progress, errorType: WordPressComRestApiEndpointError.self)
             .mapSuccess { response -> HTTPAPIResponse<T> in
                 let object = try decoder(response.body)
 
@@ -610,6 +637,38 @@ open class WordPressComRestApi: NSObject {
                     return error
                 }
             }
+    }
+
+    public func upload(
+        _ URLString: String,
+        parameters: [String: AnyObject]?,
+        fileParts: [FilePart],
+        requestEnqueued: RequestEnqueuedBlock? = nil,
+        fulfilling progress: Progress? = nil
+    ) async -> APIResult<AnyObject> {
+        let builder: HTTPRequestBuilder
+        do {
+            let form = try fileParts.map {
+                try MultipartFormField(fileAtPath: $0.url.path, name: $0.parameterName, filename: $0.filename, mimeType: $0.mimeType)
+            }
+            builder = try requestBuilder(URLString: URLString)
+                .method(.post)
+                .body(form: form)
+        } catch {
+            return .failure(.requestEncodingFailure(underlyingError: error))
+        }
+
+        return await perform(
+            request: builder.query(parameters ?? [:]),
+            fulfilling: progress,
+            decoder: { try JSONSerialization.jsonObject(with: $0) as AnyObject },
+            taskCreated: { taskID in
+                DispatchQueue.main.async {
+                    requestEnqueued?(NSNumber(value: taskID))
+                }
+            },
+            session: uploadURLSession
+        )
     }
 
 }

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -326,6 +326,8 @@ open class WordPressComRestApi: NSObject {
             completion(
                 result
                     .map { ($0.body, $0.response) }
+                    // The completion expects a result with any Error.
+                    // We need to "downcast" the WordPressComRestApiEndpointError error in the APIResult.
                     .mapError { error -> Error in error }
             )
         }

--- a/WordPressKitTests/WordPressComRestApiTests.swift
+++ b/WordPressKitTests/WordPressComRestApiTests.swift
@@ -330,8 +330,8 @@ class WordPressComRestApiTests: XCTestCase {
             XCTFail("This call should fail")
         }, failure: { (error, _) in
             expect.fulfill()
-            XCTAssert(error.domain == NSURLErrorDomain, "The error domain should be NSURLErrorDomain")
-            XCTAssert(error.code == NSURLErrorCancelled, "The error code should be NSURLErrorCancelled")
+            XCTAssertEqual(error.domain, NSURLErrorDomain, "The error domain should be NSURLErrorDomain")
+            XCTAssertEqual(error.code, NSURLErrorCancelled, "The error code should be NSURLErrorCancelled")
         })
         self.waitForExpectations(timeout: 2, handler: nil)
     }
@@ -436,7 +436,12 @@ class WordPressComRestApiTests: XCTestCase {
             },
             failure: { error, _ in
                 complete.fulfill()
-                XCTAssertEqual(error.domain, "Alamofire.AFError")
+
+                if WordPressComRestApi.useURLSession {
+                    XCTAssertTrue(error is WordPressAPIError<WordPressComRestApiEndpointError>)
+                } else {
+                    XCTAssertEqual(error.domain, "Alamofire.AFError")
+                }
             }
         )
 


### PR DESCRIPTION
### Description

This PR updates the WP.com REST API client to send HTTP requests using URLSession, when `useURLSession` is set to true (it's false by default).

> [!Note]
> I'd recommend reviewing this PR commit-by-commit.

### Testing Details

The unit test suite passes with `useURLSession` set to ture. I had to updated one test case to make it pass, because the new URLSession API does not return AFError.

In theory, all the new code in this PR are dead code at the moment. I will update the apps to enable `useURLSession` as in-development feature flag, and we can see how the new implementation work out in the app.

https://github.com/wordpress-mobile/WordPress-iOS/pull/22540 can be used to get an app build which enables `useURLSession` by default.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
