### PR TITLE
Remove temp file once HTTP request completes

### DIFF
--- a/WordPressKit/HTTPRequestBuilder.swift
+++ b/WordPressKit/HTTPRequestBuilder.swift
@@ -215,7 +215,7 @@ final class HTTPRequestBuilder {
         request.setValue("text/xml", forHTTPHeaderField: "Content-Type")
         let encoder = WPXMLRPCEncoder(method: xmlrpcRequest.method, andParameters: xmlrpcRequest.parameters)
         if forceWriteToFile {
-            let fileName = "\(ProcessInfo.processInfo.globallyUniqueString)_file.xmlrpc"
+            let fileName = "\(UUID().uuidString).xmlrpc"
             let fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(fileName)
             try encoder.encode(toFile: fileURL.path)
 


### PR DESCRIPTION
> [!Note]
> This PR is built on top of https://github.com/wordpress-mobile/WordPressKit-iOS/pull/739.

### Description

In some HTTP requests (i.e. uploading a large image from a background URL session), HTTP request body is written into a temp file first. Once the request completes (success of failure), the temp file should be deleted to avoid taking up device disk space.

### Testing Details

See the added unit tests.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
