### PR TITLE
Use a different GET function

### DIFF
--- a/WordPressKit/ProductServiceRemote.swift
+++ b/WordPressKit/ProductServiceRemote.swift
@@ -43,10 +43,8 @@ open class ProductServiceRemote {
 
         serviceRemote.wordPressComRestApi.GET(
             path,
-            parameters: [:]) { result, _ in
-
-            switch result {
-            case .success(let responseProducts):
+            parameters: [:],
+            success: { responseProducts, _ in
                 guard let productsDictionary = responseProducts as? [String: [String: Any]] else {
                     completion(.failure(GetProductError.failedCastingProductsToDictionary(responseProducts)))
                     return
@@ -74,9 +72,10 @@ open class ProductServiceRemote {
                 }
 
                 completion(.success(products))
-            case .failure(let error):
+            },
+            failure: { error, _ in
                 completion(.failure(error))
             }
-        }
+        )
     }
 }

--- a/WordPressKit/SharingServiceRemote.swift
+++ b/WordPressKit/SharingServiceRemote.swift
@@ -69,20 +69,21 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let path = path(forEndpoint: "sites/\(siteID)/external-services", withVersion: ._2_0)
         let params = ["type": "publicize" as AnyObject]
 
-        wordPressComRestApi.GET(path, parameters: params) { result, httpResponse in
-            switch result {
-            case .success(let response):
+        wordPressComRestApi.GET(
+            path,
+            parameters: params,
+            success: { response, httpResponse in
                 guard let responseDict = response as? NSDictionary else {
                     failure?(self.errorForUnexpectedResponse(httpResponse))
                     return
                 }
 
                 success?(self.remotePublicizeServicesFromDictionary(responseDict))
-
-            case .failure(let error):
+            },
+            failure: { error, _ in
                 failure?(error as NSError)
             }
-        }
+        )
     }
 
     /// Fetches the current user's list of keyring connections.


### PR DESCRIPTION
### Description

This PR simply uses the `GET` function that takes success and failure callbacks, to replace the one that takes a completion callback.

The reason of this change is the completion block one comes from [WordPressRestApi](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/trunk/WordPressKit/WordPressRestApi.swift#L19), which will be removed as part of my `WordPressOrgRestApi` rewrite.

### Testing Details

None needed. These changes look pretty safe to me. 😄 

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
