### PR TITLE
Merge release 14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,7 @@ _None._
 
 ### Breaking Changes
 
-- Rewrite `WordPressOrgRestApi` to support self hosted sites and WordPress.com sites. [#724]
-- Decouple `PluginDirectoryServiceRemote` from Alamofire. [#725]
-- Remove `Endpoint`. [#725]
+_None._
 
 ### New Features
 
@@ -44,11 +42,23 @@ _None._
 
 ### Bug Fixes
 
-- Fix crash when uploading files using background URLSession. [#739]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 14.0.0
+
+### Breaking Changes
+
+- Rewrite `WordPressOrgRestApi` to support self hosted sites and WordPress.com sites. [#724]
+- Decouple `PluginDirectoryServiceRemote` from Alamofire. [#725]
+- Remove `Endpoint`. [#725]
+
+### Bug Fixes
+
+- Fix crash when uploading files using background `URLSession`. [#739]
 
 ## 13.1.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '13.1.0'
+  s.version       = '14.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 24.4 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.