### PR TITLE
Merge release 14.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,20 @@ _None._
 
 ### New Features
 
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## 14.1.0
+
+### New Features
+
 - Add Reader discover streams endpoint. [#744]
 
 ### Bug Fixes

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '14.0.1'
+  s.version       = '14.1.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 24.5 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

cc @wargcm I saw there's a branch named `cm/release-14.1.0`. I created this branch and PR because there was not a PR for that branch. I'd say now it is no longer needed. Thank you for taking releases into consideration. 🙇‍♂️ 