### PR TITLE
Bump version to 14.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,17 @@ _None._
 
 ### Bug Fixes
 
-- Fix parsing issues in getting Zendesk metadata and feature announcements. [#746]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 14.0.1
+
+### Bug Fixes
+
+- Fix parsing issues in getting Zendesk metadata and feature announcements. [#746]
 
 ## 14.0.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '14.0.0'
+  s.version       = '14.0.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

Release 14.0.1.


---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
