### PR TITLE
Offline Mode: Add getPost(withID)

### DIFF
--- a/Sources/WordPressKit/Services/PostServiceRemoteExtended.swift
+++ b/Sources/WordPressKit/Services/PostServiceRemoteExtended.swift
@@ -1,23 +1,29 @@
 import Foundation
 
 public protocol PostServiceRemoteExtended: PostServiceRemote {
+    /// Returns a post with the given ID.
+    ///
+    /// - throws: ``PostServiceRemoteError`` or oher underlying errors
+    /// (see ``WordPressAPIError``)
+    func post(withID postID: Int) async throws -> RemotePost
+
     /// Creates a new post with the given parameters.
     func createPost(with parameters: RemotePostCreateParameters) async throws -> RemotePost
 
     /// Performs a partial update to the existing post.
     ///
-    /// - throws: ``PostServiceRemoteUpdatePostError`` or oher underlying errors
+    /// - throws: ``PostServiceRemoteError`` or oher underlying errors
     /// (see ``WordPressAPIError``)
     func patchPost(withID postID: Int, parameters: RemotePostUpdateParameters) async throws -> RemotePost
 
     /// Permanently deletes a post with the given ID.
     ///
-    /// - throws: ``PostServiceRemoteUpdatePostError`` or oher underlying errors
+    /// - throws: ``PostServiceRemoteError`` or oher underlying errors
     /// (see ``WordPressAPIError``)
     func deletePost(withID postID: Int) async throws
 }
 
-public enum PostServiceRemoteUpdatePostError: Error {
+public enum PostServiceRemoteError: Error {
     /// 409 (Conflict)
     case conflict
     /// 404 (Not Found)

--- a/Sources/WordPressKit/Services/PostServiceRemoteXMLRPC.h
+++ b/Sources/WordPressKit/Services/PostServiceRemoteXMLRPC.h
@@ -4,4 +4,6 @@
 
 @interface PostServiceRemoteXMLRPC : ServiceRemoteWordPressXMLRPC <PostServiceRemote>
 
++ (RemotePost *)remotePostFromXMLRPCDictionary:(NSDictionary *)xmlrpcDictionary;
+
 @end

--- a/Sources/WordPressKit/Services/PostServiceRemoteXMLRPC.m
+++ b/Sources/WordPressKit/Services/PostServiceRemoteXMLRPC.m
@@ -294,6 +294,10 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
 }
 
 - (RemotePost *)remotePostFromXMLRPCDictionary:(NSDictionary *)xmlrpcDictionary {
+    return [PostServiceRemoteXMLRPC remotePostFromXMLRPCDictionary:xmlrpcDictionary];
+}
+
++ (RemotePost *)remotePostFromXMLRPCDictionary:(NSDictionary *)xmlrpcDictionary {
     RemotePost *post = [RemotePost new];
 
     post.postID = [xmlrpcDictionary numberForKey:@"post_id"];
@@ -339,7 +343,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     return post;
 }
 
-- (NSString *)statusForPostStatus:(NSString *)status andDate:(NSDate *)date
++ (NSString *)statusForPostStatus:(NSString *)status andDate:(NSDate *)date
 {
     // Scheduled posts are synced with a post_status of 'publish' but we want to
     // work with a status of 'future' from within the app.
@@ -349,12 +353,12 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     return status;
 }
 
-- (NSArray *)tagsFromXMLRPCTermsArray:(NSArray *)terms {
++ (NSArray *)tagsFromXMLRPCTermsArray:(NSArray *)terms {
     NSArray *tags = [terms filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"taxonomy = 'post_tag' AND name != NIL"]];
     return [tags valueForKey:@"name"];
 }
 
-- (NSArray *)remoteCategoriesFromXMLRPCTermsArray:(NSArray *)terms {
++ (NSArray *)remoteCategoriesFromXMLRPCTermsArray:(NSArray *)terms {
     return [[terms wp_filter:^BOOL(NSDictionary *category) {
         return [[category stringForKey:@"taxonomy"] isEqualToString:@"category"];
     }] wp_map:^id(NSDictionary *category) {
@@ -362,7 +366,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     }];
 }
 
-- (RemotePostCategory *)remoteCategoryFromXMLRPCDictionary:(NSDictionary *)xmlrpcCategory {
++ (RemotePostCategory *)remoteCategoryFromXMLRPCDictionary:(NSDictionary *)xmlrpcCategory {
     RemotePostCategory *category = [RemotePostCategory new];
     category.categoryID = [xmlrpcCategory numberForKey:@"term_id"];
     category.name = [xmlrpcCategory stringForKey:@"name"];


### PR DESCRIPTION
### Description

Add `getPost(withID)` that supports `PostServiceRemoteError.notFound`.

Can we tested via https://github.com/wordpress-mobile/WordPress-iOS/pull/23004

Fixes #

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
