### PR TITLE
Merge 15.0.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,7 @@ _None._
 
 ### Breaking Changes
 
-- Reworked the `NSDate` RFC3339 / WordPress.com JSON conversions API [#759]
-- Changed `FilePart` `filename` property to `fileName` [#765]
+_None._
 
 ### New Features
 
@@ -43,11 +42,22 @@ _None._
 
 ### Bug Fixes
 
-- Fix crash when querying a WordPress plugin whose slug is not url-safe. [#767]
+_None._
 
 ### Internal Changes
 
 _None._
+
+## 15.0.0
+
+### Breaking Changes
+
+- Reworked the `NSDate` RFC3339 / WordPress.com JSON conversions API [#759]
+- Changed `FilePart` `filename` property to `fileName` [#765]
+
+### Bug Fixes
+
+- Fix crash when querying a WordPress plugin whose slug is not url-safe. [#767]
 
 ## 14.1.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '15.0.0-beta.1'
+  s.version       = '15.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION

This version bump PR is part of the code freeze workflow for WordPress iOS 24.5 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.

See also #767 