### PR TITLE
Stats: Fix a crash in a remote service when accessing date formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ _None._
 
 ### Bug Fixes
 
-_None._
+- Fix a rare crash when accessing date formatter from different threads in StatsRemoteService. [#749]
 
 ### Internal Changes
 

--- a/WordPressKit/StatsServiceRemoteV2.swift
+++ b/WordPressKit/StatsServiceRemoteV2.swift
@@ -17,12 +17,12 @@ open class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
     public let siteID: Int
     private let siteTimezone: TimeZone
 
-    private lazy var periodDataQueryDateFormatter: DateFormatter = {
+    private var periodDataQueryDateFormatter: DateFormatter {
         let df = DateFormatter()
         df.locale = Locale(identifier: "en_US_POSIX")
         df.dateFormat = "yyyy-MM-dd"
         return df
-    }()
+    }
 
     private lazy var calendarForSite: Calendar = {
         var cal = Calendar(identifier: .iso8601)
@@ -117,8 +117,9 @@ open class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
             return val1
         }
 
-        wordPressComRestApi.GET(path, parameters: properties, success: { (response, _) in
+        wordPressComRestApi.GET(path, parameters: properties, success: { [weak self] (response, _) in
             guard
+                let self,
                 let jsonResponse = response as? [String: AnyObject],
                 let dateString = jsonResponse["date"] as? String,
                 let date = self.periodDataQueryDateFormatter.date(from: dateString)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22796

### Description

A crash with stack trace `[NSDateFormatter _regenerateFormatter]` and `KERN_INVALID_ADDRESS at 0xb3` suggests that the crash may have happened due to date formatter being accessed from different threads and/or objects being deinitialized when being accessed. 

I couldn't find ways to reproduce the issue but I found two potential fixes:

- Creating a new instance of periodDataQueryDateFormatter every time it's used to avoid the same DateFormatter being referenced from different threads. The same is done with `ISO8601DateFormatter()` in `StatsServiceRemoteV2` line 260.
- Using [weak sef] in wordPressComRestApi.GET closure that could've caused issues with memory.

### Testing Details

I tried finding ways to force the crash but couldn't do it.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
