### PR TITLE
Fix `WordPressComRestApi.GETData`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fix parsing issues in getting Zendesk metadata and feature announcements. [#746]
 
 ### Internal Changes
 

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -187,6 +187,7 @@
 		4AE278442B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE278432B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift */; };
 		4AE278482B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE278472B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift */; };
 		4AE2784A2B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE278492B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift */; };
+		4AE7E36B2B9A995500C8CED5 /* AnnouncementServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE7E36A2B9A995500C8CED5 /* AnnouncementServiceRemoteTests.swift */; };
 		57BCD3D426209D9500292CB3 /* AppTransportSecuritySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */; };
 		730E869F21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */; };
 		731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */; };
@@ -908,6 +909,7 @@
 		4AE278432B2FAF6200E4D9B1 /* HTTPProtocolHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPProtocolHelpers.swift; sourceTree = "<group>"; };
 		4AE278472B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyEncodingTests.swift; sourceTree = "<group>"; };
 		4AE278492B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPHeaderValueParserTests.swift; sourceTree = "<group>"; };
+		4AE7E36A2B9A995500C8CED5 /* AnnouncementServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementServiceRemoteTests.swift; sourceTree = "<group>"; };
 		57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTransportSecuritySettings.swift; sourceTree = "<group>"; };
 		6C2A33D76FD1052D6F30466D /* Pods-WordPressKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.debug.xcconfig"; sourceTree = "<group>"; };
 		6F2E0CC4FA01B5475A378DA2 /* Pods-WordPressKitTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -1627,6 +1629,14 @@
 			name = BlockEditorSettings;
 			sourceTree = "<group>";
 		};
+		4AE7E3692B9A994200C8CED5 /* Announcement */ = {
+			isa = PBXGroup;
+			children = (
+				4AE7E36A2B9A995500C8CED5 /* AnnouncementServiceRemoteTests.swift */,
+			);
+			name = Announcement;
+			sourceTree = "<group>";
+		};
 		57A38E502624F7D000472480 /* WordPressAPI */ = {
 			isa = PBXGroup;
 			children = (
@@ -1832,6 +1842,7 @@
 			children = (
 				93BD273E1EE732CC002BB00B /* Accounts */,
 				826016FE1F9FD59400533B6C /* Activity */,
+				4AE7E3692B9A994200C8CED5 /* Announcement */,
 				F194E1212417ED7E00874408 /* Authentication */,
 				FAD1345425909DF500A8FEB1 /* Backup */,
 				FA1D0F8F299535020025D76C /* Blaze */,
@@ -3675,6 +3686,7 @@
 				46ABD0E0262EED3D00C7FF24 /* WordPressOrgXMLRPCValidatorTests.swift in Sources */,
 				D813437621F6D70D0060D99A /* SiteSegmentsResponseDecodingTests.swift in Sources */,
 				436D56382118DC4B00CEAA33 /* TransactionsServiceRemoteTests.swift in Sources */,
+				4AE7E36B2B9A995500C8CED5 /* AnnouncementServiceRemoteTests.swift in Sources */,
 				9F3E0BA82087355E009CB5BA /* RemoteReaderSiteInfoSubscriptionTests.swift in Sources */,
 				BA62CFE924B592E000978BE1 /* DynamicMockProvider.swift in Sources */,
 				24ADA24E24F9B32D001B5DAE /* FeatureFlagSerializationTest.swift in Sources */,

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		4AE278482B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE278472B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift */; };
 		4AE2784A2B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE278492B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift */; };
 		4AE7E36B2B9A995500C8CED5 /* AnnouncementServiceRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE7E36A2B9A995500C8CED5 /* AnnouncementServiceRemoteTests.swift */; };
+		4AE7E36D2B9A9BC400C8CED5 /* site-zendesk-metadata-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4AE7E36C2B9A9BC400C8CED5 /* site-zendesk-metadata-success.json */; };
 		57BCD3D426209D9500292CB3 /* AppTransportSecuritySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */; };
 		730E869F21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730E869E21E44EFD00753E1A /* WordPressComServiceRemote+SiteVerticals.swift */; };
 		731BA83621DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 731BA83521DECD61000FDFCD /* SiteCreationRequestEncodingTests.swift */; };
