### PR TITLE
Add `apiURL` parameter for changing WP.com API URL

### DIFF
--- a/WordPressKit/WordPressOrgRestApi.swift
+++ b/WordPressKit/WordPressOrgRestApi.swift
@@ -40,7 +40,7 @@ public final class WordPressOrgRestApi: NSObject {
     }
 
     enum Site {
-        case dotCom(siteID: UInt64, bearerToken: String)
+        case dotCom(siteID: UInt64, bearerToken: String, apiURL: URL)
         case selfHosted(apiURL: URL, credential: SelfHostedSiteCredential)
     }
 
@@ -49,8 +49,8 @@ public final class WordPressOrgRestApi: NSObject {
 
     var selfHostedSiteNonce: String?
 
-    public convenience init(dotComSiteID: UInt64, bearerToken: String, userAgent: String? = nil) {
-        self.init(site: .dotCom(siteID: dotComSiteID, bearerToken: bearerToken), userAgent: userAgent)
+    public convenience init(dotComSiteID: UInt64, bearerToken: String, userAgent: String? = nil, apiURL: URL = WordPressComRestApi.apiBaseURL) {
+        self.init(site: .dotCom(siteID: dotComSiteID, bearerToken: bearerToken, apiURL: apiURL), userAgent: userAgent)
     }
 
     public convenience init(selfHostedSiteWPJSONURL apiURL: URL, credential: SelfHostedSiteCredential, userAgent: String? = nil) {
@@ -68,7 +68,7 @@ public final class WordPressOrgRestApi: NSObject {
         if let userAgent {
             additionalHeaders["User-Agent"] = userAgent
         }
-        if case let Site.dotCom(siteID: _, bearerToken: token) = site {
+        if case let Site.dotCom(siteID: _, bearerToken: token, _) = site {
             additionalHeaders["Authorization"] = "Bearer \(token)"
         }
 
@@ -203,8 +203,8 @@ public final class WordPressOrgRestApi: NSObject {
 private extension WordPressOrgRestApi {
     func apiBaseURL() -> URL {
         switch site {
-        case .dotCom:
-            return URL(string: "https://public-api.wordpress.com")!
+        case let .dotCom(_, _, apiURL):
+            return apiURL
         case let .selfHosted(apiURL, _):
             return apiURL
         }
@@ -252,7 +252,7 @@ private extension HTTPRequestBuilder {
         }
 
         switch site {
-        case let .dotCom(siteID, _):
+        case let .dotCom(siteID, _, _):
             // Currently only the following namespaces are supported. When adding more supported namespaces, remember to
             // update the "path adapter" code below for the REST API in WP.COM.
             assert(route.hasPrefix("/wp/v2") || route.hasPrefix("/wp-block-editor/v1"), "Unsupported .org REST API route: \(route)")

--- a/WordPressKit/WordPressOrgRestApi.swift
+++ b/WordPressKit/WordPressOrgRestApi.swift
@@ -68,7 +68,7 @@ public final class WordPressOrgRestApi: NSObject {
         if let userAgent {
             additionalHeaders["User-Agent"] = userAgent
         }
-        if case let Site.dotCom(siteID: _, bearerToken: token, _) = site {
+        if case let Site.dotCom(_, token, _) = site {
             additionalHeaders["Authorization"] = "Bearer \(token)"
         }
 

--- a/WordPressKitTests/WordPressOrgRestApiTests.swift
+++ b/WordPressKitTests/WordPressOrgRestApiTests.swift
@@ -114,4 +114,10 @@ extension WordPressOrgRestApi {
     }
 }
 
+extension WordPressOrgRestApi.Site {
+    static func dotCom(siteID: UInt64, bearerToken: String) -> Self {
+        .dotCom(siteID: siteID, bearerToken: bearerToken, apiURL: WordPressComRestApi.apiBaseURL)
+    }
+}
+
 private struct AnyResponse: Decodable {}

--- a/WordPressKitTests/WordPressOrgRestApiTests.swift
+++ b/WordPressKitTests/WordPressOrgRestApiTests.swift
@@ -103,6 +103,18 @@ class WordPressOrgRestApiTests: XCTestCase {
         let api = WordPressOrgRestApi(site: .dotCom(siteID: 1001, bearerToken: "fakeToken"))
         let _ = try await api.get(path: "/wp-block-editor/v1/settings", type: AnyResponse.self).get()
     }
+
+    func testSettingWPComAPIURL() async {
+        var request: URLRequest?
+        stub(condition: { _ in true }, response: {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.networkConnectionLost))
+        })
+
+        let api = WordPressOrgRestApi(dotComSiteID: 1001, bearerToken: "token", apiURL: URL(string: "http://localhost:8000")!)
+        let _ = await api.get(path: "/wp/v2/hello", type: AnyResponse.self)
+        XCTAssertEqual(request?.url?.absoluteString, "http://localhost:8000/wp/v2/sites/1001/hello")
+    }
 }
 
 extension WordPressOrgRestApi {


### PR DESCRIPTION
### Description

This PR brings back support of mocking WP.com .org REST API. See https://github.com/wordpress-mobile/WordPress-iOS/pull/22612#pullrequestreview-1891508629 for context in the WordPress app.

### Testing Details

I have added one unit test. Let me know if you think there are more can be added.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
