### PR TITLE
SPM Prep - Use `WordPressComRESTAPIInterfacing` for all sync GET and POST requests in the Swift code

### DIFF
--- a/Sources/WordPressKit/Models/EditorSettings.swift
+++ b/Sources/WordPressKit/Models/EditorSettings.swift
@@ -36,7 +36,7 @@ public struct EditorSettings {
 }
 
 extension EditorSettings {
-    init(with response: AnyObject) throws {
+    init(with response: Any) throws {
         guard let response = response as? [String: AnyObject] else {
             throw NSError(domain: NSURLErrorDomain, code: NSURLErrorBadServerResponse, userInfo: nil)
         }

--- a/Sources/WordPressKit/Services/AtomicAuthenticationServiceRemote.swift
+++ b/Sources/WordPressKit/Services/AtomicAuthenticationServiceRemote.swift
@@ -3,7 +3,7 @@ import Foundation
 public class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
 
     public enum ResponseError: Error {
-        case responseIsNotADictionary(response: AnyObject)
+        case responseIsNotADictionary(response: Any)
         case decodingFailure(response: [String: AnyObject])
         case couldNotInstantiateCookie(name: String, value: String, domain: String, path: String, expires: Date)
     }
@@ -16,11 +16,9 @@ public class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/atomic-auth-proxy/read-access-cookies"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                 parameters: nil,
-                success: {
-                    responseObject, _ in
-
+                success: { responseObject, _ in
                     do {
                         let settings = try self.cookie(from: responseObject)
                         success(settings)
@@ -39,7 +37,7 @@ public class AtomicAuthenticationServiceRemote: ServiceRemoteWordPressComREST {
         return Date(timeIntervalSince1970: TimeInterval(expiration))
     }
 
-    private func cookie(from responseObject: AnyObject) throws -> HTTPCookie {
+    private func cookie(from responseObject: Any) throws -> HTTPCookie {
         guard let response = responseObject as? [String: AnyObject] else {
             let error = ResponseError.responseIsNotADictionary(response: responseObject)
             WPKitLogError("❗️Error: \(error)")

--- a/Sources/WordPressKit/Services/AtomicSiteServiceRemote.swift
+++ b/Sources/WordPressKit/Services/AtomicSiteServiceRemote.swift
@@ -23,7 +23,7 @@ public final class AtomicSiteServiceRemote: ServiceRemoteWordPressComREST {
         if let scrollID {
             parameters["scroll_id"] = scrollID
         }
-        wordPressComRestApi.GET(path, parameters: parameters as [String: AnyObject]) { responseObject, httpResponse in
+        wordPressComRESTAPI.get(path, parameters: parameters as [String: AnyObject]) { responseObject, httpResponse in
             guard (200..<300).contains(httpResponse?.statusCode ?? 0),
                   let data = (responseObject as? [String: AnyObject])?["data"],
                   JSONSerialization.isValidJSONObject(data) else {
@@ -67,7 +67,7 @@ public final class AtomicSiteServiceRemote: ServiceRemoteWordPressComREST {
         if let scrollID {
             parameters["scroll_id"] = scrollID
         }
-        wordPressComRestApi.GET(path, parameters: parameters as [String: AnyObject]) { responseObject, httpResponse in
+        wordPressComRESTAPI.get(path, parameters: parameters as [String: AnyObject]) { responseObject, httpResponse in
             guard (200..<300).contains(httpResponse?.statusCode ?? 0),
                   let data = (responseObject as? [String: AnyObject])?["data"],
                   JSONSerialization.isValidJSONObject(data) else {

--- a/Sources/WordPressKit/Services/AutomatedTransferService.swift
+++ b/Sources/WordPressKit/Services/AutomatedTransferService.swift
@@ -26,7 +26,7 @@ public class AutomatedTransferService: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/automated-transfers/eligibility"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject] else {
                 failure(.unknown)
                 return
@@ -53,7 +53,7 @@ public class AutomatedTransferService: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let payload = ["plugin": pluginSlug] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: payload, success: { (responseObject, _) in
+        wordPressComRESTAPI.post(path, parameters: payload, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -80,7 +80,7 @@ public class AutomatedTransferService: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/automated-transfers/status"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return

--- a/Sources/WordPressKit/Services/BlogJetpackSettingsServiceRemote.swift
+++ b/Sources/WordPressKit/Services/BlogJetpackSettingsServiceRemote.swift
@@ -13,13 +13,13 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
 
         let endpoint = "jetpack-blogs/\(siteID)/rest-api"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
-        let parameters = ["path": "/jetpack/v4/settings"]
+        let parameters: [String: Any] = ["path": "/jetpack/v4/settings"]
 
-        wordPressComRestApi.GET(path,
-                                parameters: parameters as [String: AnyObject]?,
-                                success: {
-                                    response, _ in
-                                    guard let results = response["data"] as? [String: AnyObject],
+        wordPressComRESTAPI.get(path,
+                                parameters: parameters,
+                                success: { response, _ in
+                                    guard let responseDict = response as? [String: Any],
+                                        let results = responseDict["data"] as? [String: AnyObject],
                                         let remoteSettings = try? self.remoteJetpackSettingsFromDictionary(results) else {
                                         failure(ResponseError.decodingFailure)
                                         return
@@ -38,11 +38,11 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "jetpack-blogs/\(siteID)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: nil,
-                                success: {
-                                    response, _ in
-                                    guard let results = response["settings"] as? [String: AnyObject],
+                                success: { response, _ in
+                                    guard let responseDict = response as? [String: Any],
+                                        let results = responseDict["settings"] as? [String: AnyObject],
                                         let remoteMonitorSettings = try? self.remoteJetpackMonitorSettingsFromDictionary(results) else {
                                         failure(ResponseError.decodingFailure)
                                         return
@@ -61,11 +61,11 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/jetpack/modules"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: nil,
-                                success: {
-                                    response, _ in
-                                    guard let modules = response["modules"] as? [[String: AnyObject]],
+                                success: { response, _ in
+                                    guard let responseDict = response as? [String: Any],
+                                        let modules = responseDict["modules"] as? [[String: AnyObject]],
                                         let remoteModulesSettings = try? self.remoteJetpackModulesSettingsFromArray(modules) else {
                                         failure(ResponseError.decodingFailure)
                                         return
@@ -94,7 +94,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
                           "body": jSONBody,
                           "json": true] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: parameters,
                                  success: {
                                      _, _  in
@@ -113,7 +113,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = dictionaryFromJetpackMonitorSettings(settings)
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: parameters,
                                  success: {
                                     _, _  in
@@ -131,7 +131,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = [ModuleOptionKeys.active: active]
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: parameters as [String: AnyObject],
                                  success: {
                                      _, _  in
@@ -148,7 +148,7 @@ public class BlogJetpackSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "jetpack-blogs/\(siteID)/mine/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: nil,
                                  success: {
                                      _, _  in

--- a/Sources/WordPressKit/Services/BloggingPromptsServiceRemote.swift
+++ b/Sources/WordPressKit/Services/BloggingPromptsServiceRemote.swift
@@ -108,7 +108,7 @@ open class BloggingPromptsServiceRemote: ServiceRemoteWordPressComREST {
             return
         }
 
-        wordPressComRestApi.POST(path, parameters: parameters) { responseObject, _ in
+        wordPressComRESTAPI.post(path, parameters: parameters) { responseObject, _ in
             do {
                 let data = try JSONSerialization.data(withJSONObject: responseObject)
                 let response = try JSONDecoder().decode(UpdateBloggingPromptsSettingsResponse.self, from: data)

--- a/Sources/WordPressKit/Services/DashboardServiceRemote.swift
+++ b/Sources/WordPressKit/Services/DashboardServiceRemote.swift
@@ -17,7 +17,7 @@ open class DashboardServiceRemote: ServiceRemoteWordPressComREST {
             failure(error)
         }
 
-        wordPressComRestApi.GET(requestUrl,
+        wordPressComRESTAPI.get(requestUrl,
                                 parameters: params,
                                 success: { response, _ in
             guard let cards = response as? NSDictionary else {

--- a/Sources/WordPressKit/Services/EditorServiceRemote.swift
+++ b/Sources/WordPressKit/Services/EditorServiceRemote.swift
@@ -6,7 +6,7 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/gutenberg?platform=mobile&editor=\(editor.rawValue)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, _) in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { (responseObject, _) in
             do {
                 let settings = try EditorSettings(with: responseObject)
                 success(settings)
@@ -28,7 +28,7 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
             "set_only_if_empty": setOnlyIfEmpty
         ] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { (responseObject, _) in
+        wordPressComRESTAPI.post(path, parameters: parameters, success: { (responseObject, _) in
             guard let response = responseObject as? [String: String] else {
                 if let boolResponse = responseObject as? Bool, boolResponse == false {
                     return failure(EditorSettings.Error.badRequest)
@@ -51,7 +51,7 @@ public class EditorServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/gutenberg"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { (responseObject, _) in
             do {
                 let settings = try EditorSettings(with: responseObject)
                 success(settings)

--- a/Sources/WordPressKit/Services/FeatureFlagRemote.swift
+++ b/Sources/WordPressKit/Services/FeatureFlagRemote.swift
@@ -21,7 +21,7 @@ open class FeatureFlagRemote: ServiceRemoteWordPressComREST {
             return
         }
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: dictionary,
                                 success: { response, _ in
 

--- a/Sources/WordPressKit/Services/HomepageSettingsServiceRemote.swift
+++ b/Sources/WordPressKit/Services/HomepageSettingsServiceRemote.swift
@@ -26,7 +26,7 @@ public class HomepageSettingsServiceRemote: ServiceRemoteWordPressComREST {
             parameters[Keys.pageForPostsID] = postsPageID as AnyObject
         }
 
-        wordPressComRestApi.POST(path, parameters: parameters,
+        wordPressComRESTAPI.post(path, parameters: parameters,
                                 success: { _, _ in
             success()
         }, failure: { error, _ in

--- a/Sources/WordPressKit/Services/JetpackBackupServiceRemote.swift
+++ b/Sources/WordPressKit/Services/JetpackBackupServiceRemote.swift
@@ -29,7 +29,7 @@ open class JetpackBackupServiceRemote: ServiceRemoteWordPressComREST {
             parameters["types"] = types.toDictionary() as AnyObject
         }
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { response, _ in
+        wordPressComRESTAPI.post(path, parameters: parameters, success: { response, _ in
             do {
                 let decoder = JSONDecoder.apiDecoder
                 let data = try JSONSerialization.data(withJSONObject: response, options: [])
@@ -88,7 +88,7 @@ open class JetpackBackupServiceRemote: ServiceRemoteWordPressComREST {
 
         let parameters = ["dismissed": true] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { _, _ in
+        wordPressComRESTAPI.post(path, parameters: parameters, success: { _, _ in
             success()
         }, failure: { error, _ in
             failure(error)
@@ -109,7 +109,7 @@ open class JetpackBackupServiceRemote: ServiceRemoteWordPressComREST {
             path = backupPath(for: siteID)
         }
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { response, _ in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { response, _ in
             do {
                 let decoder = JSONDecoder.apiDecoder
                 let data = try JSONSerialization.data(withJSONObject: response, options: [])

--- a/Sources/WordPressKit/Services/JetpackCapabilitiesServiceRemote.swift
+++ b/Sources/WordPressKit/Services/JetpackCapabilitiesServiceRemote.swift
@@ -19,7 +19,7 @@ open class JetpackCapabilitiesServiceRemote: ServiceRemoteWordPressComREST {
                 let endpoint = "sites/\(siteID)/rewind/capabilities"
                 let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-                self.wordPressComRestApi.GET(path,
+                self.wordPressComRESTAPI.get(path,
                                          parameters: nil,
                                          success: { response, _  in
                                             if let capabilities = (response as? [String: AnyObject])?["capabilities"] as? [String] {

--- a/Sources/WordPressKit/Services/JetpackProxyServiceRemote.swift
+++ b/Sources/WordPressKit/Services/JetpackProxyServiceRemote.swift
@@ -26,7 +26,7 @@ public class JetpackProxyServiceRemote: ServiceRemoteWordPressComREST {
                              method: DotComMethod,
                              parameters: [String: AnyHashable] = [:],
                              locale: String? = nil,
-                             completion: @escaping (Result<AnyObject, Error>) -> Void) -> Progress? {
+                             completion: @escaping (Result<Any, Error>) -> Void) -> Progress? {
         let urlString = self.path(forEndpoint: "jetpack-blogs/\(siteID)/rest-api", withVersion: ._1_1)
 
         // Construct the request parameters to be forwarded to the actual endpoint.
@@ -49,7 +49,7 @@ public class JetpackProxyServiceRemote: ServiceRemoteWordPressComREST {
             requestParams["locale"] = locale
         }
 
-        return wordPressComRestApi.POST(urlString, parameters: requestParams as [String: AnyObject]) { response, _ in
+        return wordPressComRESTAPI.post(urlString, parameters: requestParams) { response, _ in
             completion(.success(response))
         } failure: { error, _ in
             completion(.failure(error))

--- a/Sources/WordPressKit/Services/JetpackScanServiceRemote.swift
+++ b/Sources/WordPressKit/Services/JetpackScanServiceRemote.swift
@@ -19,8 +19,9 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
     public func startScanForSite(_ siteID: Int, success: @escaping(Bool) -> Void, failure: @escaping(Error) -> Void) {
         let path = self.scanPath(for: siteID, with: "enqueue")
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (response, _) in
-            guard let responseValue = response["success"] as? Bool else {
+        wordPressComRESTAPI.post(path, parameters: nil, success: { (response, _) in
+            guard let responseDict = response as? [String: Any],
+                let responseValue = responseDict["success"] as? Bool else {
                 success(false)
                 return
             }
@@ -35,7 +36,7 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
     public func getScanForSite(_ siteID: Int, success: @escaping(JetpackScan) -> Void, failure: @escaping(Error) -> Void) {
         let path = self.scanPath(for: siteID)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (response, _) in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { (response, _) in
             do {
                 let decoder = JSONDecoder.apiDecoder
                 let data = try JSONSerialization.data(withJSONObject: response, options: [])
@@ -67,7 +68,7 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: "sites/\(siteID)/alerts/fix", withVersion: ._2_0)
         let parameters = ["threat_ids": threats.map { $0.id as AnyObject }] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { (response, _) in
+        wordPressComRESTAPI.post(path, parameters: parameters, success: { (response, _) in
             do {
                 let decoder = JSONDecoder.apiDecoder
                 let data = try JSONSerialization.data(withJSONObject: response, options: [])
@@ -101,7 +102,7 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: "sites/\(siteID)/alerts/\(threat.id)", withVersion: ._2_0)
         let parameters = ["ignore": true] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { (_, _) in
+        wordPressComRESTAPI.post(path, parameters: parameters, success: { (_, _) in
             success()
         }, failure: { (error, _) in
             failure(error)
@@ -113,7 +114,7 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: "sites/\(siteID)/alerts/fix", withVersion: ._2_0)
         let parameters = ["threat_ids": threats.map { $0.id as AnyObject }] as [String: AnyObject]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { (response, _) in
+        wordPressComRESTAPI.get(path, parameters: parameters, success: { (response, _) in
             do {
                 let decoder = JSONDecoder.apiDecoder
                 let data = try JSONSerialization.data(withJSONObject: response, options: [])
@@ -132,7 +133,7 @@ public class JetpackScanServiceRemote: ServiceRemoteWordPressComREST {
     public func getHistoryForSite(_ siteID: Int, success: @escaping(JetpackScanHistory) -> Void, failure: @escaping(Error) -> Void) {
         let path = scanPath(for: siteID, with: "history")
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (response, _) in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { (response, _) in
             do {
                 let decoder = JSONDecoder.apiDecoder
                 let data = try JSONSerialization.data(withJSONObject: response, options: [])

--- a/Sources/WordPressKit/Services/NotificationSettingsServiceRemote.swift
+++ b/Sources/WordPressKit/Services/NotificationSettingsServiceRemote.swift
@@ -25,14 +25,14 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let path = String(format: "me/notifications/settings/?device_id=%@", deviceId)
         let requestUrl = self.path(forEndpoint: path, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(requestUrl,
+        wordPressComRESTAPI.get(requestUrl,
             parameters: nil,
-            success: { (response: AnyObject, _: HTTPURLResponse?) -> Void in
+            success: { response, _ in
                 let settings = RemoteNotificationSettings.fromDictionary(response as? NSDictionary)
                 success?(settings)
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) -> Void in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
             })
     }
 
@@ -49,13 +49,13 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
 
         let parameters = settings
 
-        wordPressComRestApi.POST(requestUrl,
+        wordPressComRESTAPI.post(requestUrl,
             parameters: parameters,
-            success: { (_: AnyObject, _: HTTPURLResponse?) -> Void in
+            success: { _, _ in
                 success?()
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) -> Void in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
             })
     }
 
@@ -83,9 +83,9 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
             "device_uuid": device.wordPressIdentifier()
         ]
 
-        wordPressComRestApi.POST(requestUrl,
-            parameters: parameters as [String: AnyObject]?,
-            success: { (response: AnyObject, _: HTTPURLResponse?) -> Void in
+        wordPressComRESTAPI.post(requestUrl,
+            parameters: parameters as [String: Any],
+            success: { response, _ in
                 if let responseDict = response as? NSDictionary,
                     let rawDeviceId = responseDict.object(forKey: "ID") {
                     // Failsafe: Make sure deviceId is always a string
@@ -98,8 +98,8 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
                     failure?(outerError)
                 }
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) -> Void in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
             })
     }
 
@@ -114,13 +114,13 @@ open class NotificationSettingsServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = String(format: "devices/%@/delete", deviceId)
         let requestUrl = path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(requestUrl,
+        wordPressComRESTAPI.post(requestUrl,
             parameters: nil,
-            success: { (_: AnyObject!, _: HTTPURLResponse?) -> Void in
+            success: { _, _ in
                 success?()
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) -> Void in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
             })
     }
 

--- a/Sources/WordPressKit/Services/NotificationSyncServiceRemote.swift
+++ b/Sources/WordPressKit/Services/NotificationSyncServiceRemote.swift
@@ -88,7 +88,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
 
         let parameters = ["counts": notifications]
 
-        wordPressComRestApi.POST(requestUrl, parameters: parameters as [String: AnyObject]?, success: { (response, _)  in
+        wordPressComRESTAPI.post(requestUrl, parameters: parameters as [String: AnyObject]?, success: { (response, _)  in
             let error = self.errorFromResponse(response)
             completion(error)
 
@@ -111,7 +111,7 @@ public class NotificationSyncServiceRemote: ServiceRemoteWordPressComREST {
             "time": timestamp
         ]
 
-        wordPressComRestApi.POST(requestUrl, parameters: parameters as [String: AnyObject]?, success: { (response, _)  in
+        wordPressComRESTAPI.post(requestUrl, parameters: parameters as [String: AnyObject]?, success: { (response, _)  in
             let error = self.errorFromResponse(response)
             completion(error)
 
@@ -131,7 +131,7 @@ private extension NotificationSyncServiceRemote {
     ///
     /// - Returns: SyncError.failed whenever the success field is either missing, or set to false.
     ///
-    func errorFromResponse(_ response: AnyObject) -> Error? {
+    func errorFromResponse(_ response: Any) -> Error? {
         let document = response as? [String: AnyObject]
         let success = document?["success"] as? Bool
         guard success != true else {
@@ -166,7 +166,7 @@ private extension NotificationSyncServiceRemote {
             parameters["fields"] = fields as AnyObject?
         }
 
-        wordPressComRestApi.GET(requestUrl, parameters: parameters, success: { response, _  in
+        wordPressComRESTAPI.get(requestUrl, parameters: parameters, success: { response, _  in
             let document = response as? [String: AnyObject]
             let notes = document?["notes"] as? [[String: AnyObject]]
             let parsed = notes?.compactMap { RemoteNotification(document: $0) }

--- a/Sources/WordPressKit/Services/PeopleServiceRemote.swift
+++ b/Sources/WordPressKit/Services/PeopleServiceRemote.swift
@@ -40,7 +40,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "fields": "ID, nice_name, first_name, last_name, name, avatar_URL, roles, is_super_admin, linked_user_ID" as AnyObject
         ]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(path, parameters: parameters, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                 let users = response["users"] as? [[String: AnyObject]],
                 let people = try? self.peopleFromResponse(users, siteID: siteID, type: User.self) else {
@@ -81,7 +81,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "fields": "ID, nice_name, first_name, last_name, name, avatar_URL" as AnyObject
         ]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(path, parameters: parameters, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                 let followers = response["users"] as? [[String: AnyObject]],
                 let people = try? self.peopleFromResponse(followers, siteID: siteID, type: Follower.self) else {
@@ -119,7 +119,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "type": "email" as AnyObject
         ]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { responseObject, _ in
+        wordPressComRESTAPI.get(path, parameters: parameters, success: { responseObject, _ in
             guard let response = responseObject as? [String: AnyObject],
                   let subscribers = response["subscribers"] as? [[String: AnyObject]],
                   let totalPages = response["pages"] as? Int else {
@@ -158,7 +158,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "page": pageNumber as AnyObject
         ]
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { responseObject, _ in
+        wordPressComRESTAPI.get(path, parameters: parameters, success: { responseObject, _ in
             guard let response = responseObject as? [String: AnyObject],
                 let viewers = response["viewers"] as? [[String: AnyObject]],
                 let people = try? self.peopleFromResponse(viewers, siteID: siteID, type: Viewer.self) else {
@@ -194,7 +194,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = ["roles": [newRole]]
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                 parameters: parameters as [String: AnyObject]?,
                 success: { (responseObject, _) in
                     guard let response = responseObject as? [String: AnyObject],
@@ -233,7 +233,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             parameters["reassign"] = reassignID as AnyObject?
         }
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (_, _) in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { (_, _) in
             success?()
         }, failure: { (error, _) in
             failure?(error)
@@ -255,7 +255,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/followers/\(userID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (_, _) in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { (_, _) in
             success?()
         }, failure: { (error, _) in
             failure?(error)
@@ -277,7 +277,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/email-followers/\(userID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { _, _ in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { _, _ in
             success?()
         }, failure: { error, _ in
             failure?(error)
@@ -299,7 +299,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/viewers/\(userID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (_, _) in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { (_, _) in
             success?()
         }, failure: { (error, _) in
             failure?(error)
@@ -321,7 +321,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/roles"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                     let roles = try? self.rolesFromResponse(response) else {
                 failure?(ResponseError.decodingFailure)
@@ -356,7 +356,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "role": role
         ]
 
-        wordPressComRestApi.POST(path, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
+        wordPressComRESTAPI.post(path, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
             guard let responseDict = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -399,7 +399,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "message": message
         ]
 
-        wordPressComRestApi.POST(path, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
+        wordPressComRESTAPI.post(path, parameters: parameters as [String: AnyObject]?, success: { (responseObject, _) in
             guard let responseDict = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -435,7 +435,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
             "number": 100
         ] as [String: AnyObject]
 
-        wordPressComRestApi.GET(path, parameters: params, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(path, parameters: params, success: { (responseObject, _) in
             guard let responseDict = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -467,7 +467,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/invites/links/generate"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, _) in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { (responseObject, _) in
             guard let responseArray = responseObject as? [[String: AnyObject]] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -498,7 +498,7 @@ public class PeopleServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/invites/links/disable"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { (responseObject, _) in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { (responseObject, _) in
             let deletedKeys = responseObject as? [String] ?? [String]()
             success(deletedKeys)
 

--- a/Sources/WordPressKit/Services/Plans/PlanServiceRemote.swift
+++ b/Sources/WordPressKit/Services/Plans/PlanServiceRemote.swift
@@ -23,7 +23,7 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "plans/mobile"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: nil,
                                 success: {
                                     response, _ in
@@ -56,7 +56,7 @@ public class PlanServiceRemote: ServiceRemoteWordPressComREST {
             "locale": locale
         ]
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: parameters as [String: AnyObject],
                                 success: {
                                     response, _ in

--- a/Sources/WordPressKit/Services/Plans/PlanServiceRemote_ApiVersion1_3.swift
+++ b/Sources/WordPressKit/Services/Plans/PlanServiceRemote_ApiVersion1_3.swift
@@ -11,11 +11,10 @@ import WordPressShared
         let endpoint = "sites/\(siteID)/plans"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_3)
 
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             path,
             parameters: nil,
-            success: {
-                response, _ in
+            success: { response, _ in
                 do {
                     try success(PlanServiceRemote_ApiVersion1_3.mapPlansResponse(response))
                 } catch {
@@ -25,14 +24,13 @@ import WordPressShared
                     failure(error)
                 }
             },
-            failure: {
-                error, _ in
+            failure: { error, _ in
                 failure(error)
             }
         )
     }
 
-    private static func mapPlansResponse(_ response: AnyObject) throws
+    private static func mapPlansResponse(_ response: Any) throws
         -> (activePlan: RemotePlan_ApiVersion1_3, availablePlans: [RemotePlan_ApiVersion1_3]) {
 
         guard let json = response as? [String: AnyObject] else {

--- a/Sources/WordPressKit/Services/PluginServiceRemote.swift
+++ b/Sources/WordPressKit/Services/PluginServiceRemote.swift
@@ -11,7 +11,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
     public func getFeaturedPlugins(success: @escaping ([PluginDirectoryEntry]) -> Void, failure: @escaping (Error) -> Void) {
         let endpoint = "wpcom/v2/plugins/featured"
 
-        wordPressComRestApi.GET(endpoint, parameters: nil, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(endpoint, parameters: nil, success: { (responseObject, _) in
             guard let response = responseObject as? [[String: AnyObject]] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -33,7 +33,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_2)
         let parameters = [String: AnyObject]()
 
-        wordPressComRestApi.GET(path, parameters: parameters, success: { (responseObject, _) in
+        wordPressComRESTAPI.get(path, parameters: parameters, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject] else {
                 failure(ResponseError.decodingFailure)
                 return
@@ -59,7 +59,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_2)
         let parameters = [String: AnyObject]()
 
-        wordPressComRestApi.POST(
+        wordPressComRESTAPI.post(
             path,
             parameters: parameters,
             success: { (responseObject, _)  in
@@ -120,7 +120,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/plugins/\(pluginSlug)/install"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_2)
 
-        wordPressComRestApi.POST(
+        wordPressComRESTAPI.post(
             path,
             parameters: nil,
             success: { responseObject, _  in
@@ -148,7 +148,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/plugins/\(escapedPluginID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_2)
 
-        wordPressComRestApi.POST(
+        wordPressComRESTAPI.post(
             path,
             parameters: nil,
             success: { _, _  in
@@ -167,7 +167,7 @@ public class PluginServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/plugins/\(escapedPluginID)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_2)
 
-        wordPressComRestApi.POST(
+        wordPressComRESTAPI.post(
             path,
             parameters: parameters,
             success: { _, _  in

--- a/Sources/WordPressKit/Services/PostServiceRemoteREST+Revisions.swift
+++ b/Sources/WordPressKit/Services/PostServiceRemoteREST+Revisions.swift
@@ -7,7 +7,7 @@ public extension PostServiceRemoteREST {
                                  failure: @escaping (Error?) -> Void) {
         let endpoint = "sites/\(siteId)/post/\(postId)/diffs"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: nil,
                                 success: { (response, _) in
                                     do {
@@ -31,7 +31,7 @@ public extension PostServiceRemoteREST {
     func getPostLatestRevisionID(for postId: NSNumber, success: @escaping (NSNumber?) -> Void, failure: @escaping (Error?) -> Void) {
         let endpoint = "sites/\(siteID)/posts/\(postId)"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             path,
             parameters: [
                 "context": "edit",

--- a/Sources/WordPressKit/Services/ProductServiceRemote.swift
+++ b/Sources/WordPressKit/Services/ProductServiceRemote.swift
@@ -41,7 +41,7 @@ open class ProductServiceRemote {
     open func getProducts(completion: @escaping (Result<[Product], Error>) -> Void) {
         let path = serviceRemote.path(forEndpoint: "products", withVersion: ._1_1)
 
-        serviceRemote.wordPressComRestApi.GET(
+        serviceRemote.wordPressComRESTAPI.get(
             path,
             parameters: [:],
             success: { responseProducts, _ in

--- a/Sources/WordPressKit/Services/PushAuthenticationServiceRemote.swift
+++ b/Sources/WordPressKit/Services/PushAuthenticationServiceRemote.swift
@@ -20,11 +20,11 @@ import Foundation
             "push_token": token
         ]
 
-        wordPressComRestApi.POST(requestUrl, parameters: parameters as [String: AnyObject],
-                                 success: { (_: AnyObject, _: HTTPURLResponse?) -> Void in
+        wordPressComRESTAPI.post(requestUrl, parameters: parameters,
+                                 success: { _, _ in
                                     success?()
                                  },
-                                 failure: { (_: NSError, _: HTTPURLResponse?) -> Void in
+                                 failure: { _, _ in
                                     failure?()
                                  })
     }

--- a/Sources/WordPressKit/Services/QR Login/QRLoginServiceRemote.swift
+++ b/Sources/WordPressKit/Services/QR Login/QRLoginServiceRemote.swift
@@ -7,7 +7,7 @@ open class QRLoginServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: "auth/qr-code/validate", withVersion: ._2_0)
         let parameters = [ "token": token, "data": data ] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters as [String: AnyObject], success: { (response, _) in
+        wordPressComRESTAPI.post(path, parameters: parameters as [String: AnyObject], success: { (response, _) in
             do {
                 let decoder = JSONDecoder.apiDecoder
                 let data = try JSONSerialization.data(withJSONObject: response, options: [])
@@ -33,8 +33,9 @@ open class QRLoginServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: "auth/qr-code/authenticate", withVersion: ._2_0)
         let parameters = [ "token": token, "data": data ] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { (response, _) in
-            guard let authenticated = response["authenticated"] as? Bool else {
+        wordPressComRESTAPI.post(path, parameters: parameters, success: { (response, _) in
+            guard let responseDict = response as? [String: Any],
+                let authenticated = responseDict["authenticated"] as? Bool else {
                 success(false)
                 return
             }

--- a/Sources/WordPressKit/Services/ReaderPostServiceRemote+RelatedPosts.swift
+++ b/Sources/WordPressKit/Services/ReaderPostServiceRemote+RelatedPosts.swift
@@ -24,7 +24,7 @@ extension ReaderPostServiceRemote {
             "size_global": count
         ] as [String: AnyObject]
 
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             path,
             parameters: parameters,
             success: { (response, _) in

--- a/Sources/WordPressKit/Services/ReaderPostServiceRemote+Subscriptions.swift
+++ b/Sources/WordPressKit/Services/ReaderPostServiceRemote+Subscriptions.swift
@@ -28,7 +28,7 @@ extension ReaderPostServiceRemote {
                                               failure: @escaping (Error?) -> Void) {
         let path = self.path(forEndpoint: "sites/\(siteID)/posts/\(postID)/subscribers/mine", withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: nil, success: { response, _ in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { response, _ in
             do {
                 guard let responseObject = response as? [String: AnyObject],
                     let isSubscribed = responseObject[Constants.isSubscribed] as? Bool else {
@@ -58,7 +58,7 @@ extension ReaderPostServiceRemote {
                                       failure: @escaping (Error?) -> Void) {
         let path = self.path(forEndpoint: "sites/\(siteID)/posts/\(postID)/subscribers/new", withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { response, _ in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { response, _ in
             do {
                 guard let responseObject = response as? [String: AnyObject],
                     let subscribed = responseObject[Constants.success] as? Bool else {
@@ -88,7 +88,7 @@ extension ReaderPostServiceRemote {
                                           failure: @escaping (Error) -> Void) {
         let path = self.path(forEndpoint: "sites/\(siteID)/posts/\(postID)/subscribers/mine/delete", withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path, parameters: nil, success: { response, _ in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { response, _ in
             do {
                 guard let responseObject = response as? [String: AnyObject],
                     let unsubscribed = responseObject[Constants.success] as? Bool else {
@@ -125,7 +125,7 @@ extension ReaderPostServiceRemote {
                                                       failure: @escaping (Error?) -> Void) {
         let path = self.path(forEndpoint: "sites/\(siteID)/posts/\(postID)/subscribers/mine/update", withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: [Constants.receiveNotificationsRequestKey: receiveNotifications] as [String: AnyObject],
                                  success: { response, _ in
             guard let responseObject = response as? [String: AnyObject],

--- a/Sources/WordPressKit/Services/ReaderPostServiceRemote+V2.swift
+++ b/Sources/WordPressKit/Services/ReaderPostServiceRemote+V2.swift
@@ -15,11 +15,12 @@ extension ReaderPostServiceRemote {
             return
         }
 
-        wordPressComRestApi.GET(requestUrl,
+        wordPressComRESTAPI.get(requestUrl,
                                 parameters: nil,
                                 success: { response, _ in
-                                    let nextPageHandle = response["next_page_handle"] as? String
-                                    let postsDictionary = response["posts"] as? [[String: Any]]
+                                    let responseDict = response as? [String: Any]
+                                    let nextPageHandle = responseDict?["next_page_handle"] as? String
+                                    let postsDictionary = responseDict?["posts"] as? [[String: Any]]
                                     let posts = postsDictionary?.compactMap { RemoteReaderPost(dictionary: $0) } ?? []
                                     success(posts, nextPageHandle)
         }, failure: { error, _ in
@@ -99,7 +100,7 @@ extension ReaderPostServiceRemote {
 
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.POST(path, parameters: params, success: { (responseObject, _) in
+        wordPressComRESTAPI.post(path, parameters: params, success: { (responseObject, _) in
             guard let response = responseObject as? [String: AnyObject],
                   let status = response["status"] as? Bool,
                   status == true else {

--- a/Sources/WordPressKit/Services/ReaderSiteSearchServiceRemote.swift
+++ b/Sources/WordPressKit/Services/ReaderSiteSearchServiceRemote.swift
@@ -34,7 +34,7 @@ public class ReaderSiteSearchServiceRemote: ServiceRemoteWordPressComREST {
             "q": query as AnyObject
         ]
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: parameters,
                                 success: { response, _ in
                                     do {
@@ -53,7 +53,7 @@ public class ReaderSiteSearchServiceRemote: ServiceRemoteWordPressComREST {
 
 private extension ReaderSiteSearchServiceRemote {
 
-    func mapSearchResponse(_ response: AnyObject) throws -> ([ReaderFeed], Int) {
+    func mapSearchResponse(_ response: Any) throws -> ([ReaderFeed], Int) {
         do {
             let decoder = JSONDecoder()
             let data = try JSONSerialization.data(withJSONObject: response, options: [])

--- a/Sources/WordPressKit/Services/ReaderTopicServiceRemote+Interests.swift
+++ b/Sources/WordPressKit/Services/ReaderTopicServiceRemote+Interests.swift
@@ -9,7 +9,7 @@ extension ReaderTopicServiceRemote {
                                failure: @escaping (Error) -> Void) {
         let path = self.path(forEndpoint: "read/interests", withVersion: ._2_0)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: nil,
                                 success: { response, _ in
                                     do {
@@ -36,7 +36,7 @@ extension ReaderTopicServiceRemote {
         let path = self.path(forEndpoint: "read/tags/mine/new", withVersion: ._1_2)
         let parameters = ["tags": withSlugs] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path, parameters: parameters, success: { _, _ in
+        wordPressComRESTAPI.post(path, parameters: parameters, success: { _, _ in
             success()
         }) { error, _ in
             WPKitLogError("Error fetching reader interests: \(error)")
@@ -50,6 +50,6 @@ extension ReaderTopicServiceRemote {
     public func pathForTopic(slug: String) -> String {
         let endpoint = path(forEndpoint: "read/tags/\(slug)/posts", withVersion: ._1_2)
 
-        return wordPressComRestApi.baseURL.appendingPathComponent(endpoint).absoluteString
+        return wordPressComRESTAPI.baseURL.appendingPathComponent(endpoint).absoluteString
     }
 }

--- a/Sources/WordPressKit/Services/ReaderTopicServiceRemote+Subscription.swift
+++ b/Sources/WordPressKit/Services/ReaderTopicServiceRemote+Subscription.swift
@@ -84,7 +84,7 @@ extension ReaderTopicServiceRemote {
 
         WPKitLogInfo("URL: \(urlRequest)")
 
-        wordPressComRestApi.POST(urlRequest, parameters: parameters, success: { (_, response) in
+        wordPressComRESTAPI.post(urlRequest, parameters: parameters, success: { (_, response) in
             WPKitLogInfo("Success \(response?.url?.absoluteString ?? "unknown url")")
             success()
         }) { (error, response) in

--- a/Sources/WordPressKit/Services/RemoteConfigRemote.swift
+++ b/Sources/WordPressKit/Services/RemoteConfigRemote.swift
@@ -14,7 +14,7 @@ open class RemoteConfigRemote: ServiceRemoteWordPressComREST {
         let endpoint = "mobile/remote-config"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: nil,
                                 success: { response, _ in
             if let remoteConfigDictionary = response as? [String: Any] {

--- a/Sources/WordPressKit/Services/SharingServiceRemote.swift
+++ b/Sources/WordPressKit/Services/SharingServiceRemote.swift
@@ -44,7 +44,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let params = ["type": "publicize"]
 
-        wordPressComRestApi.GET(path, parameters: params as [String: AnyObject]?) { responseObject, httpResponse in
+        wordPressComRESTAPI.get(path, parameters: params as [String: AnyObject]?) { responseObject, httpResponse in
             guard let responseDict = responseObject as? NSDictionary else {
                 failure?(self.errorForUnexpectedResponse(httpResponse))
                 return
@@ -53,7 +53,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
             success?(self.remotePublicizeServicesFromDictionary(responseDict))
 
         } failure: { error, _ in
-            failure?(error)
+            failure?(error as NSError)
         }
     }
 
@@ -69,7 +69,7 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let path = path(forEndpoint: "sites/\(siteID)/external-services", withVersion: ._2_0)
         let params = ["type": "publicize" as AnyObject]
 
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             path,
             parameters: params,
             success: { response, httpResponse in
@@ -96,9 +96,9 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "me/keyring-connections"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
             parameters: nil,
-            success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+            success: { responseObject, httpResponse in
                 guard let onSuccess = success else {
                     return
                 }
@@ -133,8 +133,8 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                 onSuccess(keyringConnections)
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
         })
     }
 
@@ -170,9 +170,9 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/publicize-connections"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
             parameters: nil,
-            success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+            success: { responseObject, httpResponse in
                 guard let onSuccess = success else {
                     return
                 }
@@ -190,8 +190,8 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                 onSuccess(publicizeConnections)
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
         })
     }
 
@@ -218,9 +218,9 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                 parameters[PublicizeConnectionParams.externalUserID] = userID as AnyObject?
             }
 
-            wordPressComRestApi.POST(path,
+            wordPressComRESTAPI.post(path,
                 parameters: parameters,
-                success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+                success: { responseObject, httpResponse in
                     guard let onSuccess = success else {
                         return
                     }
@@ -233,8 +233,8 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                     onSuccess(conn)
                 },
-                failure: { (error: NSError, _: HTTPURLResponse?) in
-                    failure?(error)
+                failure: { error, _ in
+                    failure?(error as NSError)
             })
     }
 
@@ -262,9 +262,9 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                 PublicizeConnectionParams.externalUserID: externalUserID
             ]
 
-            wordPressComRestApi.POST(path,
+            wordPressComRESTAPI.post(path,
                 parameters: parameters as [String: AnyObject]?,
-                success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+                success: { responseObject, httpResponse in
                     guard let onSuccess = success else {
                         return
                     }
@@ -277,8 +277,8 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                     onSuccess(conn)
                 },
-                failure: { (error: NSError, _: HTTPURLResponse?) in
-                    failure?(error)
+                failure: { error, _ in
+                    failure?(error as NSError)
             })
     }
 
@@ -302,9 +302,9 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
                 PublicizeConnectionParams.shared: shared
             ]
 
-            wordPressComRestApi.POST(path,
+            wordPressComRESTAPI.post(path,
                 parameters: parameters as [String: AnyObject]?,
-                success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+                success: { responseObject, httpResponse in
                     guard let onSuccess = success else {
                         return
                     }
@@ -317,8 +317,8 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                     onSuccess(conn)
                 },
-                failure: { (error: NSError, _: HTTPURLResponse?) in
-                    failure?(error)
+                failure: { error, _ in
+                    failure?(error as NSError)
             })
     }
 
@@ -334,13 +334,13 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/publicize-connections/\(connectionID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
             parameters: nil,
-            success: { (_: AnyObject, _: HTTPURLResponse?) in
+            success: { _, _ in
                 success?()
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
         })
     }
 
@@ -405,9 +405,9 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/sharing-buttons"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
             parameters: nil,
-            success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+            success: { responseObject, httpResponse in
                 guard let onSuccess = success else {
                     return
                 }
@@ -422,8 +422,8 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                 onSuccess(sharingButtons)
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
         })
     }
 
@@ -441,9 +441,9 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
         let buttons = dictionariesFromRemoteSharingButtons(sharingButtons)
         let parameters = [SharingButtonsKeys.sharingButtons: buttons]
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
             parameters: parameters as [String: AnyObject]?,
-            success: { (responseObject: AnyObject, httpResponse: HTTPURLResponse?) in
+            success: { responseObject, httpResponse in
                 guard let onSuccess = success else {
                     return
                 }
@@ -458,8 +458,8 @@ open class SharingServiceRemote: ServiceRemoteWordPressComREST {
 
                 onSuccess(sharingButtons)
             },
-            failure: { (error: NSError, _: HTTPURLResponse?) in
-                failure?(error)
+            failure: { error, _ in
+                failure?(error as NSError)
         })
     }
 

--- a/Sources/WordPressKit/Services/SiteManagementServiceRemote.swift
+++ b/Sources/WordPressKit/Services/SiteManagementServiceRemote.swift
@@ -14,7 +14,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/delete"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
             parameters: nil,
             success: { response, _ in
                 guard let results = response as? [String: AnyObject] else {
@@ -33,7 +33,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
                 success?()
             },
             failure: { error, _ in
-                failure?(error)
+                failure?(error as NSError)
             })
     }
 
@@ -50,7 +50,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/exports/start"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
             parameters: nil,
             success: { response, _ in
                 guard let results = response as? [String: AnyObject] else {
@@ -69,7 +69,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
                 success?()
             },
             failure: { error, _ in
-                failure?(error)
+                failure?(error as NSError)
         })
     }
 
@@ -84,7 +84,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
         let endpoint = "sites/\(siteID)/purchases"
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
             parameters: nil,
             success: { response, _ in
                 guard let results = response as? [SitePurchase] else {
@@ -96,7 +96,7 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
                 success?(actives)
             },
             failure: { error, _ in
-                failure?(error)
+                failure?(error as NSError)
         })
     }
 
@@ -112,13 +112,13 @@ open class SiteManagementServiceRemote: ServiceRemoteWordPressComREST {
         let path = self.path(forEndpoint: endpoint, withVersion: ._1_1)
         let parameters = ["variant": "next-steps"] as [String: AnyObject]
 
-        wordPressComRestApi.POST(path,
+        wordPressComRESTAPI.post(path,
                                  parameters: parameters,
                                  success: { _, _ in
                                     success?()
         },
                                  failure: { error, _ in
-                                    failure?(error)
+                                    failure?(error as NSError)
         })
     }
 

--- a/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
+++ b/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
@@ -48,7 +48,7 @@ open class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
 
         let path = self.path(forEndpoint: "sites/\(siteID)/\(pathComponent)/", withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: properties, success: { (response, _) in
+        wordPressComRESTAPI.get(path, parameters: properties, success: { (response, _) in
             guard
                 let jsonResponse = response as? [String: AnyObject],
                 let insight = InsightType(jsonDictionary: jsonResponse)
@@ -72,7 +72,7 @@ open class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
                                 success: @escaping () -> Void,
                                 failure: @escaping (Error) -> Void) {
         let path = pathForToggleSpamStateEndpoint(referrerDomain: referrerDomain, markAsSpam: !currentValue)
-        wordPressComRestApi.POST(path, parameters: nil, success: { object, _ in
+        wordPressComRESTAPI.post(path, parameters: nil, success: { object, _ in
             guard
                 let dictionary = object as? [String: AnyObject],
                 let response = MarkAsSpamResponse(dictionary: dictionary) else {
@@ -117,7 +117,7 @@ open class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
             return val1
         }
 
-        wordPressComRestApi.GET(path, parameters: properties, success: { [weak self] (response, _) in
+        wordPressComRESTAPI.get(path, parameters: properties, success: { [weak self] (response, _) in
             guard
                 let self,
                 let jsonResponse = response as? [String: AnyObject],
@@ -153,7 +153,7 @@ open class StatsServiceRemoteV2: ServiceRemoteWordPressComREST {
     public func getDetails(forPostID postID: Int, completion: @escaping ((StatsPostDetails?, Error?) -> Void)) {
         let path = self.path(forEndpoint: "sites/\(siteID)/stats/post/\(postID)/", withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: [:], success: { (response, _) in
+        wordPressComRESTAPI.get(path, parameters: [:], success: { (response, _) in
             guard
                 let jsonResponse = response as? [String: AnyObject],
                 let postDetails = StatsPostDetails(jsonDictionary: jsonResponse)
@@ -183,7 +183,7 @@ extension StatsServiceRemoteV2 {
         let pathComponent = StatsLastPostInsight.pathComponent
         let path = self.path(forEndpoint: "sites/\(siteID)/\(pathComponent)", withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path, parameters: properties, success: { (response, _) in
+        wordPressComRESTAPI.get(path, parameters: properties, success: { (response, _) in
             guard let jsonResponse = response as? [String: AnyObject],
                   let postCount = jsonResponse["found"] as? Int else {
                 completion(nil, ResponseError.decodingFailure)
@@ -224,7 +224,7 @@ extension StatsServiceRemoteV2 {
 
         let path = self.path(forEndpoint: "sites/\(siteID)/stats/post/\(postID)", withVersion: ._1_1)
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: parameters,
                                 success: { (response, _) in
                                     guard
@@ -259,7 +259,7 @@ extension StatsServiceRemoteV2 {
                           "after": ISO8601DateFormatter().string(from: startDate(for: period, endDate: endingOn)),
                           "before": ISO8601DateFormatter().string(from: endingOn)] as [String: AnyObject]
 
-        wordPressComRestApi.GET(path,
+        wordPressComRESTAPI.get(path,
                                 parameters: properties,
                                 success: { (response, _) in
                                     guard

--- a/Sources/WordPressKit/Services/TimeZoneServiceRemote.swift
+++ b/Sources/WordPressKit/Services/TimeZoneServiceRemote.swift
@@ -9,7 +9,7 @@ public class TimeZoneServiceRemote: ServiceRemoteWordPressComREST {
     public func getTimezones(success: @escaping (([TimeZoneGroup]) -> Void), failure: @escaping ((Error) -> Void)) {
         let endpoint = "timezones"
         let path = self.path(forEndpoint: endpoint, withVersion: ._2_0)
-        wordPressComRestApi.GET(path, parameters: nil, success: { (response, _) in
+        wordPressComRESTAPI.get(path, parameters: nil, success: { (response, _) in
             do {
                 let groups = try self.timezoneGroupsFromResponse(response)
                 success(groups)
@@ -23,7 +23,7 @@ public class TimeZoneServiceRemote: ServiceRemoteWordPressComREST {
 }
 
 private extension TimeZoneServiceRemote {
-    func timezoneGroupsFromResponse(_ response: AnyObject) throws -> [TimeZoneGroup] {
+    func timezoneGroupsFromResponse(_ response: Any) throws -> [TimeZoneGroup] {
         guard let response = response as? [String: Any],
             let timeZonesByContinent = response["timezones_by_continent"] as? [String: [[String: String]]],
             let manualUTCOffsets = response["manual_utc_offsets"] as? [[String: String]] else {

--- a/Sources/WordPressKit/Services/TransactionsServiceRemote.swift
+++ b/Sources/WordPressKit/Services/TransactionsServiceRemote.swift
@@ -16,7 +16,7 @@ import WordPressShared
         let endPoint = "me/transactions/supported-countries/"
         let servicePath = path(forEndpoint: endPoint, withVersion: ._1_1)
 
-        wordPressComRestApi.GET(servicePath,
+        wordPressComRESTAPI.get(servicePath,
                                 parameters: nil,
                                 success: {
                                     response, _ in
@@ -69,7 +69,7 @@ import WordPressShared
         let parameters: [String: AnyObject] = ["temporary": (temporary ? "true" : "false") as AnyObject,
                                                "products": productsDictionary as AnyObject]
 
-        wordPressComRestApi.POST(urlPath,
+        wordPressComRESTAPI.post(urlPath,
                                  parameters: parameters,
                                  success: { (response, _) in
 
@@ -104,7 +104,7 @@ import WordPressShared
                                                "cart": cart.jsonRepresentation() as AnyObject,
                                                "payment": paymentDict as AnyObject]
 
-        wordPressComRestApi.POST(urlPath, parameters: parameters, success: { (_, _) in
+        wordPressComRESTAPI.post(urlPath, parameters: parameters, success: { (_, _) in
             success()
         }) { (error, _) in
             failure(error)

--- a/Sources/WordPressKit/Services/WordPressComServiceRemote+SiteCreation.swift
+++ b/Sources/WordPressKit/Services/WordPressComServiceRemote+SiteCreation.swift
@@ -201,7 +201,7 @@ public extension WordPressComServiceRemote {
             return
         }
 
-        wordPressComRestApi.POST(
+        wordPressComRESTAPI.post(
             path,
             parameters: requestParameters,
             success: { [weak self] responseObject, httpResponse in
@@ -247,7 +247,7 @@ private extension WordPressComServiceRemote {
         return requestParameters
     }
 
-    func decodeResponse(responseObject: AnyObject) throws -> SiteCreationResponse {
+    func decodeResponse(responseObject: Any) throws -> SiteCreationResponse {
 
         let decoder = JSONDecoder()
 

--- a/Sources/WordPressKit/Services/WordPressComServiceRemote+SiteSegments.swift
+++ b/Sources/WordPressKit/Services/WordPressComServiceRemote+SiteSegments.swift
@@ -93,7 +93,7 @@ public extension WordPressComServiceRemote {
         let endpoint = "segments"
         let remotePath = path(forEndpoint: endpoint, withVersion: ._2_0)
 
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             remotePath,
             parameters: nil,
             success: { [weak self] responseObject, httpResponse in
@@ -122,7 +122,7 @@ public extension WordPressComServiceRemote {
 // MARK: - Serialization support
 
 private extension WordPressComServiceRemote {
-    private func decodeResponse(responseObject: AnyObject) throws -> [SiteSegment] {
+    private func decodeResponse(responseObject: Any) throws -> [SiteSegment] {
         let decoder = JSONDecoder()
         let data = try JSONSerialization.data(withJSONObject: responseObject, options: [])
         let response = try decoder.decode([SiteSegment].self, from: data)

--- a/Sources/WordPressKit/Services/WordPressComServiceRemote+SiteVerticals.swift
+++ b/Sources/WordPressKit/Services/WordPressComServiceRemote+SiteVerticals.swift
@@ -92,7 +92,7 @@ public extension WordPressComServiceRemote {
             return
         }
 
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             path,
             parameters: requestParameters,
             success: { [weak self] responseObject, httpResponse in
@@ -138,7 +138,7 @@ private extension WordPressComServiceRemote {
         return requestParameters
     }
 
-    func decodeResponse(responseObject: AnyObject) throws -> [SiteVertical] {
+    func decodeResponse(responseObject: Any) throws -> [SiteVertical] {
 
         let decoder = JSONDecoder()
 

--- a/Sources/WordPressKit/Services/WordPressComServiceRemote+SiteVerticalsPrompt.swift
+++ b/Sources/WordPressKit/Services/WordPressComServiceRemote+SiteVerticalsPrompt.swift
@@ -45,7 +45,7 @@ public extension WordPressComServiceRemote {
             "segment_id": request as AnyObject
         ]
 
-        wordPressComRestApi.GET(
+        wordPressComRESTAPI.get(
             path,
             parameters: requestParameters,
             success: { [weak self] responseObject, httpResponse in
@@ -74,7 +74,7 @@ public extension WordPressComServiceRemote {
 //
 private extension WordPressComServiceRemote {
 
-    func decodeResponse(responseObject: AnyObject) throws -> SiteVerticalsPrompt {
+    func decodeResponse(responseObject: Any) throws -> SiteVerticalsPrompt {
 
         let decoder = JSONDecoder()
 


### PR DESCRIPTION
### Description

Follows up on #766 applying the same pattern to all the `.GET` and `.POST` usages.

I changed each file/group of files with extensions in dedicated commits, in case one wants to review in chunks.

### Testing Details

Not all code is covered by unit tests, unfortunately. But, these changes are really about swapping interfaces without changing the implementation. They should be safe—last famous words.

---

- [ ] Please check here if your pull request includes additional test coverage. — N.A.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.