### PR TITLE
SPM Prep – Use `WordPressComRESTAPIInterfacing` in `DomainServiceRemote` and `AccountServiceRemoteREST`

### DIFF
--- a/Sources/WordPressKit/Services/AccountServiceRemoteREST+SocialService.swift
+++ b/Sources/WordPressKit/Services/AccountServiceRemoteREST+SocialService.swift
@@ -23,7 +23,7 @@ extension AccountServiceRemoteREST {
                                        oAuthClientID: String,
                                        oAuthClientSecret: String,
                                        success: @escaping (() -> Void),
-                                       failure: @escaping ((NSError) -> Void)) {
+                                       failure: @escaping ((Error) -> Void)) {
         let path = self.path(forEndpoint: "me/social-login/connect", withVersion: ._1_1)
 
         var params = [
@@ -65,7 +65,7 @@ extension AccountServiceRemoteREST {
     ///     - oAuthClientSecret The WPCOM REST API client secret.
     ///     - success The block that will be executed on success.
     ///     - failure The block that will be executed on failure.
-    public func disconnectFromSocialService(_ service: SocialServiceName, oAuthClientID: String, oAuthClientSecret: String, success: @escaping(() -> Void), failure: @escaping((NSError) -> Void)) {
+    public func disconnectFromSocialService(_ service: SocialServiceName, oAuthClientID: String, oAuthClientSecret: String, success: @escaping(() -> Void), failure: @escaping((Error) -> Void)) {
         let path = self.path(forEndpoint: "me/social-login/disconnect", withVersion: ._1_1)
         let params = [
             "client_id": oAuthClientID,

--- a/Sources/WordPressKit/Services/AccountServiceRemoteREST+SocialService.swift
+++ b/Sources/WordPressKit/Services/AccountServiceRemoteREST+SocialService.swift
@@ -37,7 +37,7 @@ extension AccountServiceRemoteREST {
             params.merge(connectParameters, uniquingKeysWith: { (current, _) in current })
         }
 
-        wordPressComRestApi.POST(path, parameters: params, success: { (_, _) in
+        wordPressComRESTAPI.post(path, parameters: params, success: { (_, _) in
             success()
         }, failure: { (error, _) in
             failure(error)
@@ -73,7 +73,7 @@ extension AccountServiceRemoteREST {
             "service": service.rawValue
         ] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: params, success: { (_, _) in
+        wordPressComRESTAPI.post(path, parameters: params, success: { (_, _) in
             success()
         }, failure: { (error, _) in
             failure(error)

--- a/Sources/WordPressKit/Services/AccountSettingsRemote.swift
+++ b/Sources/WordPressKit/Services/AccountSettingsRemote.swift
@@ -32,7 +32,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let parameters = ["context": "edit"]
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                 parameters: parameters as [String: AnyObject]?,
                 success: {
                     responseObject, _ in
@@ -54,7 +54,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = [fieldNameForChange(change): change.stringValue]
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
             parameters: parameters as [String: AnyObject]?,
             success: {
                 _, _ in
@@ -79,7 +79,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
 
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: parameters as [String: AnyObject]?,
                                  success: { _, _ in
                                     success()
@@ -99,7 +99,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let endpoint = "me/username/validate/\(username)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: nil,
                                 success: { _, _ in
                                     // The success block needs to be changed if
@@ -116,7 +116,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let endpoint = "wpcom/v2/users/username/suggestions"
         let parameters = ["name": base]
 
-        wordPressComRestApi.GET(endpoint, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(endpoint, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                 let suggestions = response["suggestions"] as? [String] else {
                 finished([])
@@ -134,7 +134,7 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = ["password": password]
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: parameters as [String: AnyObject]?,
                                  success: {
                                     _, _ in
@@ -149,14 +149,14 @@ public class AccountSettingsRemote: ServiceRemoteWordPressComREST {
         let endpoint = "me/account/close"
         let path = path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil) { _, _ in
+        wordPressComRESTAPI.post(path, parameters: nil) { _, _ in
             success()
         } failure: { error, _ in
             failure(error)
         }
     }
 
-    private func settingsFromResponse(_ responseObject: AnyObject) throws -> AccountSettings {
+    private func settingsFromResponse(_ responseObject: Any) throws -> AccountSettings {
         guard let response = responseObject as? [String: AnyObject],
             let firstName = response["first_name"] as? String,
             let lastName = response["last_name"] as? String,

--- a/Sources/WordPressKit/Services/ActivityServiceRemote_ApiVersion1_0.swift
+++ b/Sources/WordPressKit/Services/ActivityServiceRemote_ApiVersion1_0.swift
@@ -28,11 +28,12 @@
             parameters["types"] = types.toDictionary() as AnyObject
         }
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: parameters,
                                  success: { response, _ in
-                                    guard let restoreID = response["restore_id"] as? Int,
-                                          let jobID = response["job_id"] as? Int else {
+                                    guard let responseDict = response as? [String: Any],
+                                          let restoreID = responseDict["restore_id"] as? Int,
+                                          let jobID = responseDict["job_id"] as? Int else {
                                         failure(ResponseError.decodingFailure)
                                         return
                                     }

--- a/Sources/WordPressKit/Services/Domains/DomainsServiceRemote.swift
+++ b/Sources/WordPressKit/Services/Domains/DomainsServiceRemote.swift
@@ -112,7 +112,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/domains"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: nil,
+        wordPressComRESTAPI.get(path, parameters: nil,
             success: {
                 response, _ in
                 do {
@@ -133,7 +133,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
 
         let parameters: [String: AnyObject] = ["domain": domain as AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters,
+        wordPressComRESTAPI.post(path, parameters: parameters,
                                 success: { _, _ in
 
             success()
@@ -149,7 +149,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         let endPoint = "domains/supported-states/\(countryCode)"
         let servicePath = path(forEndpoint: endPoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             servicePath,
             parameters: nil,
             success: {
@@ -175,7 +175,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
         let endPoint = "me/domain-contact-information"
         let servicePath = path(forEndpoint: endPoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             servicePath,
             parameters: nil,
             success: { (response, _) in
@@ -201,7 +201,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
 
         let parameters: [String: AnyObject] = ["contact_information": contactInformation as AnyObject,
                                                "domain_names": domainNames as AnyObject]
-        wordPressComRestApi.POST(
+        wordPressComRESTAPI.post(
             servicePath,
             parameters: parameters,
             success: { response, _ in
@@ -239,7 +239,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
             parameters["quantity"] = quantity as AnyObject
         }
 
-        wordPressComRestApi.GET(servicePath,
+        wordPressComRESTAPI.get(servicePath,
                                 parameters: parameters,
                                 success: {
                                     response, _ in
@@ -257,7 +257,7 @@ public class DomainsServiceRemote: ServiceRemoteWordPressComREST {
     }
 }
 
-private func map(suggestions response: AnyObject) throws -> [DomainSuggestion] {
+private func map(suggestions response: Any) throws -> [DomainSuggestion] {
     guard let jsonSuggestions = response as? [[String: AnyObject]] else {
         throw DomainsServiceRemote.ResponseError.decodingFailed
     }
@@ -272,7 +272,7 @@ private func map(suggestions response: AnyObject) throws -> [DomainSuggestion] {
     return suggestions
 }
 
-private func mapDomainsResponse(_ response: AnyObject) throws -> [RemoteDomain] {
+private func mapDomainsResponse(_ response: Any) throws -> [RemoteDomain] {
     guard let json = response as? [String: AnyObject],
         let domainsJson = json["domains"] as? [[String: AnyObject]] else {
             throw DomainsServiceRemote.ResponseError.decodingFailed

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRESTAPIInterfacing.h
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRESTAPIInterfacing.h
@@ -6,13 +6,17 @@
 
 @property (strong, nonatomic, readonly) NSURL * _Nonnull baseURL;
 
+/// - Note: `parameters` has `id` instead of the more common `NSObject *` as its value type so it will convert to `AnyObject` in Swift.
+///         In Swift, it's simpler to work with `AnyObject` than with `NSObject`. For example `"abc" as AnyObject` over `"abc" as NSObject`.
 - (NSProgress * _Nullable)get:(NSString * _Nonnull)URLString
-                   parameters:(NSDictionary<NSString *, NSObject *> * _Nullable)parameters
+                   parameters:(NSDictionary<NSString *, id> * _Nullable)parameters
                       success:(void (^ _Nonnull)(id _Nonnull, NSHTTPURLResponse * _Nullable))success
                       failure:(void (^ _Nonnull)(NSError * _Nonnull, NSHTTPURLResponse * _Nullable))failure;
 
+/// - Note: `parameters` has `id` instead of the more common `NSObject *` as its value type so it will convert to `AnyObject` in Swift.
+///         In Swift, it's simpler to work with `AnyObject` than with `NSObject`. For example `"abc" as AnyObject` over `"abc" as NSObject`.
 - (NSProgress * _Nullable)post:(NSString * _Nonnull)URLString
-                    parameters:(NSDictionary<NSString *, NSObject *> * _Nullable)parameters
+                    parameters:(NSDictionary<NSString *, id> * _Nullable)parameters
                        success:(void (^ _Nonnull)(id _Nonnull, NSHTTPURLResponse * _Nullable))success
                        failure:(void (^ _Nonnull)(NSError * _Nonnull, NSHTTPURLResponse * _Nullable))failure;
 

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -615,20 +615,34 @@ extension WordPressComRestApi: WordPressComRESTAPIInterfacing {
     // The same applies for the other methods below.
     public func get(
         _ URLString: String,
-        parameters: [String: NSObject]?,
+        parameters: [String: Any]?,
         success: @escaping (Any, HTTPURLResponse?) -> Void,
         failure: @escaping (any Error, HTTPURLResponse?) -> Void
     ) -> Progress? {
-        GET(URLString, parameters: parameters, success: success, failure: failure)
+        GET(
+            URLString,
+            // It's possible `WordPressComRestApi` could be updated to use `[String: Any]` instead.
+            // But leaving that investigation for later.
+            parameters: parameters as? [String: AnyObject],
+            success: success,
+            failure: failure
+        )
     }
 
     public func post(
         _ URLString: String,
-        parameters: [String: NSObject]?,
+        parameters: [String: Any]?,
         success: @escaping (Any, HTTPURLResponse?) -> Void,
         failure: @escaping (any Error, HTTPURLResponse?) -> Void
     ) -> Progress? {
-        POST(URLString, parameters: parameters, success: success, failure: failure)
+        POST(
+            URLString,
+            // It's possible `WordPressComRestApi` could be updated to use `[String: Any]` instead.
+            // But leaving that investigation for later.
+            parameters: parameters as? [String: AnyObject],
+            success: success,
+            failure: failure
+        )
     }
 
     public func multipartPOST(


### PR DESCRIPTION
### Description

A small PR to get feedback on my approach to adopt the `WordPressComRESTAPIInterfacing` abstraction layer from #760 in Swift. 

This required a few minor tweaks, mainly to make sure the code across Objective-C and Swift deals with `Any` instead of `NSObject`. I think this is okay. `Any` is as loose a type as it comes in Swift, but the loss of type safety is only a matter of making the two languages working together. All the code I've dealt with so far uses stricter types at runtime, of course.

### Testing Details

Ensure CI is green.

### Next Steps

Assuming the implementation direction I've taken is appropriate, after this lands I'll move on with porting it to the rest of the Swift files. 

---

- [ ] Please check here if your pull request includes additional test coverage. — N.A.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.