### PR TITLE
Fix crash in background url session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fix crash when uploading files using background URLSession. [#739]
 
 ### Internal Changes
 

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -261,7 +261,7 @@ class BackgroundURLSessionDelegate: NSObject, URLSessionDataDelegate {
     private var taskData = [Int: SessionTaskData]()
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        session.recieved(data, forTaskWithIdentifier: dataTask.taskIdentifier)
+        session.received(data, forTaskWithIdentifier: dataTask.taskIdentifier)
     }
 
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
@@ -300,7 +300,7 @@ private extension URLSession {
         }
     }
 
-    func recieved(_ data: Data, forTaskWithIdentifier taskID: Int) {
+    func received(_ data: Data, forTaskWithIdentifier taskID: Int) {
         updateData(forTaskWithIdentifier: taskID) { task in
             task.responseBody.append(data)
         }

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -24,9 +24,9 @@ extension URLSession {
 
     /// Create a background URLSession instance that can be used in the `perform(request:...)` async function.
     ///
-    /// The `perform(request:...)` async function can be used in all non-background URLSession instances without any
-    /// extra work. However, there is a requirement to make the function works with with background URLSession instances.
-    /// That is the URLSession must have a delegate of `BackgroundURLSessionDelegate` type.
+    /// The `perform(request:...)` async function can be used in all non-background `URLSession` instances without any
+    /// extra work. However, there is a requirement to make the function works with with background `URLSession` instances.
+    /// That is the `URLSession` must have a delegate of `BackgroundURLSessionDelegate` type.
     static func backgroundSession(configuration: URLSessionConfiguration) -> URLSession {
         assert(configuration.identifier != nil)
         // Pass `delegateQueue: nil` to get a serial queue, which is required to ensure thread safe access to
@@ -62,7 +62,7 @@ extension URLSession {
         errorType: E.Type = E.self
     ) async -> WordPressAPIResult<HTTPAPIResponse<Data>, E> {
         if configuration.identifier != nil {
-            assert(delegate is BackgroundURLSessionDelegate, "Unexpected URLSession delegate type. See the `backgroundSession(configuration:)`")
+            assert(delegate is BackgroundURLSessionDelegate, "Unexpected `URLSession` delegate type. See the `backgroundSession(configuration:)`")
         }
 
         if let parentProgress {
@@ -113,8 +113,8 @@ extension URLSession {
     ) throws -> URLSessionTask {
         var request = try builder.build(encodeBody: false)
 
-        // This additional `callCompletionFromDelegate` is added so that we can test `BackgroundURLSessionDelegate`
-        // in unit tests. Background URLSession doesn't work on unit tests, we have to create a non-background URLSession
+        // This additional `callCompletionFromDelegate` is added to unit test `BackgroundURLSessionDelegate`.
+        // Background `URLSession` doesn't work on unit tests, we have to create a non-background `URLSession`
         // which has a `BackgroundURLSessionDelegate` delegate in order to test `BackgroundURLSessionDelegate`.
         //
         // In reality, `callCompletionFromDelegate` and `isBackgroundSession` have the same value.
@@ -151,7 +151,7 @@ extension URLSession {
         }
 
         if callCompletionFromDelegate {
-            assert(delegate is BackgroundURLSessionDelegate, "Unexpected URLSession delegate type. See the `backgroundSession(configuration:)`")
+            assert(delegate is BackgroundURLSessionDelegate, "Unexpected `URLSession` delegate type. See the `backgroundSession(configuration:)`")
 
             set(completion: completion, forTaskWithIdentifier: task.taskIdentifier)
         }

--- a/WordPressKit/HTTPClient.swift
+++ b/WordPressKit/HTTPClient.swift
@@ -321,3 +321,9 @@ private extension URLSession {
     }
 
 }
+
+extension URLSession {
+    var debugNumberOfTaskData: Int {
+        self.taskData.count
+    }
+}

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -335,7 +335,11 @@ open class WordPressComRestApi: NSObject {
     private lazy var uploadURLSession: URLSession = {
         let configuration = sessionConfiguration(background: backgroundUploads)
         configuration.sharedContainerIdentifier = self.sharedContainerIdentifier
-        return URLSession(configuration: configuration)
+        if configuration.identifier != nil {
+            return URLSession.backgroundSession(configuration: configuration)
+        } else {
+            return URLSession(configuration: configuration)
+        }
     }()
 
     private func sessionConfiguration(background: Bool) -> URLSessionConfiguration {

--- a/WordPressKit/WordPressOrgXMLRPCApi.swift
+++ b/WordPressKit/WordPressOrgXMLRPCApi.swift
@@ -41,7 +41,13 @@ open class WordPressOrgXMLRPCApi: NSObject {
             additionalHeaders["User-Agent"] = userAgent as AnyObject?
         }
         sessionConfiguration.httpAdditionalHeaders = additionalHeaders
-        return URLSession(configuration: sessionConfiguration, delegate: sessionDelegate, delegateQueue: nil)
+        // When using a background URLSession, we don't need to apply the authentication challenge related
+        // implementations in `SessionDelegate`.
+        if sessionConfiguration.identifier != nil {
+            return URLSession.backgroundSession(configuration: sessionConfiguration)
+        } else {
+            return URLSession(configuration: sessionConfiguration, delegate: sessionDelegate, delegateQueue: nil)
+        }
     }
 
     // swiftlint:disable weak_delegate

--- a/WordPressKitTests/Utilities/URLSessionHelperTests.swift
+++ b/WordPressKitTests/Utilities/URLSessionHelperTests.swift
@@ -16,6 +16,7 @@ class URLSessionHelperTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         HTTPStubs.removeAllStubs()
+        XCTAssertEqual(session.debugNumberOfTaskData, 0)
     }
 
     func testConnectionError() async throws {


### PR DESCRIPTION
### Description

I thought I tested background uploads from Jetpack share extension with [the "user URLSession" feature flag][PR] on. I turns out I didn't, because the feature flag only takes effect within the app, and doesn't change make the share extension to use URLSession instead of Alamofire.

#### Issue

The issue is pretty obvious once the feature flag is removed in https://github.com/wordpress-mobile/WordPress-iOS/pull/22707: the share extension would crash because `URLSession.uploadTask(with:fromFile:completion:)` crashes on background URLSession instances.

#### Fix

In the `perform(request:...)` async function, we rely on `URLSession` APIs which accept a completion handler to call the continuation API. As I mentioned above, those APIs are not available to background URLSession instances. That means we'll have to use a customized `URLSessionDelegate` to receive HTTP response and call the completion block created in `perform(request:...)`. Those are done in the new `BackgroundURLSessionDelegate` type.

Please note, this new delegate is only used in background URLSession instances. That means in theory this PR has no effect on the JP/WP iOS app process which uses non-background URLSession instances.

[PR]: https://github.com/wordpress-mobile/WordPress-iOS/pull/22540

### Testing Details

As I mentioned in the code comment, background URLSession doesn't work in current unit test set up, but I have added some simple code to ensure we can still test `BackgroundURLSessionDelegate` from unit tests.

~I'll open a PR on the WordPress-iOS repo, so that we can test its share extension, which uses this PR's changes.~
See the "Test Instructions" in https://github.com/wordpress-mobile/WordPress-iOS/pull/22755.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.