### PR TITLE
SPM Prep – Use `WordPressComRESTAPIInterfacing` in the Objective-C consumers

### DIFF
--- a/WordPressKit/BlogServiceRemoteREST.m
+++ b/WordPressKit/BlogServiceRemoteREST.m
@@ -106,7 +106,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               if (success) {
@@ -138,7 +138,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     NSDictionary *parameters = @{@"context": @"edit"};
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
        parameters:parameters
           success:^(NSDictionary *responseObject, NSHTTPURLResponse *httpResponse) {
              
@@ -168,7 +168,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
        parameters:nil
           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
               NSDictionary *formats = [self mapPostFormatsFromResponse:responseObject[@"formats"]];
@@ -189,7 +189,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               NSDictionary *responseDict = (NSDictionary *)responseObject;
@@ -210,7 +210,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     NSString *path = [self pathForSettings];
     NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
        parameters:nil
           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
               if (![responseObject isKindOfClass:[NSDictionary class]]){
@@ -240,7 +240,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     NSString *path = [NSString stringWithFormat:@"sites/%@/settings?context=edit", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
         parameters:parameters
            success:^(NSDictionary *responseDict, NSHTTPURLResponse *httpResponse) {
                if (![responseDict isKindOfClass:[NSDictionary class]]) {
@@ -272,7 +272,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               if (success) {
@@ -293,7 +293,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     NSString *path = [self pathForEndpoint:@"connect/site-info" withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     NSURL *siteURL = [NSURL URLWithString:siteAddress];
 
-    [self.wordPressComRestApi GET:path
+    [self.wordPressComRESTAPI get:path
                        parameters:@{ @"url": siteURL.absoluteString }
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               if (success) {

--- a/WordPressKit/CommentServiceRemoteREST.m
+++ b/WordPressKit/CommentServiceRemoteREST.m
@@ -41,7 +41,7 @@
     [parameters removeObjectForKey:@"status"];
     parameters[@"status"] = [self parameterForCommentStatus:statusFilter];
 
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               if (success) {
@@ -84,7 +84,7 @@
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         RemoteComment *comment = [self remoteCommentFromJSONDictionary:responseObject];
@@ -116,7 +116,7 @@
                                  @"content": comment.content,
                                  @"context": @"edit",
                                  };
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                // TODO: validate response
@@ -147,7 +147,7 @@
         @"context": @"edit",
     };
 
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                // TODO: validate response
@@ -174,7 +174,7 @@
                                  @"status": [self remoteStatusWithStatus:comment.status],
                                  @"context": @"edit",
                                  };
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                // TODO: validate response
@@ -197,7 +197,7 @@
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                if (success) {
@@ -226,7 +226,7 @@
     NSDictionary *parameters = @{
         @"force": @"wpcom" // Force fetching data from shadow site on Jetpack sites
     };
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
@@ -258,7 +258,7 @@
         @"content": content,
         @"context": @"edit",
     };
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                if (success) {
@@ -282,7 +282,7 @@
     
     NSDictionary *parameters = @{@"content": content};
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
         parameters:parameters
            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                if (success) {
@@ -310,7 +310,7 @@
         @"content": content,
         @"context": @"edit",
     };
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                if (success) {
@@ -339,7 +339,7 @@
         @"context"  : @"edit",
     };
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                if (success) {
@@ -360,7 +360,7 @@
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                if (success) {
@@ -381,7 +381,7 @@
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                if (success) {
@@ -402,7 +402,7 @@
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                if (success) {
@@ -444,7 +444,7 @@
         parameters[@"exclude"] = excludeUserIDs;
     }
 
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {

--- a/WordPressKit/MediaServiceRemoteREST.m
+++ b/WordPressKit/MediaServiceRemoteREST.m
@@ -18,7 +18,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     
     NSDictionary * parameters = @{};
     
-    [self.wordPressComRestApi GET:requestUrl parameters:parameters success:^(id responseObject, NSHTTPURLResponse *response) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:parameters success:^(id responseObject, NSHTTPURLResponse *response) {
         if (success) {
             NSDictionary *response = (NSDictionary *)responseObject;
             success([MediaServiceRemoteREST remoteMediaFromJSONDictionary:response]);
@@ -60,7 +60,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
        parameters:[NSDictionary dictionaryWithDictionary:parameters]
           success:^(id responseObject, NSHTTPURLResponse *response) {
               NSArray *mediaItems = responseObject[@"media"];
@@ -104,7 +104,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
         parameters[@"mime_type"] = mediaType;
     }
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
        parameters:[NSDictionary dictionaryWithDictionary:parameters]
           success:^(id responseObject, NSHTTPURLResponse *response) {
               NSDictionary *jsonDictionary = (NSDictionary *)responseObject;
@@ -261,7 +261,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 
     NSDictionary *parameters = [self parametersFromRemoteMedia:media];
 
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
         parameters:parameters
            success:^(id responseObject, NSHTTPURLResponse *response) {
                RemoteMedia *media = [MediaServiceRemoteREST remoteMediaFromJSONDictionary:responseObject];
@@ -285,7 +285,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                NSDictionary *response = (NSDictionary *)responseObject;
@@ -318,7 +318,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         NSDictionary *response = (NSDictionary *)responseObject;
@@ -358,7 +358,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_2_0];
 
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                NSDictionary *response = (NSDictionary *)responseObject;

--- a/WordPressKit/MenusServiceRemote.m
+++ b/WordPressKit/MenusServiceRemote.m
@@ -39,7 +39,7 @@ NSString * const MenusRemoteKeyClasses = @"classes";
     NSString *requestURL = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestURL
+    [self.wordPressComRESTAPI post:requestURL
         parameters:@{MenusRemoteKeyName: menuName}
            success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                void(^responseFailure)(void) = ^() {
@@ -94,7 +94,7 @@ NSString * const MenusRemoteKeyClasses = @"classes";
     // Brent Coursey - 10/1/2015
     [params setObject:menuID forKey:MenusRemoteKeyID];
     
-    [self.wordPressComRestApi POST:requestURL
+    [self.wordPressComRESTAPI post:requestURL
         parameters:params
            success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                void(^responseFailure)(void) = ^() {
@@ -131,7 +131,7 @@ NSString * const MenusRemoteKeyClasses = @"classes";
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus/%@/delete", siteID, menuID];
     NSString *requestURL = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
-    [self.wordPressComRestApi POST:requestURL
+    [self.wordPressComRESTAPI post:requestURL
         parameters:nil
            success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                void(^responseFailure)(void) = ^() {
@@ -169,7 +169,7 @@ NSString * const MenusRemoteKeyClasses = @"classes";
     NSString *requestURL = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestURL
+    [self.wordPressComRESTAPI get:requestURL
        parameters:nil
           success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
               if (![responseObject isKindOfClass:[NSDictionary class]]) {

--- a/WordPressKit/PostServiceRemoteREST.m
+++ b/WordPressKit/PostServiceRemoteREST.m
@@ -41,7 +41,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     
     NSDictionary *parameters = @{ @"context": @"edit" };
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
        parameters:parameters
           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
               if (success) {
@@ -83,7 +83,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
         [mutableParameters addEntriesFromDictionary:options];
         parameters = [NSDictionary dictionaryWithDictionary:mutableParameters];
     }
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
        parameters:parameters
           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
               if (success) {
@@ -106,7 +106,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     
     NSDictionary *parameters = [self parametersWithRemotePost:post];
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
@@ -132,7 +132,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     
     NSDictionary *parameters = [self parametersWithRemotePost:post];
 
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
         parameters:parameters
            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
@@ -196,7 +196,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     
     NSDictionary *parameters = [self parametersWithRemotePost:post];
 
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
         parameters:parameters
            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
@@ -222,7 +222,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     
     NSDictionary *parameters = [self parametersWithRemotePost:post];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                                RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
@@ -247,7 +247,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
         parameters:nil
            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                if (success) {
@@ -271,7 +271,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
         parameters:nil
            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
@@ -297,7 +297,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
         parameters:nil
            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                RemotePost *post = [self remotePostFromJSONDictionary:responseObject];
@@ -340,7 +340,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
         parameters[@"exclude"] = excludeUserIDs;
     }
 
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -72,7 +72,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
            parameters:nil
               success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                   if (!success) {
@@ -113,7 +113,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
         return;
     }
 
-    [self.wordPressComRestApi GET:path
+    [self.wordPressComRESTAPI get:path
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                               if (!success) {
@@ -144,7 +144,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
             success();
         }
@@ -164,7 +164,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
             success();
         }
@@ -201,7 +201,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
                            failure:(void (^)(NSError *))failure
 {
     NSString *path = [endpoint absoluteString];
-    [self.wordPressComRestApi GET:path
+    [self.wordPressComRESTAPI get:path
            parameters:params
               success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
                   if (!success) {

--- a/WordPressKit/ReaderPostServiceRemote.m
+++ b/WordPressKit/ReaderPostServiceRemote.m
@@ -181,7 +181,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
 
     NSString *endpoint = [NSString stringWithFormat:@"read/search?q=%@", [phrase stringByUrlEncoding]];
     NSString *absolutePath = [self pathForEndpoint:endpoint withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
-    NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:self.wordPressComRestApi.baseURL];
+    NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:self.wordPressComRESTAPI.baseURL];
     return [url absoluteString];
 }
 

--- a/WordPressKit/ReaderSiteServiceRemote.m
+++ b/WordPressKit/ReaderSiteServiceRemote.m
@@ -17,7 +17,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }
@@ -44,7 +44,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
             success();
         }
@@ -61,7 +61,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
             success();
         }
@@ -80,7 +80,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     
     NSDictionary *params = @{ReaderSiteServiceRemoteURLKey: siteURL,
                              ReaderSiteServiceRemoteSourceKey: ReaderSiteServiceRemoteSourceValue};
-    [self.wordPressComRestApi POST:requestUrl parameters:params success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:params success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         NSDictionary *dict = (NSDictionary *)responseObject;
         BOOL subscribed = [[dict numberForKey:@"subscribed"] boolValue];
         if (!subscribed) {
@@ -109,7 +109,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     
     NSDictionary *params = @{ReaderSiteServiceRemoteURLKey: siteURL};
     
-    [self.wordPressComRestApi POST:requestUrl parameters:params success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:params success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         NSDictionary *dict = (NSDictionary *)responseObject;
         BOOL subscribed = [[dict numberForKey:@"subscribed"] boolValue];
         if (subscribed) {
@@ -163,7 +163,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:successBlock failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:nil success:successBlock failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         NSString *newHost;
         if ([host hasPrefix:@"www."]) {
             // If the provided host includes a www. prefix, try again without it.
@@ -178,7 +178,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
         NSString *newPathRequestUrl = [self pathForEndpoint:newPath
                                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
         
-        [self.wordPressComRestApi GET:newPathRequestUrl parameters:nil success:successBlock failure:failureBlock];
+        [self.wordPressComRESTAPI get:newPathRequestUrl parameters:nil success:successBlock failure:failureBlock];
     }];
 }
 
@@ -218,7 +218,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }
@@ -239,7 +239,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }
@@ -270,7 +270,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         NSDictionary *dict = (NSDictionary *)responseObject;
         if (![[dict numberForKey:@"success"] boolValue]) {
             if (blocked) {

--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -19,7 +19,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_3];
 
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(NSDictionary *response, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(NSDictionary *response, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }
@@ -65,7 +65,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
 
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }
@@ -93,7 +93,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(NSDictionary *responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(NSDictionary *responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }
@@ -124,7 +124,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [self.wordPressComRestApi POST:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }
@@ -146,7 +146,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
 
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }
@@ -180,7 +180,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
                                withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
     }
     
-    [self.wordPressComRestApi GET:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
+    [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
             return;
         }

--- a/WordPressKit/ReaderTopicServiceRemote.m
+++ b/WordPressKit/ReaderTopicServiceRemote.m
@@ -221,7 +221,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 - (NSString *)endpointUrlForPath:(NSString *)endpoint
 {
     NSString *absolutePath = [self pathForEndpoint:endpoint withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
-    NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:self.wordPressComRestApi.baseURL];
+    NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:self.wordPressComRESTAPI.baseURL];
     return [url absoluteString];
 }
 

--- a/WordPressKit/TaxonomyServiceRemoteREST.m
+++ b/WordPressKit/TaxonomyServiceRemoteREST.m
@@ -186,7 +186,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
     NSString *path = [NSString stringWithFormat:@"sites/%@/%@/new?context=edit", self.siteID, typeIdentifier];
     NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                                if (![responseObject isKindOfClass:[NSDictionary class]]) {
@@ -211,7 +211,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi GET:requestUrl
+    [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                               if (![responseObject isKindOfClass:[NSDictionary class]]) {
@@ -236,7 +236,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
                            success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                                if (![responseObject isKindOfClass:[NSDictionary class]]) {
@@ -261,7 +261,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl
+    [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
                            success:^(id _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
                                if (![responseObject isKindOfClass:[NSDictionary class]]) {

--- a/WordPressKit/ThemeServiceRemote.m
+++ b/WordPressKit/ThemeServiceRemote.m
@@ -28,7 +28,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    NSProgress *progress = [self.wordPressComRestApi GET:requestUrl
+    NSProgress *progress = [self.wordPressComRESTAPI get:requestUrl
                                               parameters:nil
                                                  success:^(NSDictionary *themeDictionary, NSHTTPURLResponse *httpResponse) {
                                                      if (success) {
@@ -55,7 +55,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    NSProgress *progress = [self.wordPressComRestApi GET:requestUrl
+    NSProgress *progress = [self.wordPressComRESTAPI get:requestUrl
                                 parameters:nil
                                    success:^(NSDictionary *response, NSHTTPURLResponse *httpResponse) {
                                        if (success) {
@@ -81,7 +81,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    NSProgress *progress = [self.wordPressComRestApi GET:requestUrl
+    NSProgress *progress = [self.wordPressComRESTAPI get:requestUrl
                                 parameters:nil
                                    success:^(NSDictionary *themeDictionary, NSHTTPURLResponse *httpResponse) {
                                        if (success) {
@@ -233,7 +233,7 @@ static NSString* const ThemeRequestPageKey = @"page";
                                 failure:(ThemeServiceRemoteFailureBlock)failure
 {
 
-    return [self.wordPressComRestApi GET:requestUrl
+    return [self.wordPressComRESTAPI get:requestUrl
                               parameters:parameters
                                  success:^(NSDictionary *response, NSHTTPURLResponse *httpResponse) {
                                      if (success) {
@@ -270,7 +270,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     
     NSDictionary* parameters = @{@"theme": themeId};
     
-    NSProgress *progress = [self.wordPressComRestApi POST:requestUrl
+    NSProgress *progress = [self.wordPressComRESTAPI post:requestUrl
                                  parameters:parameters
                                     success:^(NSDictionary *themeDictionary, NSHTTPURLResponse *httpResponse) {
                                         if (success) {
@@ -299,7 +299,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSString *requestUrl = [self pathForEndpoint:path
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    NSProgress *progress = [self.wordPressComRestApi POST:requestUrl
+    NSProgress *progress = [self.wordPressComRESTAPI post:requestUrl
                                                parameters:nil
                                                   success:^(NSDictionary *themeDictionary, NSHTTPURLResponse *httpResponse) {
                                                       if (success) {

--- a/WordPressKit/WordPressComRESTAPIInterfacing.h
+++ b/WordPressKit/WordPressComRESTAPIInterfacing.h
@@ -4,14 +4,14 @@
 
 @property (strong, nonatomic, readonly) NSURL * _Nonnull baseURL;
 
-- (void)get:(NSString * _Nonnull)URLString
- parameters:(NSDictionary<NSString *, NSObject *> * _Nullable)parameters
-    success:(void (^ _Nonnull)(id _Nonnull, NSHTTPURLResponse * _Nullable))success
-    failure:(void (^ _Nonnull)(NSError * _Nonnull, NSHTTPURLResponse * _Nullable))failure;
+- (NSProgress * _Nullable)get:(NSString * _Nonnull)URLString
+                   parameters:(NSDictionary<NSString *, NSObject *> * _Nullable)parameters
+                      success:(void (^ _Nonnull)(id _Nonnull, NSHTTPURLResponse * _Nullable))success
+                      failure:(void (^ _Nonnull)(NSError * _Nonnull, NSHTTPURLResponse * _Nullable))failure;
 
-- (void)post:(NSString * _Nonnull)URLString
-  parameters:(NSDictionary<NSString *, NSObject *> * _Nullable)parameters
-     success:(void (^ _Nonnull)(id _Nonnull, NSHTTPURLResponse * _Nullable))success
-     failure:(void (^ _Nonnull)(NSError * _Nonnull, NSHTTPURLResponse * _Nullable))failure;
+- (NSProgress * _Nullable)post:(NSString * _Nonnull)URLString
+                    parameters:(NSDictionary<NSString *, NSObject *> * _Nullable)parameters
+                       success:(void (^ _Nonnull)(id _Nonnull, NSHTTPURLResponse * _Nullable))success
+                       failure:(void (^ _Nonnull)(NSError * _Nonnull, NSHTTPURLResponse * _Nullable))failure;
 
 @end

--- a/WordPressKit/WordPressComRESTAPIInterfacing.h
+++ b/WordPressKit/WordPressComRESTAPIInterfacing.h
@@ -2,6 +2,8 @@
 
 @protocol WordPressComRESTAPIInterfacing
 
+@property (strong, nonatomic, readonly) NSURL * _Nonnull baseURL;
+
 - (void)get:(NSString * _Nonnull)URLString
  parameters:(NSDictionary<NSString *, NSObject *> * _Nullable)parameters
     success:(void (^ _Nonnull)(id _Nonnull, NSHTTPURLResponse * _Nullable))success

--- a/WordPressKit/WordPressComRestApi.swift
+++ b/WordPressKit/WordPressComRestApi.swift
@@ -634,7 +634,7 @@ extension WordPressComRestApi: WordPressComRESTAPIInterfacing {
         parameters: [String: NSObject]?,
         success: @escaping (Any, HTTPURLResponse?) -> Void,
         failure: @escaping (any Error, HTTPURLResponse?) -> Void
-    ) {
+    ) -> Progress? {
         GET(URLString, parameters: parameters, success: success, failure: failure)
     }
 
@@ -643,7 +643,7 @@ extension WordPressComRestApi: WordPressComRESTAPIInterfacing {
         parameters: [String: NSObject]?,
         success: @escaping (Any, HTTPURLResponse?) -> Void,
         failure: @escaping (any Error, HTTPURLResponse?) -> Void
-    ) {
+    ) -> Progress? {
         POST(URLString, parameters: parameters, success: success, failure: failure)
     }
 }

--- a/WordPressKit/WordPressComServiceRemote.m
+++ b/WordPressKit/WordPressComServiceRemote.m
@@ -61,7 +61,7 @@
     NSString *requestUrl = [self pathForEndpoint:@"users/new"
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl parameters:params success:successBlock failure:failureBlock];
+    [self.wordPressComRESTAPI post:requestUrl parameters:params success:successBlock failure:failureBlock];
 }
 
 - (void)createWPComAccountWithGoogle:(NSString *)token
@@ -222,7 +222,7 @@
     NSString *requestUrl = [self pathForEndpoint:@"sites/new"
                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    [self.wordPressComRestApi POST:requestUrl parameters:params success:successBlock failure:failureBlock];
+    [self.wordPressComRESTAPI post:requestUrl parameters:params success:successBlock failure:failureBlock];
 }
 
 #pragma mark - Error localization

--- a/WordPressKit/WordPressComServiceRemote.m
+++ b/WordPressKit/WordPressComServiceRemote.m
@@ -116,7 +116,7 @@
     };
 
     NSString *requestUrl = [self pathForEndpoint:@"users/social/new" withVersion:ServiceRemoteWordPressComRESTApiVersion_1_0];
-    [self.wordPressComRestApi POST:requestUrl parameters:params success:successBlock failure:failureBlock];
+    [self.wordPressComRESTAPI post:requestUrl parameters:params success:successBlock failure:failureBlock];
 }
 
 - (void)validateWPComBlogWithUrl:(NSString *)blogUrl

--- a/WordPressKitTests/BlogServiceRemoteRESTTests.m
+++ b/WordPressKitTests/BlogServiceRemoteRESTTests.m
@@ -37,7 +37,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isKindOfClass:[NSDictionary class]]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -62,7 +62,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -88,7 +88,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
     NSDictionary *parameters = @{@"context": @"edit"};
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isEqual:parameters]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -113,7 +113,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);

--- a/WordPressKitTests/MenusServiceRemoteTests.m
+++ b/WordPressKitTests/MenusServiceRemoteTests.m
@@ -32,7 +32,7 @@
                 && [[parameters objectForKey:@"name"] isEqualToString:name]);
     };
     
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg checkWithBlock:parametersCheckBlock]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -59,7 +59,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -89,7 +89,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -112,7 +112,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);

--- a/WordPressKitTests/PostServiceRemoteRESTTests.m
+++ b/WordPressKitTests/PostServiceRemoteRESTTests.m
@@ -40,7 +40,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNotNil]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -82,7 +82,7 @@
                 && [[parameters objectForKey:@"type"] isEqualToString:postType]);
     };
     
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -118,7 +118,7 @@
                 && [parameters objectForKey:testOptionKey] == testOptionValue);
     };
     
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -153,7 +153,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -198,7 +198,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -243,7 +243,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -276,7 +276,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNotNil]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -304,7 +304,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
     
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -341,7 +341,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -378,7 +378,7 @@
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);

--- a/WordPressKitTests/TaxonomyServiceRemoteRESTTests.m
+++ b/WordPressKitTests/TaxonomyServiceRemoteRESTTests.m
@@ -57,7 +57,7 @@
     };
     
     WordPressComRestApi *api = self.service.wordPressComRestApi;
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg checkWithBlock:parametersCheckBlock]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -76,7 +76,7 @@
     };
 
     WordPressComRestApi *api = self.service.wordPressComRestApi;
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -113,7 +113,7 @@
         ]
       };
     NSHTTPURLResponse *response = OCMStrictClassMock([NSHTTPURLResponse class]);
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg any]
              success:([OCMArg invokeBlockWithArgs:json, response, nil])
              failure:[OCMArg isNotNil]]);
@@ -164,7 +164,7 @@
     };
     
     WordPressComRestApi *api = self.service.wordPressComRestApi;
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -190,7 +190,7 @@
     };
     
     WordPressComRestApi *api = self.service.wordPressComRestApi;
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -217,7 +217,7 @@
     };
 
     WordPressComRestApi *api = self.service.wordPressComRestApi;
-    OCMStub([api POST:[OCMArg isEqual:url]
+    OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg checkWithBlock:parametersCheckBlock]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]);
@@ -236,7 +236,7 @@
     };
 
     WordPressComRestApi *api = self.service.wordPressComRestApi;
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -279,7 +279,7 @@
     };
     
     WordPressComRestApi *api = self.service.wordPressComRestApi;
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);
@@ -305,7 +305,7 @@
     };
     
     WordPressComRestApi *api = self.service.wordPressComRestApi;
-    OCMStub([api GET:[OCMArg isEqual:url]
+    OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
              failure:[OCMArg isNotNil]]);

--- a/WordPressKitTests/TaxonomyServiceRemoteRESTTests.m
+++ b/WordPressKitTests/TaxonomyServiceRemoteRESTTests.m
@@ -56,7 +56,7 @@
         return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"name"] isEqualToString:category.name]);
     };
     
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg checkWithBlock:parametersCheckBlock]
               success:[OCMArg isNotNil]
@@ -75,7 +75,7 @@
         return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"number"] integerValue] == 1000);
     };
 
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
@@ -90,7 +90,7 @@
 {
     NSString *url = [self GETtaxonomyURLWithType:@"categories"];
 
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     NSDictionary *json = @{
         @"found": @1,
         @"categories": @[
@@ -163,7 +163,7 @@
         return YES;
     };
     
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
@@ -189,7 +189,7 @@
         return YES;
     };
     
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
@@ -216,7 +216,7 @@
         return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"name"] isEqualToString:tag.name]);
     };
 
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg checkWithBlock:parametersCheckBlock]
               success:[OCMArg isNotNil]
@@ -235,7 +235,7 @@
         return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"number"] integerValue] == 1000);
     };
 
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
@@ -278,7 +278,7 @@
         return YES;
     };
     
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]
@@ -304,7 +304,7 @@
         return YES;
     };
     
-    WordPressComRestApi *api = self.service.wordPressComRestApi;
+    id<WordPressComRESTAPIInterfacing> api = self.service.wordPressComRESTAPI;
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg checkWithBlock:parametersCheckBlock]
              success:[OCMArg isNotNil]

--- a/WordPressKitTests/ThemeServiceRemoteTests.m
+++ b/WordPressKitTests/ThemeServiceRemoteTests.m
@@ -42,7 +42,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [OCMStub([api GET:[OCMArg isEqual:url]
+    [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]) andDo:^(NSInvocation *invocation) {
@@ -95,7 +95,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [OCMStub([api GET:[OCMArg isEqual:url]
+    [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]) andDo:^(NSInvocation *invocation) {
@@ -148,7 +148,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
 
-    [OCMStub([api GET:[OCMArg isEqual:url]
+    [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]) andDo:^(NSInvocation *invocation) {
@@ -203,7 +203,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
         NSCAssert(totalThemeCount == expectedThemes, @"Expected %ld themes to be found", expectedThemes);
     };
     
-    [OCMStub([api GET:[OCMArg isEqual:url]
+    [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNotNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]) andDo:^(NSInvocation *invocation) {
@@ -247,7 +247,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     NSString *url = [service pathForEndpoint:endpoint
                                  withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
 
-    [OCMStub([api GET:[OCMArg isEqual:url]
+    [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNotNil]
               success:[OCMArg isNotNil]
               failure:[OCMArg isNotNil]]) andDo:^(NSInvocation *invocation) {
@@ -311,7 +311,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
         return [themeIdParameter isEqualToString:themeId];
     };
 
-    [OCMStub([api POST:[OCMArg isEqual:url]
+    [OCMStub([api post:[OCMArg isEqual:url]
             parameters:[OCMArg checkWithBlock:checkBlock]
                success:[OCMArg isNotNil]
                failure:[OCMArg isNotNil]]) andDo:^(NSInvocation *invocation) {


### PR DESCRIPTION
### Description

The bulk of this PR is going from `wordPressComRestApi GET|POST` to `wordPressComRESTAPI get|post`. That is, from the concrete implementation to the one referenced via the new `WordPressComRESTAPIInterfacing` protocol introduced in #760 .

Other than that, there are two notable changes:

- Added `baseURL: URL` property to `WordPressComRESTAPIInterfacing`, https://github.com/wordpress-mobile/WordPressKit-iOS/pull/761/commits/72c7132d44ea02302c19dbb8ede6d926f690adf7
- Updated the methods in the protocol to return `NSProgress *`. This was always the behavior in the original `WordPressComRestApi`, but because the return value is discardable, I didn't notice it till I run into code that required it, https://github.com/wordpress-mobile/WordPressKit-iOS/pull/761/commits/83d03ab72f9e6a452ab5e29ad9edeb1862572090


### Testing Details

Green CI 👌 

## Next up
Basically, cherry-pick the work from https://github.com/wordpress-mobile/WordPressKit-iOS/pull/738 but in a neat and reviewable order:

- Move files into Sources/ and Tests/
- Introduce `Bundle` helper that differentiates between SPM and CocoaPods installations
- Isolate core API objects in dedicated package

See also, https://github.com/wordpress-mobile/WordPressKit-iOS/pull/756, #758, #760 which are related to the SPM work but independent from this one.


---

- [ ] Please check here if your pull request includes additional test coverage. — N.A.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.