### PR TITLE
SPM Prep – Move some `async perform` types at the `WordPressComRESTAPIInterface` level

### DIFF
--- a/Sources/APIInterface/include/WordPressComRESTAPIInterfacing.h
+++ b/Sources/APIInterface/include/WordPressComRESTAPIInterfacing.h
@@ -6,6 +6,12 @@
 
 @property (strong, nonatomic, readonly) NSURL * _Nonnull baseURL;
 
+/// The key with which to specify locale in the parameters of a request.
+@property (strong, nonatomic, readonly) NSString * _Nonnull localeKey;
+
+/// Whether the user's preferred language locale should be appended.
+@property (nonatomic, readonly) BOOL appendsPreferredLanguageLocale;
+
 /// - Note: `parameters` has `id` instead of the more common `NSObject *` as its value type so it will convert to `AnyObject` in Swift.
 ///         In Swift, it's simpler to work with `AnyObject` than with `NSObject`. For example `"abc" as AnyObject` over `"abc" as NSObject`.
 - (NSProgress * _Nullable)get:(NSString * _Nonnull)URLString

--- a/Sources/APIInterface/include/WordPressComRESTAPIInterfacing.h
+++ b/Sources/APIInterface/include/WordPressComRESTAPIInterfacing.h
@@ -18,6 +18,10 @@
 /// The value with which to specify locale in the parameters of a request.
 @property (strong, nonatomic, readonly) NSString * _Nonnull localeValue;
 
+@property (strong, nonatomic, readonly) NSURLSession * _Nonnull urlSession;
+
+@property (strong, nonatomic, readonly) void (^ _Nullable invalidTokenHandler)(void);
+
 /// - Note: `parameters` has `id` instead of the more common `NSObject *` as its value type so it will convert to `AnyObject` in Swift.
 ///         In Swift, it's simpler to work with `AnyObject` than with `NSObject`. For example `"abc" as AnyObject` over `"abc" as NSObject`.
 - (NSProgress * _Nullable)get:(NSString * _Nonnull)URLString

--- a/Sources/APIInterface/include/WordPressComRESTAPIInterfacing.h
+++ b/Sources/APIInterface/include/WordPressComRESTAPIInterfacing.h
@@ -6,11 +6,17 @@
 
 @property (strong, nonatomic, readonly) NSURL * _Nonnull baseURL;
 
+/// Whether the user's preferred language locale should be appended to the request.
+/// Should default to `true`.
+///
+/// - SeeAlso: `localeKey` and `localeValue` to configure the locale appendend to the request.
+@property (nonatomic, readonly) BOOL appendsPreferredLanguageLocale;
+
 /// The key with which to specify locale in the parameters of a request.
 @property (strong, nonatomic, readonly) NSString * _Nonnull localeKey;
 
-/// Whether the user's preferred language locale should be appended.
-@property (nonatomic, readonly) BOOL appendsPreferredLanguageLocale;
+/// The value with which to specify locale in the parameters of a request.
+@property (strong, nonatomic, readonly) NSString * _Nonnull localeValue;
 
 /// - Note: `parameters` has `id` instead of the more common `NSObject *` as its value type so it will convert to `AnyObject` in Swift.
 ///         In Swift, it's simpler to work with `AnyObject` than with `NSObject`. For example `"abc" as AnyObject` over `"abc" as NSObject`.

--- a/Sources/WordPressKit/Models/RemotePostParameters.swift
+++ b/Sources/WordPressKit/Models/RemotePostParameters.swift
@@ -198,10 +198,14 @@ private enum RemotePostWordPressComCodingKeys: String, CodingKey {
     static let postTags = "post_tag"
 }
 
