### PR TITLE
Tooling: Define SwiftLint version and run on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#3.0.1
+    - automattic/a8c-ci-toolkit#3.1.0
   # Common environment values to use with the `env` key.
   env: &common_env
     IMAGE_ID: xcode-15.0.1
@@ -33,8 +33,17 @@ steps:
     plugins: *common_plugins
 
   #################
-  # Lint
+  # Linters
   #################
+  - label: ":swift: SwiftLint"
+    command: run_swiftlint --strict
+    plugins: *common_plugins
+    notify:
+      - github_commit_status:
+          context: "SwiftLint"
+    agents:
+      queue: "default"
+
   - label: "🧹 Lint"
     key: "lint"
     command: |

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,11 +2,15 @@
 AllCops:
   NewCops: enable
 
+# Override the maximum line length
+Layout/LineLength:
+  Max: 160
+
 # Allow the Podspec filename to match the project
 Naming/FileName:
   Exclude:
     - 'WordPressKit.podspec'
 
-# Override the maximum line length
-Layout/LineLength:
-  Max: 160
+Metrics/BlockLength:
+  Exclude:
+    - 'fastlane/Fastfile'

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,3 +1,5 @@
+swiftlint_version: 0.54.0
+
 parent_config: https://raw.githubusercontent.com/Automattic/swiftlint-config/0f8ab6388bd8d15a04391825ab125f80cfb90704/.swiftlint.yml
 remote_timeout: 10.0
 

--- a/Podfile
+++ b/Podfile
@@ -9,6 +9,12 @@ APP_IOS_DEPLOYMENT_TARGET = Gem::Version.new('13.0')
 
 platform :ios, APP_IOS_DEPLOYMENT_TARGET
 
+def swiftlint_version
+  require 'yaml'
+
+  YAML.load_file('.swiftlint.yml')['swiftlint_version']
+end
+
 def wordpresskit_pods
   pod 'Alamofire', '~> 4.8.0'
   pod 'WordPressShared', '~> 2.0.0-beta.2'
@@ -35,7 +41,7 @@ target 'WordPressKitTests' do
 end
 
 abstract_target 'Tools' do
-  pod 'SwiftLint', '~> 0.54'
+  pod 'SwiftLint', swiftlint_version
 end
 
 # Let Pods targets inherit deployment target from the app

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,7 +28,7 @@ DEPENDENCIES:
   - OCMock (~> 3.4)
   - OHHTTPStubs (~> 9.0)
   - OHHTTPStubs/Swift (~> 9.0)
-  - SwiftLint (~> 0.54)
+  - SwiftLint (= 0.54.0)
   - UIDeviceIdentifier (~> 2.0)
   - WordPressShared (~> 2.0.0-beta.2)
   - wpxmlrpc (~> 0.10.0)
@@ -54,6 +54,6 @@ SPEC CHECKSUMS:
   WordPressShared: f93f99269258b46dad04f4e4dbf540ce2e5c1e66
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
 
-PODFILE CHECKSUM: 9ca3a8756de542f45541c503cc23e3166b215206
+PODFILE CHECKSUM: a06b4d2f7183f40a91a0f219ca399141aee28c5f
 
 COCOAPODS: 1.14.3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,9 +2,9 @@
 
 default_platform(:ios)
 
-platform :ios do
-  SWIFTLINT_PATH = './Pods/SwiftLint/swiftlint'
+SWIFTLINT_PATH = './Pods/SwiftLint/swiftlint'
 
+platform :ios do
   lane :lint do
     swiftlint(
       executable: SWIFTLINT_PATH,


### PR DESCRIPTION
### Description

Building on top of https://github.com/wordpress-mobile/WordPressKit-iOS/pull/693, this PR uses the newly added `run-swiftlint` command added to https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin.

The main changes:
- Setting the SwiftLint version in the `.swiftlint.yml` file.
- Usage of the `run_swiftlint` command from `a8c-ci-toolkit-buildkite-plugin` in a Buildkite step to run SwiftLint on CI.
- Uses the`swiftlint_version` field from `.swiftlint.yml` to use the right SwiftLint version in the `Podfile`.


### Testing Details

Make sure CI is 🟢

---

- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
