### PR TITLE
Use `URLComponents.url` instead of Alamofire's `asURL`

### DIFF
--- a/WordPressKit/Insights/StatsCommentsInsight.swift
+++ b/WordPressKit/Insights/StatsCommentsInsight.swift
@@ -83,7 +83,7 @@ private extension StatsTopCommentsAuthor {
 
         if var components = URLComponents(string: avatar) {
             components.query = "d=mm&s=60" // to get a properly-sized avatar.
-            url = try? components.asURL()
+            url = components.url
         } else {
             url = nil
         }

--- a/WordPressKit/Insights/StatsDotComFollowersInsight.swift
+++ b/WordPressKit/Insights/StatsDotComFollowersInsight.swift
@@ -79,7 +79,7 @@ extension StatsFollower {
 
         if var components = URLComponents(string: avatar) {
             components.query = "d=mm&s=60" // to get a properly-sized avatar.
-            url = try? components.asURL()
+            url = components.url
         } else {
             url = nil
         }

--- a/WordPressKit/Time Interval/StatsTopAuthorsTimeIntervalData.swift
+++ b/WordPressKit/Time Interval/StatsTopAuthorsTimeIntervalData.swift
@@ -91,7 +91,7 @@ extension StatsTopAuthor {
         let url: URL?
         if var components = URLComponents(string: avatar) {
             components.query = "d=mm&s=60"
-            url = try? components.asURL()
+            url = components.url
         } else {
             url = nil
         }


### PR DESCRIPTION
### Description

Simple changes to remove `asURL`, which is an Alamofire API.

### Testing Details

None needed.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