-struct RemotePostCreateParametersWordPressComEncoder: Encodable {
+public struct RemotePostCreateParametersWordPressComEncoder: Encodable {
     let parameters: RemotePostCreateParameters
 
-    func encode(to encoder: Encoder) throws {
+    public init(parameters: RemotePostCreateParameters) {
+        self.parameters = parameters
+    }
+
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: RemotePostWordPressComCodingKeys.self)
         try container.encodeIfPresent(parameters.type, forKey: .type)
         try container.encodeIfPresent(parameters.status, forKey: .status)
@@ -281,10 +285,14 @@ struct RemotePostUpdateParametersWordPressComMetadata: Encodable {
     }
 }
 
-struct RemotePostUpdateParametersWordPressComEncoder: Encodable {
+public struct RemotePostUpdateParametersWordPressComEncoder: Encodable {
     let parameters: RemotePostUpdateParameters
 
-    func encode(to encoder: Encoder) throws {
+    public init(parameters: RemotePostUpdateParameters) {
+        self.parameters = parameters
+    }
+
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: RemotePostWordPressComCodingKeys.self)
         try container.encodeIfPresent(parameters.ifNotModifiedSince, forKey: .ifNotModifiedSince)
 
@@ -348,10 +356,14 @@ private enum RemotePostXMLRPCCodingKeys: String, CodingKey {
     static let postTags = "post_tag"
 }
 
-struct RemotePostCreateParametersXMLRPCEncoder: Encodable {
+public struct RemotePostCreateParametersXMLRPCEncoder: Encodable {
     let parameters: RemotePostCreateParameters
 
-    func encode(to encoder: Encoder) throws {
+    public init(parameters: RemotePostCreateParameters) {
+        self.parameters = parameters
+    }
+
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: RemotePostXMLRPCCodingKeys.self)
         try container.encode(parameters.type, forKey: .type)
         try container.encodeIfPresent(parameters.status, forKey: .postStatus)
@@ -387,10 +399,14 @@ struct RemotePostCreateParametersXMLRPCEncoder: Encodable {
     }
 }
 
-struct RemotePostUpdateParametersXMLRPCEncoder: Encodable {
+public struct RemotePostUpdateParametersXMLRPCEncoder: Encodable {
     let parameters: RemotePostUpdateParameters
 
-    func encode(to encoder: Encoder) throws {
+    public init(parameters: RemotePostUpdateParameters) {
+        self.parameters = parameters
+    }
+
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: RemotePostXMLRPCCodingKeys.self)
         try container.encodeIfPresent(parameters.ifNotModifiedSince, forKey: .ifNotModifiedSince)
         try container.encodeIfPresent(parameters.status, forKey: .postStatus)

--- a/Sources/WordPressKit/WordPressAPI/DateFormatter+WordPressCom.swift
+++ b/Sources/WordPressKit/WordPressAPI/DateFormatter+WordPressCom.swift
@@ -3,7 +3,7 @@ extension DateFormatter {
     /// A `DateFormatter` configured to manage dates compatible with the WordPress.com API.
     ///
     /// - SeeAlso: [https://developer.wordpress.com/docs/api/](https://developer.wordpress.com/docs/api/)
-    static let wordPressCom: DateFormatter = {
+    public static let wordPressCom: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ssZ"
         formatter.timeZone = NSTimeZone(forSecondsFromGMT: 0) as TimeZone

--- a/Sources/WordPressKit/WordPressAPI/HTTPRequestBuilder.swift
+++ b/Sources/WordPressKit/WordPressAPI/HTTPRequestBuilder.swift
@@ -5,8 +5,8 @@ import wpxmlrpc
 ///
 /// Calling this class's url related functions (the ones that changes path, query, etc) does not modify the
 /// original URL string. The URL will be perserved in the final result that's returned by the `build` function.
-final class HTTPRequestBuilder {
-    enum Method: String, CaseIterable {
+public final class HTTPRequestBuilder {
+    public enum Method: String, CaseIterable {
         case get = "GET"
         case post = "POST"
         case put = "PUT"

--- a/Sources/WordPressKit/WordPressAPI/WordPressAPIError.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressAPIError.swift
@@ -22,7 +22,6 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
     /// Other error occured.
     case unknown(underlyingError: Error)
 
-
     var response: HTTPURLResponse? {
         switch self {
         case .requestEncodingFailure, .connection, .unknown:

--- a/Sources/WordPressKit/WordPressAPI/WordPressAPIError.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressAPIError.swift
@@ -18,13 +18,10 @@ public enum WordPressAPIError<EndpointError>: Error where EndpointError: Localiz
     /// The API call returned an status code that's unacceptable to the endpoint.
     case unacceptableStatusCode(response: HTTPURLResponse, body: Data)
     /// The API call returned an HTTP response that WordPressKit can't parse. Receiving this error could be an indicator that there is an error response that's not handled properly by WordPressKit.
-    case unparsableResponse(response: HTTPURLResponse?, body: Data?, underlyingError: Error)
+    case unparsableResponse(response: HTTPURLResponse?, body: Data?, underlyingError: Error = URLError(.cannotParseResponse))
     /// Other error occured.
     case unknown(underlyingError: Error)
 
-    static func unparsableResponse(response: HTTPURLResponse?, body: Data?) -> Self {
-        return WordPressAPIError<EndpointError>.unparsableResponse(response: response, body: body, underlyingError: URLError(.cannotParseResponse))
-    }
 
     var response: HTTPURLResponse? {
         switch self {

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -310,17 +310,6 @@ open class WordPressComRestApi: NSObject {
         return "\(String(describing: oAuthToken)),\(String(describing: userAgent))".hashValue
     }
 
-    private func requestBuilder(URLString: String) throws -> HTTPRequestBuilder {
-        let locale: (String, String)?
-        if appendsPreferredLanguageLocale {
-            locale = (localeKey, WordPressComLanguageDatabase().deviceLanguage.slug)
-        } else {
-            locale = nil
-        }
-
-        return try HTTPRequestBuilder.with(URLString: URLString, relativeTo: baseURL, appendingLocale: locale)
-    }
-
     @objc public func temporaryFileURL(withExtension fileExtension: String) -> URL {
         assert(!fileExtension.isEmpty, "file Extension cannot be empty")
         let fileName = "\(ProcessInfo.processInfo.globallyUniqueString)_file.\(fileExtension)"
@@ -427,8 +416,7 @@ open class WordPressComRestApi: NSObject {
     ) async -> APIResult<T> {
         var builder: HTTPRequestBuilder
         do {
-            builder = try requestBuilder(URLString: URLString)
-                .method(method)
+            builder = try requestBuilder(URLString: URLString).method(method)
         } catch {
             return .failure(.requestEncodingFailure(underlyingError: error))
         }
@@ -485,6 +473,17 @@ extension WordPressComRESTAPIInterfacing {
                     return error
                 }
             }
+    }
+
+    func requestBuilder(URLString: String) throws -> HTTPRequestBuilder {
+        let locale: (String, String)?
+        if appendsPreferredLanguageLocale {
+            locale = (localeKey, localeValue)
+        } else {
+            locale = nil
+        }
+
+        return try HTTPRequestBuilder.with(URLString: URLString, relativeTo: baseURL, appendingLocale: locale)
     }
 }
 

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -177,7 +177,6 @@ open class WordPressComRestApi: NSObject {
         }
     }
 
-
     // MARK: Network requests
 
     /**

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -97,6 +97,10 @@ open class WordPressComRestApi: NSObject {
 
     public let localeKey: String
 
+    public var localeValue: String {
+        WordPressComLanguageDatabase().deviceLanguage.slug
+    }
+
     @objc public let baseURL: URL
 
     private var invalidTokenHandler: (() -> Void)?

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -449,15 +449,18 @@ open class WordPressComRestApi: NSObject {
             invalidTokenHandler: invalidTokenHandler
         )
     }
+}
 
-    private func perform<T>(
+extension WordPressComRESTAPIInterfacing {
+
+    func perform<T>(
         request: HTTPRequestBuilder,
         fulfilling progress: Progress?,
         decoder: @escaping (Data) throws -> T,
         session: URLSession,
         invalidTokenHandler: (() -> Void)?,
         taskCreated: ((Int) -> Void)? = nil
-    ) async -> APIResult<T> {
+    ) async -> WordPressAPIResult<HTTPAPIResponse<T>, WordPressComRestApiEndpointError> {
         await session
             .perform(request: request, taskCreated: taskCreated, fulfilling: progress, errorType: WordPressComRestApiEndpointError.self)
             .mapSuccess { response -> HTTPAPIResponse<T> in

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -383,12 +383,12 @@ open class WordPressComRestApi: NSObject {
             request: builder.query(parameters ?? [:]),
             fulfilling: progress,
             decoder: { try JSONSerialization.jsonObject(with: $0) as AnyObject },
+            session: uploadURLSession,
             taskCreated: { taskID in
                 DispatchQueue.main.async {
                     requestEnqueued?(NSNumber(value: taskID))
                 }
-            },
-            session: uploadURLSession
+            }
         )
     }
 
@@ -447,8 +447,8 @@ open class WordPressComRestApi: NSObject {
         request: HTTPRequestBuilder,
         fulfilling progress: Progress?,
         decoder: @escaping (Data) throws -> T,
-        taskCreated: ((Int) -> Void)? = nil,
-        session: URLSession
+        session: URLSession,
+        taskCreated: ((Int) -> Void)? = nil
     ) async -> APIResult<T> {
         await session
             .perform(request: request, taskCreated: taskCreated, fulfilling: progress, errorType: WordPressComRestApiEndpointError.self)

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -384,6 +384,7 @@ open class WordPressComRestApi: NSObject {
             fulfilling: progress,
             decoder: { try JSONSerialization.jsonObject(with: $0) as AnyObject },
             session: uploadURLSession,
+            invalidTokenHandler: invalidTokenHandler,
             taskCreated: { taskID in
                 DispatchQueue.main.async {
                     requestEnqueued?(NSNumber(value: taskID))
@@ -440,7 +441,13 @@ open class WordPressComRestApi: NSObject {
             }
         }
 
-        return await perform(request: builder, fulfilling: progress, decoder: decoder, session: urlSession)
+        return await perform(
+            request: builder,
+            fulfilling: progress,
+            decoder: decoder,
+            session: urlSession,
+            invalidTokenHandler: invalidTokenHandler
+        )
     }
 
     private func perform<T>(
@@ -448,6 +455,7 @@ open class WordPressComRestApi: NSObject {
         fulfilling progress: Progress?,
         decoder: @escaping (Data) throws -> T,
         session: URLSession,
+        invalidTokenHandler: (() -> Void)?,
         taskCreated: ((Int) -> Void)? = nil
     ) async -> APIResult<T> {
         await session

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -95,7 +95,7 @@ open class WordPressComRestApi: NSObject {
 
     private let backgroundUploads: Bool
 
-    private let localeKey: String
+    public let localeKey: String
 
     @objc public let baseURL: URL
 

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -103,7 +103,7 @@ open class WordPressComRestApi: NSObject {
 
     @objc public let baseURL: URL
 
-    private var invalidTokenHandler: (() -> Void)?
+    public var invalidTokenHandler: (() -> Void)?
 
     /**
      Configure whether or not the user's preferred language locale should be appended. Defaults to true.
@@ -177,9 +177,6 @@ open class WordPressComRestApi: NSObject {
         }
     }
 
-    @objc func setInvalidTokenHandler(_ handler: @escaping () -> Void) {
-        invalidTokenHandler = handler
-    }
 
     // MARK: Network requests
 
@@ -319,7 +316,7 @@ open class WordPressComRestApi: NSObject {
 
     // MARK: - Async
 
-    private lazy var urlSession: URLSession = {
+    public lazy var urlSession: URLSession = {
         URLSession(configuration: sessionConfiguration(background: false))
     }()
 

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -440,7 +440,7 @@ open class WordPressComRestApi: NSObject {
             }
         }
 
-        return await perform(request: builder, fulfilling: progress, decoder: decoder)
+        return await perform(request: builder, fulfilling: progress, decoder: decoder, session: urlSession)
     }
 
     private func perform<T>(
@@ -448,9 +448,9 @@ open class WordPressComRestApi: NSObject {
         fulfilling progress: Progress?,
         decoder: @escaping (Data) throws -> T,
         taskCreated: ((Int) -> Void)? = nil,
-        session: URLSession? = nil
+        session: URLSession
     ) async -> APIResult<T> {
-        await (session ?? self.urlSession)
+        await session
             .perform(request: request, taskCreated: taskCreated, fulfilling: progress, errorType: WordPressComRestApiEndpointError.self)
             .mapSuccess { response -> HTTPAPIResponse<T> in
                 let object = try decoder(response.body)

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -360,7 +360,7 @@ open class WordPressComRestApi: NSObject {
         return configuration
     }
 
-    func perform(
+    public func perform(
         _ method: HTTPRequestBuilder.Method,
         URLString: String,
         parameters: [String: AnyObject]? = nil,

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -379,17 +379,6 @@ open class WordPressComRestApi: NSObject {
         )
     }
 
-    public func perform(
-        _ method: HTTPRequestBuilder.Method,
-        URLString: String,
-        parameters: [String: AnyObject]? = nil,
-        fulfilling progress: Progress? = nil
-    ) async -> APIResult<AnyObject> {
-        await perform(method, URLString: URLString, parameters: parameters, fulfilling: progress) {
-            try (JSONSerialization.jsonObject(with: $0) as AnyObject)
-        }
-    }
-
     func perform<T: Decodable>(
         _ method: HTTPRequestBuilder.Method,
         URLString: String,
@@ -403,8 +392,25 @@ open class WordPressComRestApi: NSObject {
             return try decoder.decode(type, from: $0)
         }
     }
+}
 
-    private func perform<T>(
+extension WordPressComRESTAPIInterfacing {
+
+    public typealias APIResult<T> = WordPressAPIResult<HTTPAPIResponse<T>, WordPressComRestApiEndpointError>
+
+    public func perform(
+        _ method: HTTPRequestBuilder.Method,
+        URLString: String,
+        parameters: [String: AnyObject]? = nil,
+        fulfilling progress: Progress? = nil
+    ) async -> APIResult<AnyObject> {
+        await perform(method, URLString: URLString, parameters: parameters, fulfilling: progress) {
+            try (JSONSerialization.jsonObject(with: $0) as AnyObject)
+        }
+    }
+
+    // FIXME: This was private. It became public during the extraction. Consider whether to make it privated once done.
+    public func perform<T>(
         _ method: HTTPRequestBuilder.Method,
         URLString: String,
         parameters: [String: AnyObject]?,
@@ -434,13 +440,9 @@ open class WordPressComRestApi: NSObject {
             invalidTokenHandler: invalidTokenHandler
         )
     }
-}
 
-extension WordPressComRESTAPIInterfacing {
-
-    public typealias APIResult<T> = WordPressAPIResult<HTTPAPIResponse<T>, WordPressComRestApiEndpointError>
-
-    func perform<T>(
+    // FIXME: This was private. It became public during the extraction. Consider whether to make it privated once done.
+    public func perform<T>(
         request: HTTPRequestBuilder,
         fulfilling progress: Progress?,
         decoder: @escaping (Data) throws -> T,

--- a/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressComRestApi.swift
@@ -441,6 +441,8 @@ open class WordPressComRestApi: NSObject {
 
 extension WordPressComRESTAPIInterfacing {
 
+    public typealias APIResult<T> = WordPressAPIResult<HTTPAPIResponse<T>, WordPressComRestApiEndpointError>
+
     func perform<T>(
         request: HTTPRequestBuilder,
         fulfilling progress: Progress?,
@@ -448,7 +450,7 @@ extension WordPressComRESTAPIInterfacing {
         session: URLSession,
         invalidTokenHandler: (() -> Void)?,
         taskCreated: ((Int) -> Void)? = nil
-    ) async -> WordPressAPIResult<HTTPAPIResponse<T>, WordPressComRestApiEndpointError> {
+    ) async -> APIResult<T> {
         await session
             .perform(request: request, taskCreated: taskCreated, fulfilling: progress, errorType: WordPressComRestApiEndpointError.self)
             .mapSuccess { response -> HTTPAPIResponse<T> in

--- a/Sources/WordPressKit/WordPressAPI/WordPressOrgXMLRPCApi.swift
+++ b/Sources/WordPressKit/WordPressAPI/WordPressOrgXMLRPCApi.swift
@@ -180,7 +180,7 @@ open class WordPressOrgXMLRPCApi: NSObject {
     /// - Parameters:
     ///   - streaming: set to `true` if there are large data (i.e. uploading files) in given `parameters`. `false` by default.
     /// - Returns: A `Result` type that contains the XMLRPC success or failure result.
-    func call(method: String, parameters: [AnyObject]?, fulfilling progress: Progress? = nil, streaming: Bool = false) async -> WordPressAPIResult<HTTPAPIResponse<AnyObject>, WordPressOrgXMLRPCApiFault> {
+    public func call(method: String, parameters: [AnyObject]?, fulfilling progress: Progress? = nil, streaming: Bool = false) async -> WordPressAPIResult<HTTPAPIResponse<AnyObject>, WordPressOrgXMLRPCApiFault> {
         let session = streaming ? uploadURLSession : urlSession
         let builder = HTTPRequestBuilder(url: endpoint)
             .method(.post)


### PR DESCRIPTION
### Description

This was part of https://github.com/wordpress-mobile/WordPressKit-iOS/pull/784 but I've been asked to wait on the actual `extension` removal because of conflicting WIP work. 

All these changes should be fine to merge regardless, as are mostly about changing access control, injecting new params, and moving methods at the protocol level.

### Testing Details

See CI.


---

- [ ] Please check here if your pull request includes additional test coverage. — N.A.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.