### PR TITLE
Remove redundant JSON encoding and decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ _None._
 - When enabled, `WrodPressOrgXMLRPCApi` sends HTTP requests using URLSession instead of Alamofire. [#719]
 - Refactor API requests that ask for SMS code during WP.com authentication. [#683]
 - Refactor BlazeServiceRemote to use URLSession-backed API. [#721]
+- Refactor some WP.com API endpoints to use URLSession-backed API. [#722]
 
 ## 13.0.0
 

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -43,7 +43,6 @@ open class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
             return params
         }()
 
-
         let decoder = JSONDecoder.apiDecoder
         // our API decoder assumes that we're converting from snake case.
         // revert it to default so the CodingKeys match the actual response keys.

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -59,7 +59,7 @@ open class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
                 )
                 .map { $0.body.values.first ?? [] }
                 .mapError { error -> Error in error.asNSError() }
-                .execute(completion: completion)
+                .execute(completion)
         }
     }
 
@@ -74,7 +74,7 @@ open class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
             await self.wordPressComRestApi.perform(.get, URLString: path, type: RemoteBloggingPromptsSettings.self)
                 .map { $0.body }
                 .mapError { error -> Error in error.asNSError() }
-                .execute(completion: completion)
+                .execute(completion)
         }
     }
 

--- a/WordPressKit/BloggingPromptsServiceRemote.swift
+++ b/WordPressKit/BloggingPromptsServiceRemote.swift
@@ -43,24 +43,24 @@ open class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
             return params
         }()
 
-        wordPressComRestApi.GET(path, parameters: requestParameter as [String: AnyObject]) { result, _ in
-            switch result {
-            case .success(let responseObject):
-                do {
-                    let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
-                    let decoder = JSONDecoder.apiDecoder
-                    // our API decoder assumes that we're converting from snake case.
-                    // revert it to default so the CodingKeys match the actual response keys.
-                    decoder.keyDecodingStrategy = .useDefaultKeys
-                    let response = try decoder.decode([String: [RemoteBloggingPrompt]].self, from: data)
-                    completion(.success(response.values.first ?? []))
-                } catch {
-                    completion(.failure(error))
-                }
 
-            case .failure(let error):
-                completion(.failure(error))
-            }
+        let decoder = JSONDecoder.apiDecoder
+        // our API decoder assumes that we're converting from snake case.
+        // revert it to default so the CodingKeys match the actual response keys.
+        decoder.keyDecodingStrategy = .useDefaultKeys
+
+        Task { @MainActor in
+            await self.wordPressComRestApi
+                .perform(
+                    .get,
+                    URLString: path,
+                    parameters: requestParameter as [String: AnyObject],
+                    jsonDecoder: decoder,
+                    type: [String: [RemoteBloggingPrompt]].self
+                )
+                .map { $0.body.values.first ?? [] }
+                .mapError { error -> Error in error.asNSError() }
+                .execute(completion: completion)
         }
     }
 
@@ -71,19 +71,11 @@ open class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
     ///   - completion: Closure that will be called when the request completes.
     open func fetchSettings(for siteID: NSNumber, completion: @escaping (Result<RemoteBloggingPromptsSettings, Error>) -> Void) {
         let path = path(forEndpoint: "sites/\(siteID)/blogging-prompts/settings", withVersion: ._2_0)
-        wordPressComRestApi.GET(path, parameters: nil) { result, _ in
-            switch result {
-            case .success(let responseObject):
-                do {
-                    let data = try JSONSerialization.data(withJSONObject: responseObject)
-                    let settings = try JSONDecoder().decode(RemoteBloggingPromptsSettings.self, from: data)
-                    completion(.success(settings))
-                } catch {
-                    completion(.failure(error))
-                }
-            case .failure(let error):
-                completion(.failure(error))
-            }
+        Task { @MainActor in
+            await self.wordPressComRestApi.perform(.get, URLString: path, type: RemoteBloggingPromptsSettings.self)
+                .map { $0.body }
+                .mapError { error -> Error in error.asNSError() }
+                .execute(completion: completion)
         }
     }
 

--- a/WordPressKit/Domains/DomainsServiceRemote+AllDomains.swift
+++ b/WordPressKit/Domains/DomainsServiceRemote+AllDomains.swift
@@ -34,7 +34,7 @@ extension DomainsServiceRemote {
                 )
                 .map { $0.body.domains }
                 .mapError { error -> Error in error.asNSError() }
-                .execute(completion: completion)
+                .execute(completion)
         }
     }
 