@@ -910,6 +911,7 @@
 		4AE278472B2FBF1100E4D9B1 /* HTTPBodyEncodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPBodyEncodingTests.swift; sourceTree = "<group>"; };
 		4AE278492B2FC6C600E4D9B1 /* HTTPHeaderValueParserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPHeaderValueParserTests.swift; sourceTree = "<group>"; };
 		4AE7E36A2B9A995500C8CED5 /* AnnouncementServiceRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementServiceRemoteTests.swift; sourceTree = "<group>"; };
+		4AE7E36C2B9A9BC400C8CED5 /* site-zendesk-metadata-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-zendesk-metadata-success.json"; sourceTree = "<group>"; };
 		57BCD3D326209D9500292CB3 /* AppTransportSecuritySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTransportSecuritySettings.swift; sourceTree = "<group>"; };
 		6C2A33D76FD1052D6F30466D /* Pods-WordPressKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKit/Pods-WordPressKit.debug.xcconfig"; sourceTree = "<group>"; };
 		6F2E0CC4FA01B5475A378DA2 /* Pods-WordPressKitTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressKitTests.release-alpha.xcconfig"; path = "Pods/Target Support Files/Pods-WordPressKitTests/Pods-WordPressKitTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -2412,6 +2414,7 @@
 				74D67F2C1F15C3740010C5ED /* site-viewers-delete-bad-json.json */,
 				74D67F2D1F15C3740010C5ED /* site-viewers-delete-failure.json */,
 				74D67F2E1F15C3740010C5ED /* site-viewers-delete-success.json */,
+				4AE7E36C2B9A9BC400C8CED5 /* site-zendesk-metadata-success.json */,
 				E6B0461125E5B6F500DF6F4F /* sites-invites-links-disable-empty.json */,
 				E6B0460F25E5B6F500DF6F4F /* sites-invites-links-disable.json */,
 				E6B0461025E5B6F500DF6F4F /* sites-invites-links-generate.json */,
@@ -3096,6 +3099,7 @@
 				C738CAF3286226D6001BE107 /* qrlogin-validate-400.json in Resources */,
 				93BD27651EE73442002BB00B /* me-sites-visibility-success.json in Resources */,
 				404057D0221C46790060250C /* stats-videos-data.json in Resources */,
+				4AE7E36D2B9A9BC400C8CED5 /* site-zendesk-metadata-success.json in Resources */,
 				E1787DB0200E564B004CB3AF /* timezones.json in Resources */,
 				93BD275E1EE73442002BB00B /* me-bad-json-failure.json in Resources */,
 				FFE247AF20C891E6002DF3A2 /* WordPressComOAuthWrongPasswordFail.json in Resources */,

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -215,7 +215,7 @@ open class WordPressComRestApi: NSObject {
                                          parameters: [String: AnyObject]?,
                                          completion: @escaping (Swift.Result<(Data, HTTPURLResponse?), Error>) -> Void) {
         Task { @MainActor in
-            let result: APIResult<Data> = await perform(.get, URLString: URLString, parameters: parameters)
+            let result = await perform(.get, URLString: URLString, parameters: parameters, fulfilling: nil, decoder: { $0 })
 
             completion(
                 result

--- a/WordPressKitTests/AnnouncementServiceRemoteTests.swift
+++ b/WordPressKitTests/AnnouncementServiceRemoteTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import XCTest
+import OHHTTPStubs
+
+@testable import WordPressKit
+
+class AnnouncementServiceRemoteTests: XCTestCase {
+
+    func testNoAnnouncement() {
+        stub(condition: isPath("/wpcom/v2/mobile/feature-announcements") && containsQueryParams(["app_id": "test-app"])) { _ in
+            HTTPStubsResponse(jsonObject: ["announcements": [String]()], statusCode: 200, headers: nil)
+        }
+
+        let remote = AnnouncementServiceRemote(wordPressComRestApi: .init(oAuthToken: "fake"))
+        var result: Result<[Announcement], Error>? = nil
+        let completed = expectation(description: "API call completed")
+        remote.getAnnouncements(appId: "test-app", appVersion: "2.0", locale: "en") {
+            result = $0
+            completed.fulfill()
+        }
+        wait(for: [completed], timeout: 0.3)
+
+        try XCTAssertEqual(XCTUnwrap(result).get().count, 0)
+    }
+
+}

--- a/WordPressKitTests/Mock Data/site-zendesk-metadata-success.json
+++ b/WordPressKitTests/Mock Data/site-zendesk-metadata-success.json
@@ -1,0 +1,5 @@
+{
+  "sites": [
+    { "ID": 123, "zendesk_site_meta": { "plan": "free", "addon": [] } }
+  ]
+}


### PR DESCRIPTION
### Description

The `GetData` function was implemented incorrectly in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/720, which caused two endpoint implementations failing to parse HTTP response body.

### Testing Details

See the new unit tests.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
