### PR TITLE
Avoid casting to `NSError` in favor of `WordPressApiError`

### DIFF
--- a/Sources/WordPressKit/Services/ActivityServiceRemote.swift
+++ b/Sources/WordPressKit/Services/ActivityServiceRemote.swift
@@ -154,7 +154,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
                                 }, failure: { error, _ in
                                     // FIXME: A hack to support free WPCom sites and Rewind.
                                     // Should be obsolete as soon as the backend stops returning 412's for those sites.
-                                    guard let endpointError = error.castToEndpointErrorWitCode(.preconditionFailure) else {
+                                    guard error.castedToEndpointErrorWitCode(.preconditionFailure) != nil else {
                                         success(RewindStatus(state: .unavailable))
                                         return
                                     }
@@ -222,7 +222,7 @@ private extension ActivityServiceRemote {
 
 private extension Error {
 
-    func castToEndpointErrorWitCode(
+    func castedToEndpointErrorWitCode(
         _ code: WordPressComRestApiErrorCode
     ) -> WordPressComRestApiEndpointError? {
         guard let apiError = self as? WordPressAPIError<WordPressComRestApiEndpointError> else {

--- a/Sources/WordPressKit/Services/ActivityServiceRemote.swift
+++ b/Sources/WordPressKit/Services/ActivityServiceRemote.swift
@@ -152,18 +152,15 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
                                         failure(ResponseError.decodingFailure)
                                     }
                                 }, failure: { error, _ in
-                                    // FIXME: A hack to support free WPCom sites and Rewind. Should be obsolote as soon as the backend
-                                    // stops returning 412's for those sites.
-                                    let nsError = error as NSError
-
-                                    guard nsError.domain == WordPressComRestApiEndpointError.errorDomain,
-                                       nsError.code == WordPressComRestApiErrorCode.preconditionFailure.rawValue else {
-                                        failure(error)
+                                    // FIXME: A hack to support free WPCom sites and Rewind.
+                                    // Should be obsolete as soon as the backend stops returning 412's for those sites.
+                                    guard let endpointError = error.castToEndpointErrorWitCode(.preconditionFailure) else {
+                                        success(RewindStatus(state: .unavailable))
                                         return
                                     }
 
-                                    let status = RewindStatus(state: .unavailable)
-                                    success(status)
+                                    failure(endpointError)
+
                                     return
                                 })
     }
@@ -221,4 +218,25 @@ private extension ActivityServiceRemote {
         return groups
     }
 
+}
+
+private extension Error {
+
+    func castToEndpointErrorWitCode(
+        _ code: WordPressComRestApiErrorCode
+    ) -> WordPressComRestApiEndpointError? {
+        guard let apiError = self as? WordPressAPIError<WordPressComRestApiEndpointError> else {
+            return .none
+        }
+
+        guard case .endpointError(let endpointError) = apiError else {
+            return .none
+        }
+
+        guard endpointError.code == code else {
+            return .none
+        }
+
+        return endpointError
+    }
 }

--- a/Sources/WordPressKit/Services/ActivityServiceRemote.swift
+++ b/Sources/WordPressKit/Services/ActivityServiceRemote.swift
@@ -159,7 +159,7 @@ open class ActivityServiceRemote: ServiceRemoteWordPressComREST {
                                         return
                                     }
 
-                                    failure(endpointError)
+                                    failure(error)
 
                                     return
                                 })

--- a/Sources/WordPressKit/Services/JetpackServiceRemote.swift
+++ b/Sources/WordPressKit/Services/JetpackServiceRemote.swift
@@ -84,11 +84,17 @@ public class JetpackServiceRemote: ServiceRemoteWordPressComREST {
                                         completion(false, JetpackInstallError(type: .installResponseError))
                                     }
         }) { error, _ in
-            let error = error as NSError
-            let key = error.userInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
-            let jetpackError = JetpackInstallError(title: error.localizedDescription,
-                                                   code: error.code,
-                                                   key: key)
+            guard let apiError = error as? WordPressAPIError<WordPressComRestApiEndpointError>,
+               case .endpointError(let endpointError) = apiError else {
+                   completion(false, nil)
+                   return
+            }
+
+            let jetpackError = JetpackInstallError(
+                title: endpointError.localizedDescription,
+                code: endpointError.errorCode,
+                key: endpointError.errorUserInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
+            )
             completion(false, jetpackError)
         }
     }

--- a/Sources/WordPressKit/Services/JetpackServiceRemote.swift
+++ b/Sources/WordPressKit/Services/JetpackServiceRemote.swift
@@ -93,7 +93,7 @@ public class JetpackServiceRemote: ServiceRemoteWordPressComREST {
             let jetpackError = JetpackInstallError(
                 title: endpointError.localizedDescription,
                 code: endpointError.errorCode,
-                key: endpointError.errorUserInfo[WordPressComRestApi.ErrorKeyErrorCode] as? String
+                key: endpointError.apiErrorCode
             )
             completion(false, jetpackError)
         }


### PR DESCRIPTION
See discussion at
https://github.com/wordpress-mobile/WordPressKit-iOS/pull/777#discussion_r1552498217 with @crazytonyli

### Testing Details

See green CI.

---

- [ ] Please check here if your pull request includes additional test coverage. — N.A.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.