### PR TITLE
Improve Insight entities parsing

### DIFF
--- a/Sources/WordPressKit/Models/Stats/Insights/StatsAllTimesInsight.swift
+++ b/Sources/WordPressKit/Models/Stats/Insights/StatsAllTimesInsight.swift
@@ -35,11 +35,11 @@ extension StatsAllTimesInsight: StatsInsightData {
         let rootContainer = try decoder.container(keyedBy: RootKeys.self)
         let container = try rootContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .stats)
 
-        self.postsCount = try container.decodeIfPresent(Int.self, forKey: .postsCount) ?? 0
-        self.bestViewsPerDayCount = try container.decode(Int.self, forKey: .bestViewsPerDayCount)
-        self.visitorsCount = try container.decodeIfPresent(Int.self, forKey: .visitorsCount) ?? 0
+        self.postsCount = (try? container.decodeIfPresent(Int.self, forKey: .postsCount)) ?? 0
+        self.bestViewsPerDayCount = (try? container.decodeIfPresent(Int.self, forKey: .bestViewsPerDayCount)) ?? 0
+        self.visitorsCount = (try? container.decodeIfPresent(Int.self, forKey: .visitorsCount)) ?? 0
 
-        self.viewsCount = try container.decodeIfPresent(Int.self, forKey: .viewsCount) ?? 0
+        self.viewsCount = (try? container.decodeIfPresent(Int.self, forKey: .viewsCount)) ?? 0
         let bestViewsDayString = try container.decodeIfPresent(String.self, forKey: .bestViewsDay) ?? ""
         self.bestViewsDay = StatsAllTimesInsight.dateFormatter.date(from: bestViewsDayString) ?? Date()
     }

--- a/Sources/WordPressKit/Models/Stats/Insights/StatsTagsAndCategoriesInsight.swift
+++ b/Sources/WordPressKit/Models/Stats/Insights/StatsTagsAndCategoriesInsight.swift
@@ -47,7 +47,7 @@ extension StatsTagAndCategory {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         let innerTags = try container.decodeIfPresent([StatsTagAndCategory].self, forKey: .children) ?? []
-        let viewsCount = try container.decodeIfPresent(Int.self, forKey: .viewsCount)
+        let viewsCount = (try? container.decodeIfPresent(Int.self, forKey: .viewsCount)) ?? 0
 
         // This gets kinda complicated. The API collects some tags/categories
         // into groups, and we have to handle that.


### PR DESCRIPTION
### Description

Make values and value-types optional when parsing Insight entity counts. 

Continuation of https://github.com/wordpress-mobile/WordPressKit-iOS/pull/763 related to a nit-pick comment https://github.com/wordpress-mobile/WordPressKit-iOS/pull/763#discussion_r1544973819

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
