### PR TITLE
Add missing parameters to RemotePostCreateParameters

### DIFF
--- a/WordPressKit/PostServiceRemoteXMLRPC+Extended.swift
+++ b/WordPressKit/PostServiceRemoteXMLRPC+Extended.swift
@@ -3,7 +3,7 @@ import wpxmlrpc
 
 extension PostServiceRemoteXMLRPC: PostServiceRemoteExtended {
     public func createPost(with parameters: RemotePostCreateParameters) async throws -> RemotePost {
-        let dictionary = try makeParameters(from: RemotePostCreateParametersXMLRPCEncoder(parameters: parameters, type: .post))
+        let dictionary = try makeParameters(from: RemotePostCreateParametersXMLRPCEncoder(parameters: parameters))
         let parameters = xmlrpcArguments(withExtra: dictionary) as [AnyObject]
         let response = try await api.call(method: "metaWeblog.newPost", parameters: parameters).get()
         guard let postID = (response.body as? NSNumber) else {
@@ -13,7 +13,7 @@ extension PostServiceRemoteXMLRPC: PostServiceRemoteExtended {
     }
 
     public func patchPost(withID postID: Int, parameters: RemotePostUpdateParameters) async throws -> RemotePost {
-        let dictionary = try makeParameters(from: RemotePostUpdateParametersXMLRPCEncoder(parameters: parameters, type: .post))
+        let dictionary = try makeParameters(from: RemotePostUpdateParametersXMLRPCEncoder(parameters: parameters))
         var parameters = xmlrpcArguments(withExtra: dictionary) as [AnyObject]
         if parameters.count > 0 {
             parameters[0] = postID as NSNumber

--- a/WordPressKit/PostServiceRemoteXMLRPC+Extended.swift
+++ b/WordPressKit/PostServiceRemoteXMLRPC+Extended.swift
@@ -6,7 +6,7 @@ extension PostServiceRemoteXMLRPC: PostServiceRemoteExtended {
         let dictionary = try makeParameters(from: RemotePostCreateParametersXMLRPCEncoder(parameters: parameters))
         let parameters = xmlrpcArguments(withExtra: dictionary) as [AnyObject]
         let response = try await api.call(method: "metaWeblog.newPost", parameters: parameters).get()
-        guard let postID = (response.body as? NSNumber) else {
+        guard let postID = (response.body as? NSObject)?.numericValue() else {
             throw URLError(.unknown) // Should never happen
         }
         return try await getPost(withID: postID)

--- a/WordPressKit/RemotePostParameters.swift
+++ b/WordPressKit/RemotePostParameters.swift
@@ -2,6 +2,8 @@ import Foundation
 
 /// The parameters required to create a post or a page.
 public struct RemotePostCreateParameters: Equatable {
+    public var type: String
+
     public var status: String
     public var date: Date?
     public var authorID: Int?
@@ -21,7 +23,8 @@ public struct RemotePostCreateParameters: Equatable {
     public var tags: [String] = []
     public var categoryIDs: [Int] = []
 
-    public init(status: String) {
+    public init(type: String, status: String) {
+        self.type = type
         self.status = status
     }
 }
@@ -155,6 +158,7 @@ extension RemotePostCreateParameters {
 
 private enum RemotePostWordPressComCodingKeys: String, CodingKey {
     case ifNotModifiedSince = "if_not_modified_since"
+    case type
     case status
     case date
     case authorID = "author"
@@ -178,6 +182,7 @@ struct RemotePostCreateParametersWordPressComEncoder: Encodable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: RemotePostWordPressComCodingKeys.self)
+        try container.encodeIfPresent(parameters.type, forKey: .type)
         try container.encodeIfPresent(parameters.status, forKey: .status)
         try container.encodeIfPresent(parameters.date, forKey: .date)
         try container.encodeIfPresent(parameters.authorID, forKey: .authorID)
@@ -243,8 +248,8 @@ struct RemotePostUpdateParametersWordPressComEncoder: Encodable {
 
 private enum RemotePostXMLRPCCodingKeys: String, CodingKey {
     case ifNotModifiedSince = "if_not_modified_since"
+    case type = "post_type"
     case postStatus = "post_status"
-    case pageStatus = "page_status"
     case date = "date_created_gmt"
     case authorID = "wp_author_id"
     case title
@@ -262,22 +267,13 @@ private enum RemotePostXMLRPCCodingKeys: String, CodingKey {
     static let postTags = "post_tag"
 }
 
-enum RemotePostEncodingPostType {
-    case post, page
-}
-
 struct RemotePostCreateParametersXMLRPCEncoder: Encodable {
     let parameters: RemotePostCreateParameters
-    let type: RemotePostEncodingPostType
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: RemotePostXMLRPCCodingKeys.self)
-        switch type {
-        case .post:
-            try container.encodeIfPresent(parameters.status, forKey: .postStatus)
-        case .page:
-            try container.encodeIfPresent(parameters.status, forKey: .pageStatus)
-        }
+        try container.encode(parameters.type, forKey: .type)
+        try container.encodeIfPresent(parameters.status, forKey: .postStatus)
         try container.encodeIfPresent(parameters.date, forKey: .date)
         try container.encodeIfPresent(parameters.authorID, forKey: .authorID)
         try container.encodeIfPresent(parameters.title, forKey: .title)
@@ -308,17 +304,11 @@ struct RemotePostCreateParametersXMLRPCEncoder: Encodable {
 
 struct RemotePostUpdateParametersXMLRPCEncoder: Encodable {
     let parameters: RemotePostUpdateParameters
-    let type: RemotePostEncodingPostType
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: RemotePostXMLRPCCodingKeys.self)
         try container.encodeIfPresent(parameters.ifNotModifiedSince, forKey: .ifNotModifiedSince)
-        switch type {
-        case .post:
-            try container.encodeIfPresent(parameters.status, forKey: .postStatus)
-        case .page:
-            try container.encodeIfPresent(parameters.status, forKey: .pageStatus)
-        }
+        try container.encodeIfPresent(parameters.status, forKey: .postStatus)
         try container.encodeIfPresent(parameters.date, forKey: .date)
         try container.encodeIfPresent(parameters.authorID, forKey: .authorID)
         try container.encodeIfPresent(parameters.title, forKey: .title)


### PR DESCRIPTION
### Description

- Add missing `type` parameter to `RemotePostCreateParameters`
- Fix how XMLRPC parses response body when creating a post (use the existing ObjC based approach)

### Testing Details

In https://github.com/wordpress-mobile/WordPress-iOS/pull/22848:

- Verify that you can create a new page
- Verify that you can change page status
- Repeat for both REST and XMLRPC

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
