### PR TITLE
SPM Prep - Isolate API version enum and convert to modern Objective-C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-_None._
+- Remove unused `anonymousWordPressComRestApiWithUserAgent` method from `ServiceRemoteWordPressComREST` [TBD]
 
 ### New Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ _None._
 
 ### Breaking Changes
 
-- Remove unused `anonymousWordPressComRestApiWithUserAgent` method from `ServiceRemoteWordPressComREST` [TBD]
+- Removed `anonymousWordPressComRestApiWithUserAgent` method from `ServiceRemoteWordPressComREST` [#778]
+- Renamed `ServiceRemoteWordPressComRESTApiVersion` to `WordPressComRestAPIVersion` [#778]
 
 ### New Features
 

--- a/Sources/APIInterface/include/WordPressComRESTAPIVersion.h
+++ b/Sources/APIInterface/include/WordPressComRESTAPIVersion.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, WordPressComRESTAPIVersion) {
+    WordPressComRESTAPIVersion_1_0 = 1000,
+    WordPressComRESTAPIVersion_1_1 = 1001,
+    WordPressComRESTAPIVersion_1_2 = 1002,
+    WordPressComRESTAPIVersion_1_3 = 1003,
+    WordPressComRESTAPIVersion_2_0 = 2000
+};

--- a/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
@@ -54,7 +54,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
                              failure:(void (^)(NSError *error))failure
 {
     NSString *requestUrl = [self pathForEndpoint:@"me"
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl
        parameters:nil
@@ -107,7 +107,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
                                  @"sites": sites
                                  };
     NSString *path = [self pathForEndpoint:@"me/sites"
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                               withVersion:WordPressComRESTAPIVersion_1_1];
     [self.wordPressComRESTAPI post:path
         parameters:parameters
            success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
@@ -126,7 +126,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
     NSString *encodedIdentifier = [identifier stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLPathRFC3986AllowedCharacterSet];
 
     NSString *path = [self pathForEndpoint:[NSString stringWithFormat:@"users/%@/auth-options", encodedIdentifier]
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                               withVersion:WordPressComRESTAPIVersion_1_1];
     [self.wordPressComRESTAPI get:path
                        parameters:nil
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
@@ -249,7 +249,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
                              failure:(void (^)(NSError *error))failure
 {
     NSString *path = [self pathForEndpoint:@"auth/send-login-email"
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_3];
+                               withVersion:WordPressComRESTAPIVersion_1_3];
     
     NSDictionary *extraParams = @{
         MagicLinkParameterFlow: MagicLinkFlowLogin,
@@ -275,7 +275,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
 {
     
     NSString *path = [self pathForEndpoint:@"auth/send-signup-email"
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                               withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *extraParams = @{
         @"signup_flow_name": @"mobile-ios",
@@ -334,7 +334,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
                                     failure:(void (^)(NSError *))failure
 {
     NSString *path = [self pathForEndpoint:@"me/send-verification-email"
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                               withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI post:path parameters:nil success:^(id _Nonnull responseObject, NSHTTPURLResponse * _Nullable httpResponse) {
         if (success) {
@@ -354,7 +354,7 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
                        failure:(void (^)(NSError *))failure
 {
     NSString *requestUrl = [self pathForEndpoint:@"me/sites"
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {

--- a/Sources/WordPressKit/Services/BlogServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/BlogServiceRemoteREST.m
@@ -104,7 +104,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
     
     NSString *path = [self pathForUsers];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
@@ -136,7 +136,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 {
     NSString *path = [self pathForPostTypes];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     NSDictionary *parameters = @{@"context": @"edit"};
     [self.wordPressComRESTAPI get:requestUrl
        parameters:parameters
@@ -166,7 +166,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 {
     NSString *path = [self pathForPostFormats];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl
        parameters:nil
@@ -187,7 +187,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 {
     NSString *path = [self pathForSite];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:nil
@@ -208,7 +208,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
                         failure:(void (^)(NSError *error))failure
 {
     NSString *path = [self pathForSettings];
-    NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    NSString *requestUrl = [self pathForEndpoint:path withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl
        parameters:nil
@@ -238,7 +238,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 
     NSDictionary *parameters = [self remoteSettingsToDictionary:settings];
     NSString *path = [NSString stringWithFormat:@"sites/%@/settings?context=edit", self.siteID];
-    NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    NSString *requestUrl = [self pathForEndpoint:path withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
         parameters:parameters
@@ -270,7 +270,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@", siteAddress];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:nil
@@ -290,7 +290,7 @@ static NSInteger const RemoteBlogUncategorizedCategory                      = 1;
                         success:(void(^)(NSDictionary *siteInfoDict))success
                         failure:(void (^)(NSError *error))failure
 {
-    NSString *path = [self pathForEndpoint:@"connect/site-info" withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    NSString *path = [self pathForEndpoint:@"connect/site-info" withVersion:WordPressComRESTAPIVersion_1_1];
     NSURL *siteURL = [NSURL URLWithString:siteAddress];
 
     [self.wordPressComRESTAPI get:path

--- a/Sources/WordPressKit/Services/CommentServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/CommentServiceRemoteREST.m
@@ -26,7 +26,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{
                                  @"force": @"wpcom", // Force fetching data from shadow site on Jetpack sites
@@ -82,7 +82,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:nil
@@ -110,7 +110,7 @@
     }
     
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = @{
                                  @"content": comment.content,
@@ -137,7 +137,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, comment.commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = @{
         @"content": comment.content,
@@ -168,7 +168,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, comment.commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = @{
                                  @"status": [self remoteStatusWithStatus:comment.status],
@@ -195,7 +195,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/delete", self.siteID, comment.commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
@@ -221,7 +221,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies?order=ASC&hierarchical=1&page=%lu&number=%lu", self.siteID, postID, (unsigned long)page, (unsigned long)number];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     NSDictionary *parameters = @{
         @"force": @"wpcom" // Force fetching data from shadow site on Jetpack sites
@@ -252,7 +252,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = @{
         @"content": content,
@@ -278,7 +278,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/replies/new", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = @{@"content": content};
     
@@ -304,7 +304,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/replies/new", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = @{
         @"content": content,
@@ -332,7 +332,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = @{
         @"status"   : status,
@@ -358,7 +358,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/delete", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
@@ -379,7 +379,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes/new", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
@@ -400,7 +400,7 @@
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes/mine/delete", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
@@ -426,7 +426,7 @@
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/comments/%@/likes", self.siteID, commentID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
     NSNumber *siteID = self.siteID;
 
     // If no count provided, default to endpoint max.

--- a/Sources/WordPressKit/Services/MediaServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/MediaServiceRemoteREST.m
@@ -14,7 +14,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 {
     NSString *apiPath = [NSString stringWithFormat:@"sites/%@/media/%@", self.siteID, mediaID];
     NSString *requestUrl = [self pathForEndpoint:apiPath
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary * parameters = @{};
     
@@ -58,7 +58,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     }
     
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl
        parameters:[NSDictionary dictionaryWithDictionary:parameters]
@@ -97,7 +97,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/media", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{ @"number" : @1 }];
     if (mediaType) {
@@ -129,7 +129,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 
     NSString *apiPath = [NSString stringWithFormat:@"sites/%@/media/new", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:apiPath
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{}];
     NSMutableArray *fileParts = [NSMutableArray array];
 
@@ -190,7 +190,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 
     NSString *apiPath = [NSString stringWithFormat:@"sites/%@/media/new", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:apiPath
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     NSDictionary *parameters = [self parametersForUploadMedia:media];
 
@@ -257,7 +257,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/media/%@", self.siteID, media.mediaID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     NSDictionary *parameters = [self parametersFromRemoteMedia:media];
 
@@ -283,7 +283,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/media/%@/delete", self.siteID, media.mediaID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
@@ -316,7 +316,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
 {
     NSString *path = [NSString stringWithFormat:@"videos/%@", videoPressID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:nil
@@ -356,7 +356,7 @@ const NSInteger WPRestErrorCodeMediaNew = 10;
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/media/videopress-playback-jwt/%@", self.siteID, videoPressID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_2_0];
+                                     withVersion:WordPressComRESTAPIVersion_2_0];
 
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil

--- a/Sources/WordPressKit/Services/MenusServiceRemote.m
+++ b/Sources/WordPressKit/Services/MenusServiceRemote.m
@@ -37,7 +37,7 @@ NSString * const MenusRemoteKeyClasses = @"classes";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus/new", siteID];
     NSString *requestURL = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestURL
         parameters:@{MenusRemoteKeyName: menuName}
@@ -77,7 +77,7 @@ NSString * const MenusRemoteKeyClasses = @"classes";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus/%@", siteID, menuID];
     NSString *requestURL = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSMutableDictionary *params = [NSMutableDictionary dictionaryWithCapacity:2];
     if (updatedName.length) {
@@ -130,7 +130,7 @@ NSString * const MenusRemoteKeyClasses = @"classes";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus/%@/delete", siteID, menuID];
     NSString *requestURL = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     [self.wordPressComRESTAPI post:requestURL
         parameters:nil
            success:^(id  _Nonnull responseObject, NSHTTPURLResponse *httpResponse) {
@@ -167,7 +167,7 @@ NSString * const MenusRemoteKeyClasses = @"classes";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/menus", siteID];
     NSString *requestURL = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestURL
        parameters:nil

--- a/Sources/WordPressKit/Services/PostServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/PostServiceRemoteREST.m
@@ -37,7 +37,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = @{ @"context": @"edit" };
     
@@ -70,7 +70,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
     
     NSDictionary *parameters = @{
                                  @"status": @"any,trash",
@@ -102,7 +102,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/autosave", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = [self parametersWithRemotePost:post];
     
@@ -128,7 +128,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/new?context=edit", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
     
     NSDictionary *parameters = [self parametersWithRemotePost:post];
 
@@ -158,7 +158,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     NSString *filename = media.file;
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/new", self.siteID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
 
     NSMutableDictionary *parameters = [NSMutableDictionary dictionaryWithDictionary:@{}];
     parameters[@"content"] = post.content;
@@ -192,7 +192,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@?context=edit", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
     
     NSDictionary *parameters = [self parametersWithRemotePost:post];
 
@@ -218,7 +218,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/autosave", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *parameters = [self parametersWithRemotePost:post];
     
@@ -245,7 +245,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
         parameters:nil
@@ -269,7 +269,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     // The parameters are passed as part of the string here because AlamoFire doesn't encode parameters on POST requests.
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/delete?context=edit", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
         parameters:nil
@@ -295,7 +295,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     // https://github.com/wordpress-mobile/WordPressKit-iOS/pull/385
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/restore?context=edit", self.siteID, post.postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
         parameters:nil
@@ -322,7 +322,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/%@/likes", self.siteID, postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
     NSNumber *siteID = self.siteID;
 
     // If no count provided, default to endpoint max.

--- a/Sources/WordPressKit/Services/ReaderPostServiceRemote.m
+++ b/Sources/WordPressKit/Services/ReaderPostServiceRemote.m
@@ -70,7 +70,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
     NSString *path = [NSString stringWithFormat:@"read/%@/%lu/posts/%lu/?meta=site", feedType, (unsigned long)siteID, (unsigned long)postID];
 
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
     
     [self.wordPressComRESTAPI get:requestUrl
            parameters:nil
@@ -142,7 +142,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
 {
     NSString *path = [NSString stringWithFormat:@"sites/%lu/posts/%lu/likes/new", (unsigned long)siteID, (unsigned long)postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
@@ -162,7 +162,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
 {
     NSString *path = [NSString stringWithFormat:@"sites/%lu/posts/%lu/likes/mine/delete", (unsigned long)siteID, (unsigned long)postID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
@@ -180,7 +180,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
     NSAssert([phrase length] > 0, @"A search phrase is required.");
 
     NSString *endpoint = [NSString stringWithFormat:@"read/search?q=%@", [phrase stringByUrlEncoding]];
-    NSString *absolutePath = [self pathForEndpoint:endpoint withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+    NSString *absolutePath = [self pathForEndpoint:endpoint withVersion:WordPressComRESTAPIVersion_1_2];
     NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:self.wordPressComRESTAPI.baseURL];
     return [url absoluteString];
 }
@@ -267,7 +267,7 @@ NSString * const ParamKeyMetaValue = @"site,feed";
     NSString *path = [NSString stringWithFormat:@"sites/%@/posts/slug:%@?meta=site,likes", hostname, slug];
 
     return [self pathForEndpoint:path
-                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                     withVersion:WordPressComRESTAPIVersion_1_1];
 }
 
 @end

--- a/Sources/WordPressKit/Services/ReaderSiteServiceRemote.m
+++ b/Sources/WordPressKit/Services/ReaderSiteServiceRemote.m
@@ -15,7 +15,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 {
     NSString *path = @"read/following/mine?meta=site,feed";
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
@@ -42,7 +42,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 {
     NSString *path = [NSString stringWithFormat:@"sites/%lu/follows/new?%@=%@", (unsigned long)siteID, ReaderSiteServiceRemoteSourceKey, ReaderSiteServiceRemoteSourceValue];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
@@ -59,7 +59,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 {
     NSString *path = [NSString stringWithFormat:@"sites/%lu/follows/mine/delete", (unsigned long)siteID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (success) {
@@ -76,7 +76,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 {
     NSString *path = @"read/following/mine/new";
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *params = @{ReaderSiteServiceRemoteURLKey: siteURL,
                              ReaderSiteServiceRemoteSourceKey: ReaderSiteServiceRemoteSourceValue};
@@ -105,7 +105,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 {
     NSString *path = @"read/following/mine/delete";
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary *params = @{ReaderSiteServiceRemoteURLKey: siteURL};
     
@@ -161,7 +161,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 
     NSString *path = [NSString stringWithFormat:@"sites/%@", host];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl parameters:nil success:successBlock failure:^(NSError *error, NSHTTPURLResponse *httpResponse) {
         NSString *newHost;
@@ -176,7 +176,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
         }
         NSString *newPath = [NSString stringWithFormat:@"sites/%@", newHost];
         NSString *newPathRequestUrl = [self pathForEndpoint:newPath
-                                                withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                                withVersion:WordPressComRESTAPIVersion_1_1];
         
         [self.wordPressComRESTAPI get:newPathRequestUrl parameters:nil success:successBlock failure:failureBlock];
     }];
@@ -216,7 +216,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 {
     NSString *path = [NSString stringWithFormat:@"sites/%lu/follows/mine", (unsigned long)siteID];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
@@ -237,7 +237,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
 {
     NSString *path = @"read/following/mine";
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
@@ -268,7 +268,7 @@ NSString * const ReaderSiteServiceRemoteErrorDomain = @"ReaderSiteServiceRemoteE
     }
     
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         NSDictionary *dict = (NSDictionary *)responseObject;

--- a/Sources/WordPressKit/Services/ReaderTopicServiceRemote.m
+++ b/Sources/WordPressKit/Services/ReaderTopicServiceRemote.m
@@ -17,7 +17,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 {
     NSString *path = @"read/menu";
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_3];
+                                     withVersion:WordPressComRESTAPIVersion_1_3];
 
     [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(NSDictionary *response, NSHTTPURLResponse *httpResponse) {
         if (!success) {
@@ -77,7 +77,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 {
     NSString *path = [self pathForFollowedSitesWithPage:page number:number];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
 
     [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
@@ -105,7 +105,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 {
     NSString *path = [NSString stringWithFormat:@"read/tags/%@/mine/delete", slug];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(NSDictionary *responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
@@ -136,7 +136,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
     NSString *path = [NSString stringWithFormat:@"read/tags/%@/mine/new", slug];
     path = [path stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLPathAllowedCharacterSet]];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     [self.wordPressComRESTAPI post:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
@@ -158,7 +158,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 {
     NSString *path = [NSString stringWithFormat:@"read/tags/%@", slug];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
 
     [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
         if (!success) {
@@ -187,11 +187,11 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
     if (isFeed) {
         NSString *path = [NSString stringWithFormat:@"read/feed/%@", siteID];
         requestUrl = [self pathForEndpoint:path
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                               withVersion:WordPressComRESTAPIVersion_1_1];
     } else {
         NSString *path = [NSString stringWithFormat:@"read/sites/%@", siteID];
         requestUrl = [self pathForEndpoint:path
-                               withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                               withVersion:WordPressComRESTAPIVersion_1_2];
     }
     
     [self.wordPressComRESTAPI get:requestUrl parameters:nil success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
@@ -234,7 +234,7 @@ static NSString * const TopicNotFoundMarker = @"-notfound-";
 
 - (NSString *)endpointUrlForPath:(NSString *)endpoint
 {
-    NSString *absolutePath = [self pathForEndpoint:endpoint withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+    NSString *absolutePath = [self pathForEndpoint:endpoint withVersion:WordPressComRESTAPIVersion_1_2];
     NSURL *url = [NSURL URLWithString:absolutePath relativeToURL:self.wordPressComRESTAPI.baseURL];
     return [url absoluteString];
 }

--- a/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.h
+++ b/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.h
@@ -3,12 +3,12 @@
 
 @class WordPressComRestApi;
 
-typedef NS_ENUM(NSInteger, ServiceRemoteWordPressComRESTApiVersion) {
-    ServiceRemoteWordPressComRESTApiVersion_1_0 = 1000,
-    ServiceRemoteWordPressComRESTApiVersion_1_1 = 1001,
-    ServiceRemoteWordPressComRESTApiVersion_1_2 = 1002,
-    ServiceRemoteWordPressComRESTApiVersion_1_3 = 1003,
-    ServiceRemoteWordPressComRESTApiVersion_2_0 = 2000
+typedef NS_ENUM(NSInteger, WordPressComRESTAPIVersion) {
+    WordPressComRESTAPIVersion_1_0 = 1000,
+    WordPressComRESTAPIVersion_1_1 = 1001,
+    WordPressComRESTAPIVersion_1_2 = 1002,
+    WordPressComRESTAPIVersion_1_3 = 1003,
+    WordPressComRESTAPIVersion_2_0 = 2000
 };
 
 NS_ASSUME_NONNULL_BEGIN
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @returns    The request URL.
  */
 - (NSString *)pathForEndpoint:(NSString *)endpoint
-                  withVersion:(ServiceRemoteWordPressComRESTApiVersion)apiVersion
+                  withVersion:(WordPressComRESTAPIVersion)apiVersion
 NS_SWIFT_NAME(path(forEndpoint:withVersion:));
 
 @end

--- a/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.h
+++ b/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.h
@@ -3,12 +3,13 @@
 
 @class WordPressComRestApi;
 
-typedef NSInteger NS_TYPED_ENUM ServiceRemoteWordPressComRESTApiVersion;
-extern ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_0;
-extern ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_1;
-extern ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_2;
-extern ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_3;
-extern ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_2_0;
+typedef NS_ENUM(NSInteger, ServiceRemoteWordPressComRESTApiVersion) {
+    ServiceRemoteWordPressComRESTApiVersion_1_0 = 1000,
+    ServiceRemoteWordPressComRESTApiVersion_1_1 = 1001,
+    ServiceRemoteWordPressComRESTApiVersion_1_2 = 1002,
+    ServiceRemoteWordPressComRESTApiVersion_1_3 = 1003,
+    ServiceRemoteWordPressComRESTApiVersion_2_0 = 2000
+};
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -50,7 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
  *  @returns    The request URL.
  */
 - (NSString *)pathForEndpoint:(NSString *)endpoint
-                  withVersion:(ServiceRemoteWordPressComRESTApiVersion)apiVersion;
+                  withVersion:(ServiceRemoteWordPressComRESTApiVersion)apiVersion
+NS_SWIFT_NAME(path(forEndpoint:withVersion:));
 
 @end
 

--- a/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.h
+++ b/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.h
@@ -1,15 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <WordPressKit/WordPressComRESTAPIInterfacing.h>
+#import <WordPressKit/WordPressComRESTAPIVersion.h>
 
 @class WordPressComRestApi;
-
-typedef NS_ENUM(NSInteger, WordPressComRESTAPIVersion) {
-    WordPressComRESTAPIVersion_1_0 = 1000,
-    WordPressComRESTAPIVersion_1_1 = 1001,
-    WordPressComRESTAPIVersion_1_2 = 1002,
-    WordPressComRESTAPIVersion_1_3 = 1003,
-    WordPressComRESTAPIVersion_2_0 = 2000
-};
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,7 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @brief  Parent class for all REST service classes.
  */
 @interface ServiceRemoteWordPressComREST : NSObject
-
 
 /**
  *  @brief      The API object to use for communications.

--- a/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.h
+++ b/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.h
@@ -52,13 +52,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)pathForEndpoint:(NSString *)endpoint
                   withVersion:(ServiceRemoteWordPressComRESTApiVersion)apiVersion;
 
-/**
- *  @brief      An anonoymous API object to use for communications where authentication is not needed.
- *
- *  @param      userAgent       The user agent string to use on all requests
- */
-+ (WordPressComRestApi *)anonymousWordPressComRestApiWithUserAgent:(NSString *)userAgent;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.m
+++ b/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.m
@@ -25,28 +25,28 @@ static NSString* const ServiceRemoteWordPressComRESTApiVersionString_2_0 = @"wpc
 
 #pragma mark - API Version
 
-- (NSString *)apiVersionStringWithEnumValue:(ServiceRemoteWordPressComRESTApiVersion)apiVersion
+- (NSString *)apiVersionStringWithEnumValue:(WordPressComRESTAPIVersion)apiVersion
 {
     NSString *result = nil;
     
     switch (apiVersion) {
-        case ServiceRemoteWordPressComRESTApiVersion_1_0:
+        case WordPressComRESTAPIVersion_1_0:
             result = ServiceRemoteWordPressComRESTApiVersionString_1_0;
             break;
 
-        case ServiceRemoteWordPressComRESTApiVersion_1_1:
+        case WordPressComRESTAPIVersion_1_1:
             result = ServiceRemoteWordPressComRESTApiVersionString_1_1;
             break;
             
-        case ServiceRemoteWordPressComRESTApiVersion_1_2:
+        case WordPressComRESTAPIVersion_1_2:
             result = ServiceRemoteWordPressComRESTApiVersionString_1_2;
             break;
 
-        case ServiceRemoteWordPressComRESTApiVersion_1_3:
+        case WordPressComRESTAPIVersion_1_3:
             result = ServiceRemoteWordPressComRESTApiVersionString_1_3;
             break;
 
-        case ServiceRemoteWordPressComRESTApiVersion_2_0:
+        case WordPressComRESTAPIVersion_2_0:
             result = ServiceRemoteWordPressComRESTApiVersionString_2_0;
             break;
 
@@ -62,7 +62,7 @@ static NSString* const ServiceRemoteWordPressComRESTApiVersionString_2_0 = @"wpc
 #pragma mark - Request URL construction
 
 - (NSString *)pathForEndpoint:(NSString *)resourceUrl
-                  withVersion:(ServiceRemoteWordPressComRESTApiVersion)apiVersion
+                  withVersion:(WordPressComRESTAPIVersion)apiVersion
 {
     NSParameterAssert([resourceUrl isKindOfClass:[NSString class]]);
     

--- a/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.m
+++ b/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.m
@@ -14,9 +14,6 @@ static NSString* const ServiceRemoteWordPressComRESTApiVersionString_1_2 = @"res
 static NSString* const ServiceRemoteWordPressComRESTApiVersionString_1_3 = @"rest/v1.3";
 static NSString* const ServiceRemoteWordPressComRESTApiVersionString_2_0 = @"wpcom/v2";
 
-@interface ServiceRemoteWordPressComREST ()
-@end
-
 @implementation ServiceRemoteWordPressComREST
 
 - (instancetype)initWithWordPressComRestApi:(WordPressComRestApi *)wordPressComRestApi {
@@ -78,13 +75,6 @@ static NSString* const ServiceRemoteWordPressComRESTApiVersionString_2_0 = @"wpc
     NSString *apiVersionString = [self apiVersionStringWithEnumValue:apiVersion];
     
     return [NSString stringWithFormat:@"%@/%@", apiVersionString, resourceUrl];
-}
-
-+ (WordPressComRestApi *)anonymousWordPressComRestApiWithUserAgent:(NSString *)userAgent {
-
-    return [[WordPressComRestApi alloc] initWithOAuthToken:nil
-                                                 userAgent:userAgent
-            ];
 }
 
 @end

--- a/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.m
+++ b/Sources/WordPressKit/Services/ServiceRemoteWordPressComREST.m
@@ -1,12 +1,6 @@
 #import "ServiceRemoteWordPressComREST.h"
 #import "WPKit-Swift.h"
 
-ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_0 = 1000;
-ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_1 = 1001;
-ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_2 = 1002;
-ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_1_3 = 1003;
-ServiceRemoteWordPressComRESTApiVersion const ServiceRemoteWordPressComRESTApiVersion_2_0 = 2000;
-
 static NSString* const ServiceRemoteWordPressComRESTApiVersionStringInvalid = @"invalid_api_version";
 static NSString* const ServiceRemoteWordPressComRESTApiVersionString_1_0 = @"rest/v1";
 static NSString* const ServiceRemoteWordPressComRESTApiVersionString_1_1 = @"rest/v1.1";

--- a/Sources/WordPressKit/Services/ServiceRequest.swift
+++ b/Sources/WordPressKit/Services/ServiceRequest.swift
@@ -13,7 +13,7 @@ protocol ServiceRequest {
     var path: String { get }
 
     /// Returns the used API version
-    var apiVersion: ServiceRemoteWordPressComRESTApiVersion { get }
+    var apiVersion: WordPressComRESTAPIVersion { get }
 }
 
 /// Reader Topic Service request
@@ -24,7 +24,7 @@ enum ReaderTopicServiceSubscriptionsRequest {
 }
 
 extension ReaderTopicServiceSubscriptionsRequest: ServiceRequest {
-    var apiVersion: ServiceRemoteWordPressComRESTApiVersion {
+    var apiVersion: WordPressComRESTAPIVersion {
         switch self {
         case .notifications: return ._2_0
         case .postsEmail: return ._1_2

--- a/Sources/WordPressKit/Services/TaxonomyServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/TaxonomyServiceRemoteREST.m
@@ -184,7 +184,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
                        failure:(nullable void (^)(NSError *error))failure
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/%@/new?context=edit", self.siteID, typeIdentifier];
-    NSString *requestUrl = [self pathForEndpoint:path withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+    NSString *requestUrl = [self pathForEndpoint:path withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters
@@ -209,7 +209,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/%@?context=edit", self.siteID, typeIdentifier];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
@@ -234,7 +234,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/%@/slug:%@/delete?context=edit", self.siteID, typeIdentifier, parameters[TaxonomyRESTSlugParameter]];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:nil
@@ -259,7 +259,7 @@ static NSUInteger const TaxonomyRESTNumberMaxValue = 1000;
 {
     NSString *path = [NSString stringWithFormat:@"sites/%@/%@/slug:%@?context=edit", self.siteID, typeIdentifier, parameters[TaxonomyRESTSlugParameter]];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl
                         parameters:parameters

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.m
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.m
@@ -26,7 +26,7 @@ static NSString* const ThemeRequestPageKey = @"page";
 
     NSString *path = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSProgress *progress = [self.wordPressComRESTAPI get:requestUrl
                                               parameters:nil
@@ -53,7 +53,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     
     NSString *path = [NSString stringWithFormat:@"sites/%@/themes/purchased", blogId];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSProgress *progress = [self.wordPressComRESTAPI get:requestUrl
                                 parameters:nil
@@ -79,7 +79,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     
     NSString *path = [NSString stringWithFormat:@"themes/%@", themeId];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSProgress *progress = [self.wordPressComRESTAPI get:requestUrl
                                 parameters:nil
@@ -105,7 +105,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSParameterAssert(page > 0);
 
     NSString *requestUrl = [self pathForEndpoint:@"themes"
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
 
     NSDictionary *parameters = @{ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
                                  ThemeRequestNumberKey: @(ThemeRequestNumberValue),
@@ -128,7 +128,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSParameterAssert([path isKindOfClass:[NSString class]]);
 
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
 
     NSDictionary *parameters = @{ThemeRequestTierKey: ThemeRequestTierAllValue,
                                  ThemeRequestNumberKey: @(ThemeRequestNumberValue),
@@ -152,7 +152,7 @@ static NSString* const ThemeRequestPageKey = @"page";
 
     NSProgress *progress = [self getThemesForBlogId:blogId
                                                page:page
-                                         apiVersion:ServiceRemoteWordPressComRESTApiVersion_1_2
+                                         apiVersion:WordPressComRESTAPIVersion_1_2
                                              params:@{ThemeRequestTierKey: ThemeRequestTierAllValue}
                                             success:success
                                             failure:failure];
@@ -169,7 +169,7 @@ static NSString* const ThemeRequestPageKey = @"page";
 
     NSProgress *progress = [self getThemesForBlogId:blogId
                                                page:1
-                                         apiVersion:ServiceRemoteWordPressComRESTApiVersion_1_0
+                                         apiVersion:WordPressComRESTAPIVersion_1_0
                                              params:@{}
                                             success:success
                                             failure:failure];
@@ -179,7 +179,7 @@ static NSString* const ThemeRequestPageKey = @"page";
 
 - (NSProgress *)getThemesForBlogId:(NSNumber *)blogId
                               page:(NSInteger)page
-                        apiVersion:(ServiceRemoteWordPressComRESTApiVersion) apiVersion
+                        apiVersion:(WordPressComRESTAPIVersion) apiVersion
                             params:(NSDictionary *)params
                            success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                            failure:(ThemeServiceRemoteFailureBlock)failure
@@ -212,7 +212,7 @@ static NSString* const ThemeRequestPageKey = @"page";
 
     NSString *path = [NSString stringWithFormat:@"themes/?filter=starting-%@", category];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_1_2];
     
     NSDictionary *parameters = @{
                                  ThemeRequestNumberKey: @(ThemeRequestNumberValue),
@@ -266,7 +266,7 @@ static NSString* const ThemeRequestPageKey = @"page";
     
     NSString* const path = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     NSDictionary* parameters = @{@"theme": themeId};
     
@@ -297,7 +297,7 @@ static NSString* const ThemeRequestPageKey = @"page";
 
     NSString* const path = [NSString stringWithFormat:@"sites/%@/themes/%@/install", blogId, themeId];
     NSString *requestUrl = [self pathForEndpoint:path
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
 
     NSProgress *progress = [self.wordPressComRESTAPI post:requestUrl
                                                parameters:nil

--- a/Sources/WordPressKit/Services/WordPressComServiceRemote.m
+++ b/Sources/WordPressKit/Services/WordPressComServiceRemote.m
@@ -59,7 +59,7 @@
                              };
     
     NSString *requestUrl = [self pathForEndpoint:@"users/new"
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl parameters:params success:successBlock failure:failureBlock];
 }
@@ -115,7 +115,7 @@
         failure(errorWithLocalizedMessage);
     };
 
-    NSString *requestUrl = [self pathForEndpoint:@"users/social/new" withVersion:ServiceRemoteWordPressComRESTApiVersion_1_0];
+    NSString *requestUrl = [self pathForEndpoint:@"users/social/new" withVersion:WordPressComRESTAPIVersion_1_0];
     [self.wordPressComRESTAPI post:requestUrl parameters:params success:successBlock failure:failureBlock];
 }
 
@@ -220,7 +220,7 @@
     
     
     NSString *requestUrl = [self pathForEndpoint:@"sites/new"
-                                     withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                     withVersion:WordPressComRESTAPIVersion_1_1];
     
     [self.wordPressComRESTAPI post:requestUrl parameters:params success:successBlock failure:failureBlock];
 }

--- a/Sources/WordPressKit/WordPressKit.h
+++ b/Sources/WordPressKit/WordPressKit.h
@@ -8,6 +8,7 @@ FOUNDATION_EXPORT const unsigned char WordPressKitVersionString[];
 
 #import <WordPressKit/FilePart.h>
 #import <WordPressKit/WordPressComRESTAPIInterfacing.h>
+#import <WordPressKit/WordPressComRESTAPIVersion.h>
 
 #import <WordPressKit/ServiceRemoteWordPressComREST.h>
 #import <WordPressKit/ServiceRemoteWordPressXMLRPC.h>

--- a/Tests/WordPressKitTests/Tests/BlogServiceRemoteRESTTests.m
+++ b/Tests/WordPressKitTests/Tests/BlogServiceRemoteRESTTests.m
@@ -35,7 +35,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/users", blog.blogID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isKindOfClass:[NSDictionary class]]
@@ -60,7 +60,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@", blog.blogID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]
@@ -85,7 +85,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/post-types", blog.blogID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     NSDictionary *parameters = @{@"context": @"edit"};
     OCMStub([api get:[OCMArg isEqual:url]
@@ -111,7 +111,7 @@ static NSTimeInterval const TestExpectationTimeout = 5;
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/post-formats", blog.blogID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]

--- a/Tests/WordPressKitTests/Tests/MenusServiceRemoteTests.m
+++ b/Tests/WordPressKitTests/Tests/MenusServiceRemoteTests.m
@@ -23,7 +23,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/menus/new", dotComID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
     NSString *name = @"SomeName";
     
     BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
@@ -57,7 +57,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/menus/%@", dotComID, menu.menuID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
@@ -87,7 +87,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/menus/%@/delete", dotComID, menu.menuID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
@@ -110,7 +110,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/menus", dotComID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNil]

--- a/Tests/WordPressKitTests/Tests/MockServiceRequest.swift
+++ b/Tests/WordPressKitTests/Tests/MockServiceRequest.swift
@@ -6,7 +6,7 @@ struct MockServiceRequest: ServiceRequest {
         return "localhost/path/"
     }
 
-    var apiVersion: ServiceRemoteWordPressComRESTApiVersion {
+    var apiVersion: WordPressComRESTAPIVersion {
         return ._1_2
     }
 }

--- a/Tests/WordPressKitTests/Tests/PostServiceRemoteRESTTests.m
+++ b/Tests/WordPressKitTests/Tests/PostServiceRemoteRESTTests.m
@@ -38,7 +38,7 @@
     NSNumber *postID = @1;
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@", dotComID, postID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNotNil]
@@ -74,7 +74,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts", dotComID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                 withVersion:WordPressComRESTAPIVersion_1_2];
 
     BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
         
@@ -105,7 +105,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts", dotComID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                 withVersion:WordPressComRESTAPIVersion_1_2];
 
     NSString *testOptionKey = @"SomeKey";
     NSString *testOptionValue = @"SomeValue";
@@ -151,7 +151,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/new?context=edit", dotComID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                 withVersion:WordPressComRESTAPIVersion_1_2];
 
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
@@ -196,7 +196,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@?context=edit", dotComID, post.postID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                 withVersion:WordPressComRESTAPIVersion_1_2];
 
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
@@ -241,7 +241,7 @@
     
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/autosave", dotComID, post.postID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
     
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isKindOfClass:[NSDictionary class]]
@@ -274,7 +274,7 @@
     
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/autosave", dotComID, post.postID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
     
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNotNil]
@@ -302,7 +302,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/delete", dotComID, post.postID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
     
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
@@ -339,7 +339,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/delete?context=edit", dotComID, post.postID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
@@ -376,7 +376,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/posts/%@/restore?context=edit", dotComID, post.postID];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]

--- a/Tests/WordPressKitTests/Tests/TaxonomyServiceRemoteRESTTests.m
+++ b/Tests/WordPressKitTests/Tests/TaxonomyServiceRemoteRESTTests.m
@@ -36,7 +36,7 @@
 {
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/%@?context=edit", self.service.siteID, taxonomyTypeIdentifier];
     NSString *url = [self.service pathForEndpoint:endpoint
-                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                      withVersion:WordPressComRESTAPIVersion_1_1];
     return url;
 }
 
@@ -50,7 +50,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/%@/new?context=edit", self.service.siteID, @"categories"];
     NSString *url = [self.service pathForEndpoint:endpoint
-                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                      withVersion:WordPressComRESTAPIVersion_1_1];
 
     BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
         return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"name"] isEqualToString:category.name]);
@@ -210,7 +210,7 @@
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/%@/new?context=edit", self.service.siteID, @"tags"];
     NSString *url = [self.service pathForEndpoint:endpoint
-                                      withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                      withVersion:WordPressComRESTAPIVersion_1_1];
     
     BOOL (^parametersCheckBlock)(id obj) = ^BOOL(NSDictionary *parameters) {
         return ([parameters isKindOfClass:[NSDictionary class]] && [[parameters objectForKey:@"name"] isEqualToString:tag.name]);

--- a/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
+++ b/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
@@ -40,7 +40,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
@@ -93,7 +93,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/themes/purchased", blogId];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
@@ -146,7 +146,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
 
     NSString *endpoint = [NSString stringWithFormat:@"themes/%@", themeId];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNil]
@@ -196,7 +196,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     NSString *url = [service pathForEndpoint:@"themes"
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                 withVersion:WordPressComRESTAPIVersion_1_2];
 
     ThemeServiceRemoteThemesRequestSuccessBlock successBlock = ^void (NSArray<RemoteTheme *> *themes, BOOL hasMore, NSInteger totalThemeCount) {
         NSCAssert([themes count] == expectedThemes, @"Expected %ld themes to be returned", expectedThemes);
@@ -245,7 +245,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/themes", blogId];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_2];
+                                 withVersion:WordPressComRESTAPIVersion_1_2];
 
     [OCMStub([api get:[OCMArg isEqual:url]
            parameters:[OCMArg isNotNil]
@@ -300,7 +300,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
 
     NSString *endpoint = [NSString stringWithFormat:@"sites/%@/themes/mine", blogId];
     NSString *url = [service pathForEndpoint:endpoint
-                                 withVersion:ServiceRemoteWordPressComRESTApiVersion_1_1];
+                                 withVersion:WordPressComRESTAPIVersion_1_1];
 
     DictionaryVerificationBlock checkBlock = ^BOOL(NSDictionary *parameters) {
         NSCAssert([parameters isKindOfClass:[NSDictionary class]],

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		3FB8642C2888089F003A86BE /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3FB8642B2888089F003A86BE /* BuildkiteTestCollector */; };
 		3FE2E94F2BB29A1B002CA2E1 /* FilePart.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FE2E94D2BB29A1B002CA2E1 /* FilePart.m */; };
 		3FE2E9502BB29A1B002CA2E1 /* FilePart.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE2E94E2BB29A1B002CA2E1 /* FilePart.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3FE2E9672BBEB8D2002CA2E1 /* WordPressComRESTAPIVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 3FE2E9662BBEB8D2002CA2E1 /* WordPressComRESTAPIVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3FFCC0412BA995290051D229 /* Date+WordPressComTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFCC0402BA995290051D229 /* Date+WordPressComTests.swift */; };
 		3FFCC0472BAA6EF40051D229 /* NSDate+WordPressCom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFCC0462BAA6EF40051D229 /* NSDate+WordPressCom.swift */; };
 		3FFCC0492BAB98130051D229 /* DateFormatter+WordPressCom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FFCC0482BAB98130051D229 /* DateFormatter+WordPressCom.swift */; };
@@ -815,6 +816,7 @@
 		3FB8642D288813E9003A86BE /* UnitTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UnitTests.xctestplan; sourceTree = "<group>"; };
 		3FE2E94D2BB29A1B002CA2E1 /* FilePart.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FilePart.m; sourceTree = "<group>"; };
 		3FE2E94E2BB29A1B002CA2E1 /* FilePart.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FilePart.h; sourceTree = "<group>"; };
+		3FE2E9662BBEB8D2002CA2E1 /* WordPressComRESTAPIVersion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WordPressComRESTAPIVersion.h; sourceTree = "<group>"; };
 		3FFCC0402BA995290051D229 /* Date+WordPressComTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+WordPressComTests.swift"; sourceTree = "<group>"; };
 		3FFCC0462BAA6EF40051D229 /* NSDate+WordPressCom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSDate+WordPressCom.swift"; sourceTree = "<group>"; };
 		3FFCC0482BAB98130051D229 /* DateFormatter+WordPressCom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+WordPressCom.swift"; sourceTree = "<group>"; };
@@ -2033,6 +2035,7 @@
 			children = (
 				3FE2E94E2BB29A1B002CA2E1 /* FilePart.h */,
 				3FFCC0552BABC78B0051D229 /* WordPressComRESTAPIInterfacing.h */,
+				3FE2E9662BBEB8D2002CA2E1 /* WordPressComRESTAPIVersion.h */,
 			);
 			path = include;
 			sourceTree = "<group>";
@@ -2617,6 +2620,7 @@
 				93C674F11EE8351E00BFAF05 /* NSMutableDictionary+Helpers.h in Headers */,
 				93BD273C1EE73282002BB00B /* AccountServiceRemoteREST.h in Headers */,
 				93BD27711EE737A8002BB00B /* ServiceRemoteWordPressXMLRPC.h in Headers */,
+				3FE2E9672BBEB8D2002CA2E1 /* WordPressComRESTAPIVersion.h in Headers */,
 				93BD276F1EE737A8002BB00B /* ServiceRemoteWordPressComREST.h in Headers */,
 				93BD273B1EE73282002BB00B /* AccountServiceRemote.h in Headers */,
 				93BD27691EE736A8002BB00B /* RemoteUser.h in Headers */,


### PR DESCRIPTION
### Description

The end goal is to extract / duplicate the `pathForEndpoint:withVersion:` logic so that it can be used outside of `ServiceRemoteWordPressComRESTApiVersion`. The reason for that is that while all the sync calls can be used across Swift and Objective-C via #777, the `async` one cannot be used in Objective-C and therefore need Swift-only types that do not depend on `WordPressComRESTAPIInterfacing`

### Testing Details

No behavior change here. If the unit tests compile, we should be good.


---

- [ ] Please check here if your pull request includes additional test coverage. — N.A.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.