### PR TITLE
Refactor BlazeService to use the new URLSession-backed API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ _None._
 - When enabled, `WordPressComRestApi` sends HTTP requests using URLSession instead of Alamofire. [#720]
 - When enabled, `WrodPressOrgXMLRPCApi` sends HTTP requests using URLSession instead of Alamofire. [#719]
 - Refactor API requests that ask for SMS code during WP.com authentication. [#683]
+- Refactor BlazeServiceRemote to use URLSession-backed API. [#721]
 
 ## 13.0.0
 

--- a/WordPressKit/BlazeServiceRemote.swift
+++ b/WordPressKit/BlazeServiceRemote.swift
@@ -12,20 +12,18 @@ open class BlazeServiceRemote: ServiceRemoteWordPressComREST {
     open func searchCampaigns(forSiteId siteId: Int, page: Int = 1, callback: @escaping (Result<BlazeCampaignsSearchResponse, Error>) -> Void) {
         let endpoint = "sites/\(siteId)/wordads/dsp/api/v1/search/campaigns/site/\(siteId)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
-        wordPressComRestApi.GET(path, parameters: [
-            "page": "\(page)" as AnyObject
-        ], success: { response, _ in
-            do {
-                let data = try JSONSerialization.data(withJSONObject: response)
-                let response = try JSONDecoder.apiDecoder.decode(BlazeCampaignsSearchResponse.self, from: data)
-                callback(.success((response)))
-            } catch {
-                WPKitLogError("Error parsing campaigns response: \(error), \(response)")
-                callback(.failure(error))
-            }
-        }, failure: { error, _ in
-            WPKitLogError("Error retrieving blaze campaigns: ", error)
-            callback(.failure(error))
-        })
+        Task { @MainActor in
+            let result = await self.wordPressComRestApi
+                .perform(
+                    .get,
+                    URLString: path,
+                    parameters: ["page": page] as [String: AnyObject],
+                    jsonDecoder: JSONDecoder.apiDecoder,
+                    type: BlazeCampaignsSearchResponse.self
+                )
+                .map { $0.body }
+                .eraseToError()
+            callback(result)
+        }
     }
 }

--- a/WordPressKit/Result+Callback.swift
+++ b/WordPressKit/Result+Callback.swift
@@ -7,4 +7,9 @@ extension Swift.Result {
         case .failure(let error): onFailure(error)
         }
     }
+
+    func eraseToError() -> Result<Success, Error> {
+        mapError { $0 }
+    }
+
 }

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -326,9 +326,7 @@ open class WordPressComRestApi: NSObject {
             completion(
                 result
                     .map { ($0.body, $0.response) }
-                    // The completion expects a result with any Error.
-                    // We need to "downcast" the WordPressComRestApiEndpointError error in the APIResult.
-                    .mapError { error -> Error in error }
+                    .eraseToError()
             )
         }
     }


### PR DESCRIPTION
### Description

I want to use the new async API in an existing code to showcase its difference compared to the existing closure-based API.

Please note, the updated function used to return `DecodingError` when fail to decode the response. It now returns `WordPressComRestApi.responseSerializationFailed`. I have checked the error handling code on the app side, which only checks if error is nil. So, it should be okay to make this change.

### Testing Details

There are [existing unit tests](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/b5c2bd39ec8f478dd53ecb7533ad025aad48f42e/WordPressKitTests/BlazeServiceRemoteTests.swift).

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
