### PR TITLE
Add theme type information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-- Add WP.com theme tier information. [#750]
+- Add WP.com theme type information. [#750]
 
 ## 14.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Add WP.com theme tier information. [#750]
 
 ## 14.0.1
 

--- a/WordPressKit/RemoteTheme.h
+++ b/WordPressKit/RemoteTheme.h
@@ -3,7 +3,7 @@
 @interface RemoteTheme : NSObject
 
 @property (nonatomic, assign) BOOL active;
-@property (nonatomic, strong) NSString *tier;
+@property (nonatomic, strong) NSString *type;
 @property (nonatomic, strong) NSString *author;
 @property (nonatomic, strong) NSString *authorUrl;
 @property (nonatomic, strong) NSString *desc;

--- a/WordPressKit/RemoteTheme.h
+++ b/WordPressKit/RemoteTheme.h
@@ -3,6 +3,7 @@
 @interface RemoteTheme : NSObject
 
 @property (nonatomic, assign) BOOL active;
+@property (nonatomic, strong) NSString *tier;
 @property (nonatomic, strong) NSString *author;
 @property (nonatomic, strong) NSString *authorUrl;
 @property (nonatomic, strong) NSString *desc;

--- a/WordPressKit/ThemeServiceRemote.m
+++ b/WordPressKit/ThemeServiceRemote.m
@@ -359,7 +359,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
     
     static NSString* const ThemeActiveKey = @"active";
-    static NSString* const ThemeTierPath = @"theme_tier.slug";
+    static NSString* const ThemeTypeKey = @"theme_type";
     static NSString* const ThemeAuthorKey = @"author";
     static NSString* const ThemeAuthorURLKey = @"author_uri";
     static NSString* const ThemeCostPath = @"cost.number";
@@ -385,7 +385,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     [self loadLaunchDateForTheme:theme fromDictionary:dictionary];
 
     theme.active = [[dictionary numberForKey:ThemeActiveKey] boolValue];
-    theme.tier = [dictionary stringForKeyPath:ThemeTierPath];
+    theme.type = [dictionary stringForKey:ThemeTypeKey];
     theme.author = [dictionary stringForKey:ThemeAuthorKey];
     theme.authorUrl = [dictionary stringForKey:ThemeAuthorURLKey];
     theme.demoUrl = [dictionary stringForKey:ThemeDemoURLKey];

--- a/WordPressKit/ThemeServiceRemote.m
+++ b/WordPressKit/ThemeServiceRemote.m
@@ -359,6 +359,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSParameterAssert([dictionary isKindOfClass:[NSDictionary class]]);
     
     static NSString* const ThemeActiveKey = @"active";
+    static NSString* const ThemeTierPath = @"theme_tier.slug";
     static NSString* const ThemeAuthorKey = @"author";
     static NSString* const ThemeAuthorURLKey = @"author_uri";
     static NSString* const ThemeCostPath = @"cost.number";
@@ -384,6 +385,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     [self loadLaunchDateForTheme:theme fromDictionary:dictionary];
 
     theme.active = [[dictionary numberForKey:ThemeActiveKey] boolValue];
+    theme.tier = [dictionary stringForKeyPath:ThemeTierPath];
     theme.author = [dictionary stringForKey:ThemeAuthorKey];
     theme.authorUrl = [dictionary stringForKey:ThemeAuthorURLKey];
     theme.demoUrl = [dictionary stringForKey:ThemeDemoURLKey];


### PR DESCRIPTION
### Description

The theme type can be:
- `managed-external`: partner themes
- `hosted-internal`: A8c themes

Addresses https://github.com/wordpress-mobile/WordPress-iOS/issues/21932

### Testing Details

See https://github.com/wordpress-mobile/WordPress-iOS/pull/22812

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
