### PR TITLE
Fix get data requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+Fix data requests. [#745]
 
 ### Internal Changes
 

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -198,7 +198,7 @@ open class WordPressComRestApi: NSObject {
         let progress = Progress.discreteProgress(totalUnitCount: 100)
 
         Task { @MainActor in
-            let result = await self.perform(.get, URLString: URLString, parameters: parameters, fulfilling: progress)
+            let result: APIResult<AnyObject> = await self.perform(.get, URLString: URLString, parameters: parameters, fulfilling: progress)
 
             switch result {
             case let .success(response):
@@ -244,7 +244,7 @@ open class WordPressComRestApi: NSObject {
         let progress = Progress.discreteProgress(totalUnitCount: 100)
 
         Task { @MainActor in
-            let result = await self.perform(.post, URLString: URLString, parameters: parameters, fulfilling: progress)
+            let result: APIResult<AnyObject> = await self.perform(.post, URLString: URLString, parameters: parameters, fulfilling: progress)
 
             switch result {
             case let .success(response):
@@ -380,6 +380,17 @@ open class WordPressComRestApi: NSObject {
         await perform(method, URLString: URLString, parameters: parameters, fulfilling: progress) {
             let decoder = jsonDecoder ?? JSONDecoder()
             return try decoder.decode(type, from: $0)
+        }
+    }
+
+    func perform(
+        _ method: HTTPRequestBuilder.Method,
+        URLString: String,
+        parameters: [String: AnyObject]? = nil,
+        fulfilling progress: Progress? = nil
+    ) async -> APIResult<Data> {
+        await perform(method, URLString: URLString, parameters: parameters, fulfilling: progress) {
+            return $0
         }
     }
 


### PR DESCRIPTION
### Description

The code was attempting to use a `JSONDecoder` to decode responses when the caller was asking for plain `Data`. The fix is to make a separate function for getting `Data` responses without any JSON decoding.


Related discussion: p1709846681819879/1709766129.730749-slack-C04PWEZSYFL

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

Test a clean install using https://github.com/wordpress-mobile/WordPress-iOS/pull/22792 and verify that a feature announcement is shown (called "Stats Refresh"). You must log in using your A8c account.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.