### PR TITLE
Do not add default query if it exists in the original URL

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -153,8 +153,9 @@ final class HTTPRequestBuilder {
         // Add default query items if they don't exist in `appendedQuery`.
         var newQuery = appendedQuery
         if !defaultQuery.isEmpty {
+            let allQuery = (original.queryItems ?? []) + newQuery
             let toBeAdded = defaultQuery.filter { item in
-                !newQuery.contains(where: { $0.name == item.name})
+                !allQuery.contains(where: { $0.name == item.name})
             }
             newQuery.append(contentsOf: toBeAdded)
         }

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -205,6 +205,15 @@ class HTTPRequestBuilderTests: XCTestCase {
         try XCTAssertEqual(builder.query(name: "foo", value: "bar").build().url?.query, "locale=zh&foo=bar")
     }
 
+    func testDefaultQueryExistsInOriginalURL() throws {
+        let url = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org/hello?locale=foo")!)
+            .query(defaults: [URLQueryItem(name: "locale", value: "en")])
+            .build()
+            .url
+
+        XCTAssertEqual(url?.query, "locale=foo")
+    }
+
     func testJSONBody() throws {
         var request = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org")!)
             .method(.post)

--- a/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
+++ b/WordPressKitTests/Utilities/HTTPRequestBuilderTests.swift
@@ -205,7 +205,7 @@ class HTTPRequestBuilderTests: XCTestCase {
         try XCTAssertEqual(builder.query(name: "foo", value: "bar").build().url?.query, "locale=zh&foo=bar")
     }
 
-    func testDefaultQueryExistsInOriginalURL() throws {
+    func testDefaultQueryDoesNotOverriedQueryItemInOriginalURL() throws {
         let url = try HTTPRequestBuilder(url: URL(string: "https://wordpress.org/hello?locale=foo")!)
             .query(defaults: [URLQueryItem(name: "locale", value: "en")])
             .build()

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -18,10 +18,10 @@ extension WordPressComRestApiTests {
         let _ = await api.perform(.get, URLString: "/path/path")
 
         let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        try XCTAssertTrue(XCTUnwrap(request?.url?.query).contains("locale=\(preferredLanguageIdentifier)"))
+        XCTAssertEqual(request?.url?.query, "locale=\(preferredLanguageIdentifier)")
     }
 
-    func testThatAppendingLocaleWorksWithExistingParams() async {
+    func testThatAppendingLocaleWorksWithExistingParams() async throws {
         var request: URLRequest?
         stub(condition: { _ in true }, response: {
             request = $0
@@ -37,8 +37,8 @@ extension WordPressComRestApiTests {
         let _ = await api.perform(.get, URLString: path, parameters: params)
 
         let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        try XCTAssertTrue(XCTUnwrap(request?.url?.query).contains("locale=\(preferredLanguageIdentifier)"))
-        try XCTAssertTrue(XCTUnwrap(request?.url?.query).contains("someKey=value"))
+        let query = try XCTUnwrap(request?.url?.query?.split(separator: "&"))
+        XCTAssertEqual(Set(query), Set(["locale=\(preferredLanguageIdentifier)", "someKey=value"]))
     }
 
     func testThatLocaleIsNotAppendedIfAlreadyIncludedInPath() async {
@@ -91,7 +91,8 @@ extension WordPressComRestApiTests {
 
         let api = WordPressComRestApi(localeKey: "foo")
 
+        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
         let _ = await api.perform(.get, URLString: "/path/path")
-        try XCTAssertTrue(XCTUnwrap(request?.url?.query).contains("foo="))
+        XCTAssertEqual(request?.url?.query, "foo=\(preferredLanguageIdentifier)")
     }
 }

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -7,7 +7,7 @@ import WordPressShared
 
 extension WordPressComRestApiTests {
 
-    func testThatAppendingLocaleWorks() async throws {
+    func testAddsLocaleToURLQueryByDefault() async throws {
         var request: URLRequest?
         stub(condition: { _ in true }, response: {
             request = $0
@@ -21,7 +21,7 @@ extension WordPressComRestApiTests {
         XCTAssertEqual(request?.url?.query, "locale=\(preferredLanguageIdentifier)")
     }
 
-    func testThatAppendingLocaleWorksWithExistingParams() async throws {
+    func testAddsLocaleToURLQueryByDefaultAndMaintainsInputParameters() async throws {
         var request: URLRequest?
         stub(condition: { _ in true }, response: {
             request = $0

--- a/WordPressKitTests/WordPressComRestApiTests+Locale.swift
+++ b/WordPressKitTests/WordPressComRestApiTests+Locale.swift
@@ -1,272 +1,97 @@
 import Foundation
 import XCTest
+import OHHTTPStubs
 
 import WordPressShared
 @testable import WordPressKit
 
 extension WordPressComRestApiTests {
 
-    func testThatAppendingLocaleWorks() {
-        // Given
-        let path = "/path/path"
-        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
+    func testThatAppendingLocaleWorks() async throws {
+        var request: URLRequest?
+        stub(condition: { _ in true }, response: {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.networkConnectionLost))
+        })
 
-        // When
         let api = WordPressComRestApi()
-        let localeAppendedPath = api.buildRequestURLFor(path: path)
+        let _ = await api.perform(.get, URLString: "/path/path")
 
-        // Then
-        XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
-        XCTAssertNotNil(actualURL)
-
-        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
-        XCTAssertNotNil(actualURLComponents)
-
-        let expectedPath = path
-        let actualPath = actualURLComponents!.path
-        XCTAssertEqual(expectedPath, actualPath)
-
-        let actualQueryItems = actualURLComponents!.queryItems
-        XCTAssertNotNil(actualQueryItems)
-
-        let expectedQueryItemCount = 1
-        let actualQueryItemCount = actualQueryItems!.count
-        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
-
-        let actualQueryItem = actualQueryItems!.first
-        XCTAssertNotNil(actualQueryItem!)
-
-        let actualQueryItemKey = actualQueryItem!.name
-        let expectedQueryItemKey = WordPressComRestApi.LocaleKeyDefault
-        XCTAssertEqual(expectedQueryItemKey, actualQueryItemKey)
-
-        let actualQueryItemValue = actualQueryItem!.value
-        XCTAssertNotNil(actualQueryItemValue)
-
-        let expectedQueryItemValue = preferredLanguageIdentifier
-        XCTAssertEqual(expectedQueryItemValue, actualQueryItemValue!)
+        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
+        try XCTAssertTrue(XCTUnwrap(request?.url?.query).contains("locale=\(preferredLanguageIdentifier)"))
     }
 
-    func testThatAppendingLocaleWorksWithExistingParams() {
-        // Given
+    func testThatAppendingLocaleWorksWithExistingParams() async {
+        var request: URLRequest?
+        stub(condition: { _ in true }, response: {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.networkConnectionLost))
+        })
+
         let path = "/path/path"
         let params: [String: AnyObject] = [
             "someKey": "value" as AnyObject
         ]
 
-        // When
         let api = WordPressComRestApi()
-        let localeAppendedPath = api.buildRequestURLFor(path: path, parameters: params)
+        let _ = await api.perform(.get, URLString: path, parameters: params)
 
-        // Then
-        XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
-        XCTAssertNotNil(actualURL)
-
-        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
-        XCTAssertNotNil(actualURLComponents)
-
-        let expectedPath = "/path/path"
-        let actualPath = actualURLComponents!.path
-        XCTAssertEqual(expectedPath, actualPath)
-
-        let actualQueryItems = actualURLComponents!.queryItems
-        XCTAssertNotNil(actualQueryItems)
-
-        let expectedQueryItemCount = 1
-        let actualQueryItemCount = actualQueryItems!.count
-        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
-
-        let actualQueryString = actualURLComponents?.query
-        XCTAssertNotNil(actualQueryString)
-
-        let queryStringIncludesLocale = actualQueryString!.contains(WordPressComRestApi.LocaleKeyDefault)
-        XCTAssertTrue(queryStringIncludesLocale)
-    }
-
-    func testThatLocaleIsNotAppendedIfAlreadyIncludedInPath() {
-        // Given
-        let preferredLanguageIdentifier = "foo"
-        let path = "/path/path?locale=\(preferredLanguageIdentifier)"
-
-        // When
-        let api = WordPressComRestApi()
-        let localeAppendedPath = api.buildRequestURLFor(path: path)
-
-        // Then
-        XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
-        XCTAssertNotNil(actualURL)
-
-        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
-        XCTAssertNotNil(actualURLComponents)
-
-        let expectedPath = "/path/path"
-        let actualPath = actualURLComponents!.path
-        XCTAssertEqual(expectedPath, actualPath)
-
-        let actualQueryItems = actualURLComponents!.queryItems
-        XCTAssertNotNil(actualQueryItems)
-
-        let expectedQueryItemCount = 1
-        let actualQueryItemCount = actualQueryItems!.count
-        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
-
-        let actualQueryItem = actualQueryItems!.first
-        XCTAssertNotNil(actualQueryItem!)
-
-        let actualQueryItemKey = actualQueryItem!.name
-        let expectedQueryItemKey = WordPressComRestApi.LocaleKeyDefault
-        XCTAssertEqual(expectedQueryItemKey, actualQueryItemKey)
-
-        let actualQueryItemValue = actualQueryItem!.value
-        XCTAssertNotNil(actualQueryItemValue)
-
-        let expectedQueryItemValue = preferredLanguageIdentifier
-        XCTAssertEqual(expectedQueryItemValue, actualQueryItemValue!)
-    }
-
-    func testThatAppendingLocaleIgnoresIfAlreadyIncludedInRequestParameters() {
-        // Given
-        let inputPath = "/path/path"
-        let expectedLocaleValue = "foo"
-        let params: [String: AnyObject] = [
-            WordPressComRestApi.LocaleKeyDefault: expectedLocaleValue as AnyObject
-        ]
-
-        // When
-        let requestURLString = WordPressComRestApi().buildRequestURLFor(path: inputPath, parameters: params)
-
-        // Then
         let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-        XCTAssertFalse(requestURLString!.contains(preferredLanguageIdentifier))
+        try XCTAssertTrue(XCTUnwrap(request?.url?.query).contains("locale=\(preferredLanguageIdentifier)"))
+        try XCTAssertTrue(XCTUnwrap(request?.url?.query).contains("someKey=value"))
     }
 
-    func testThatLocaleIsNotAppendedWhenDisabled() {
-        // Given
-        let path = "/path/path"
+    func testThatLocaleIsNotAppendedIfAlreadyIncludedInPath() async {
+        var request: URLRequest?
+        stub(condition: { _ in true }, response: {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.networkConnectionLost))
+        })
 
-        // When
+        let api = WordPressComRestApi()
+        let _ = await api.perform(.get, URLString: "/path?locale=foo")
+
+        try XCTAssertEqual(XCTUnwrap(request?.url?.query), "locale=foo")
+    }
+
+    func testThatAppendingLocaleIgnoresIfAlreadyIncludedInRequestParameters() async throws {
+        var request: URLRequest?
+        stub(condition: { _ in true }, response: {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.networkConnectionLost))
+        })
+
+        let api = WordPressComRestApi()
+        let _ = await api.perform(.get, URLString: "/path", parameters: ["locale": "foo"] as [String: AnyObject])
+
+        try XCTAssertEqual(XCTUnwrap(request?.url?.query), "locale=foo")
+    }
+
+    func testThatLocaleIsNotAppendedWhenDisabled() async {
+        var request: URLRequest?
+        stub(condition: { _ in true }, response: {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.networkConnectionLost))
+        })
+
         let api = WordPressComRestApi()
         api.appendsPreferredLanguageLocale = false
-        let localeAppendedPath = api.buildRequestURLFor(path: path)
+        let _ = await api.perform(.get, URLString: "/path")
 
-        // Then
-        XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
-        XCTAssertNotNil(actualURL)
-
-        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
-        XCTAssertNotNil(actualURLComponents)
-
-        let expectedPath = path
-        let actualPath = actualURLComponents!.path
-        XCTAssertEqual(expectedPath, actualPath)
-
-        let actualQueryItems = actualURLComponents!.queryItems
-        XCTAssertNil(actualQueryItems)
+        XCTAssertNotNil(request?.url)
+        XCTAssertNil(request?.url?.query)
     }
 
-    func testThatAlternateLocaleKeyIsHonoredWhenSpecified() {
-        // Given
-        let path = "/path/path"
-        let expectedKey = "foo"
+    func testThatAlternateLocaleKeyIsHonoredWhenSpecified() async {
+        var request: URLRequest?
+        stub(condition: { _ in true }, response: {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.networkConnectionLost))
+        })
 
-        // When
-        let api = WordPressComRestApi(localeKey: expectedKey)
-        let localeAppendedPath = api.buildRequestURLFor(path: path)
+        let api = WordPressComRestApi(localeKey: "foo")
 
-        // Then
-        XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
-        XCTAssertNotNil(actualURL)
-
-        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
-        XCTAssertNotNil(actualURLComponents)
-
-        let expectedPath = path
-        let actualPath = actualURLComponents!.path
-        XCTAssertEqual(expectedPath, actualPath)
-
-        let actualQueryItems = actualURLComponents!.queryItems
-        XCTAssertNotNil(actualQueryItems)
-
-        let expectedQueryItemCount = 1
-        let actualQueryItemCount = actualQueryItems!.count
-        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
-
-        let actualQueryItem = actualQueryItems!.first
-        XCTAssertNotNil(actualQueryItem!)
-
-        let actualQueryItemKey = actualQueryItem!.name
-        XCTAssertEqual(expectedKey, actualQueryItemKey)
-    }
-
-    func testThatAppendingLocaleWorksWhenPassingNilParameters() {
-        // Given
-        let path = "/path/path"
-        let preferredLanguageIdentifier = WordPressComLanguageDatabase().deviceLanguage.slug
-
-        // When
-        let api = WordPressComRestApi()
-        let localeAppendedPath = WordPressComRestApi().buildRequestURLFor(path: path, parameters: nil)
-
-        // Then
-        XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
-        XCTAssertNotNil(actualURL)
-
-        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
-        XCTAssertNotNil(actualURLComponents)
-
-        let expectedPath = path
-        let actualPath = actualURLComponents!.path
-        XCTAssertEqual(expectedPath, actualPath)
-
-        let actualQueryItems = actualURLComponents!.queryItems
-        XCTAssertNotNil(actualQueryItems)
-
-        let expectedQueryItemCount = 1
-        let actualQueryItemCount = actualQueryItems!.count
-        XCTAssertEqual(expectedQueryItemCount, actualQueryItemCount)
-
-        let actualQueryItem = actualQueryItems!.first
-        XCTAssertNotNil(actualQueryItem!)
-
-        let actualQueryItemKey = actualQueryItem!.name
-        let expectedQueryItemKey = WordPressComRestApi.LocaleKeyDefault
-        XCTAssertEqual(expectedQueryItemKey, actualQueryItemKey)
-
-        let actualQueryItemValue = actualQueryItem!.value
-        XCTAssertNotNil(actualQueryItemValue)
-
-        let expectedQueryItemValue = preferredLanguageIdentifier
-        XCTAssertEqual(expectedQueryItemValue, actualQueryItemValue!)
-    }
-
-    func testThatLocaleIsNotAppendedWhenDisabledAndParametersAreNil() {
-        // Given
-        let path = "/path/path"
-
-        // When
-        let api = WordPressComRestApi()
-        api.appendsPreferredLanguageLocale = false
-        let localeAppendedPath = api.buildRequestURLFor(path: path, parameters: nil)
-
-        // Then
-        XCTAssertNotNil(localeAppendedPath)
-        let actualURL = URL(string: localeAppendedPath!, relativeTo: api.baseURL)
-        XCTAssertNotNil(actualURL)
-
-        let actualURLComponents = URLComponents(url: actualURL!, resolvingAgainstBaseURL: false)
-        XCTAssertNotNil(actualURLComponents)
-
-        let expectedPath = path
-        let actualPath = actualURLComponents!.path
-        XCTAssertEqual(expectedPath, actualPath)
-
-        let actualQueryItems = actualURLComponents!.queryItems
-        XCTAssertNil(actualQueryItems)
+        let _ = await api.perform(.get, URLString: "/path/path")
+        try XCTAssertTrue(XCTUnwrap(request?.url?.query).contains("foo="))
     }
 }


### PR DESCRIPTION
### Description

While updating unit tests, I have caught an bug in the exiting implementation of appending default 'locale' query to all WP.com REST API call. The expected behaviour is in [`testThatLocaleIsNotAppendedIfAlreadyIncludedInPath`](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/2e67d20e276223f2511642ef8e2ea9655fe9878a/WordPressKitTests/WordPressComRestApiTests%2BLocale.swift#L44-L55).

#### Details

`WordPressComRestApi` adds a `locale=en` (or whatever the device locale is) query to all HTTP requests, unless the 'local' is passed as parameter. For example:
1. `WordPressComRestApi.get("/post/1")` should send an HTTP request with the default 'locale=en' in the URL: `https://.../post/1?locale=en`.
1. `WordPressComRestApi.get("/post/1", parameters: ["locale": "zh"])` should send an HTTP request with `locale=zh`, instead of the default query "locale=en".

However, there is a case missed in the current implementation, `WordPressComRestApi.get("/post/1?locale=zh")` should behave like the second example above and send an HTTP request with `locale=zh`.

### Testing Details

The bug fix is covered in the existing `testThatLocaleIsNotAppendedIfAlreadyIncludedInPath` and I have added a new dedicate unit test for it.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