--- a/WordPressKit/JetpackSocialServiceRemote.swift
+++ b/WordPressKit/JetpackSocialServiceRemote.swift
@@ -26,7 +26,7 @@ public class JetpackSocialServiceRemote: ServiceRemoteWordPressComREST {
                     }
                     return .failure(original.asNSError())
                 }
-                .execute(completion: completion)
+                .execute(completion)
         }
     }
 }

--- a/WordPressKit/JetpackSocialServiceRemote.swift
+++ b/WordPressKit/JetpackSocialServiceRemote.swift
@@ -11,20 +11,22 @@ public class JetpackSocialServiceRemote: ServiceRemoteWordPressComREST {
     public func fetchPublicizeInfo(for siteID: Int,
                                    completion: @escaping (Result<RemotePublicizeInfo?, Error>) -> Void) {
         let path = path(forEndpoint: "sites/\(siteID)/jetpack-social", withVersion: ._2_0)
-        wordPressComRestApi.GET(path, parameters: nil) { result, response in
-            switch result {
-            case .success(let responseObject):
-                do {
-                    let data = try JSONSerialization.data(withJSONObject: responseObject)
-                    let info = try? JSONDecoder.apiDecoder.decode(RemotePublicizeInfo.self, from: data)
-                    completion(.success(info))
-                } catch {
-                    completion(.failure(error))
+        Task { @MainActor in
+            await self.wordPressComRestApi
+                .perform(
+                    .get,
+                    URLString: path,
+                    jsonDecoder: .apiDecoder,
+                    type: RemotePublicizeInfo.self
+                )
+                .map { $0.body }
+                .flatMapError { original -> Result<RemotePublicizeInfo?, Error> in
+                    if case let .endpointError(endpointError) = original, endpointError.response?.statusCode == 200, endpointError.code == .responseSerializationFailed {
+                        return .success(nil)
+                    }
+                    return .failure(original.asNSError())
                 }
-
-            case .failure(let error):
-                completion(.failure(error))
-            }
+                .execute(completion: completion)
         }
     }
 }

--- a/WordPressKit/Result+Callback.swift
+++ b/WordPressKit/Result+Callback.swift
@@ -8,6 +8,10 @@ extension Swift.Result {
         }
     }
 
+    func execute(completion: (Self) -> Void) {
+        completion(self)
+    }
+
     func eraseToError() -> Result<Success, Error> {
         mapError { $0 }
     }

--- a/WordPressKit/Result+Callback.swift
+++ b/WordPressKit/Result+Callback.swift
@@ -8,7 +8,7 @@ extension Swift.Result {
         }
     }
 
-    func execute(completion: (Self) -> Void) {
+    func execute(_ completion: (Self) -> Void) {
         completion(self)
     }
 

--- a/WordPressKit/ShareAppContentServiceRemote.swift
+++ b/WordPressKit/ShareAppContentServiceRemote.swift
@@ -22,7 +22,7 @@ open class ShareAppContentServiceRemote: ServiceRemoteWordPressComREST {
                 )
                 .map { $0.body }
                 .mapError { error -> Error in error.asNSError() }
-                .execute(completion: completion)
+                .execute(completion)
         }
     }
 }

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -865,7 +865,7 @@ private extension CharacterSet {
     }()
 }
 
-private extension WordPressAPIError<WordPressComRestApiEndpointError> {
+extension WordPressAPIError<WordPressComRestApiEndpointError> {
     func asNSError() -> NSError {
         // When encoutering `URLError`, return `URLError` to avoid potentially breaking existing error handling code in the apps.
         if case let .connection(urlError) = self {


### PR DESCRIPTION
### Description

There are many places in the library that performs a redundant encoding and decoding JSON data. This PR refactor some of those cases so that we only parse JSON once.

> [!Note]
> I recommend reviewing this PR commit by commit. The changes in different files are very similar.

### Testing Details

All changes have existing test coverage.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
