### PR TITLE
Merge 17.0.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ _None._
 
 -->
 
-## Unreleased
+## 17.0.0
 
 ### Breaking Changes
 
@@ -39,7 +39,8 @@ _None._
 
 ### New Features
 
-_None._
+- Add new delete endpoint [#776]
+- Add support for metadata for `RemotePostParameters` [#783]
 
 ### Bug Fixes
 
@@ -47,7 +48,8 @@ _None._
 
 ### Internal Changes
 
-_None._
+- Make Stats-related entities Equatable [#751]
+- Fix looking up multipart form temporary file [#781]
 
 ## 16.0.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '16.0.0'
+  s.version       = '17.0.0'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the code freeze workflow for WordPress iOS 24.7 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, merge this.

