### PR TITLE
Use a path, not URL, in fetch posts from endpoint request

### DIFF
--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -200,7 +200,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
                            success:(void (^)(NSArray<RemoteReaderPost *> *posts, NSString *algorithm))success
                            failure:(void (^)(NSError *))failure
 {
-    NSString *path = [endpoint absoluteString];
+    NSString *path = [endpoint path];
     [self.wordPressComRestApi GET:path
            parameters:params
               success:^(id responseObject, NSHTTPURLResponse *httpResponse) {


### PR DESCRIPTION
### Description

The recent work on the WordPress.com API requires GET, POST, etc methods to be called using a path, but this method passed a whole URL.

### Testing Details

The change didn't affect unit tests because there are no tests for this method 😢 

<img width="1239" alt="image" src="https://github.com/wordpress-mobile/WordPressKit-iOS/assets/1218433/20d70b7d-75e7-43cf-b06d-ab4dcf353bb9">


See how https://github.com/wordpress-mobile/WordPress-iOS/pull/22622 passes in CI:

![image](https://github.com/wordpress-mobile/WordPressKit-iOS/assets/1218433/0c446e33-386d-4a43-8aa8-ada093859c40)

I left a note about the Gutenberg Gallery block failure here: https://github.com/wordpress-mobile/WordPress-iOS/pull/22612#issuecomment-1951690269

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
