### PR TITLE
Offline Mode: Switch to wp.editPost and wp.newPost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ _None._
 
 -->
 
+## Unreleased
+
+### New Features
+
+- Add `getPost(withID)` to `PostServiceRemoteExtended` [#785]
+- Add support for metadata to `PostServiceRemoteExtended` [#783]
+
+### Bug Fixes
+
+- Fix encoding for some fields in the new XMLRPC endpoints [#786]
+
+### Internal Changes
+
+- Update new APIs to create and update posts introduced `PostServiceRemoteExtended` to use `wp.newPost` and `wp.editPost` instead of the older versions of these APIs [#792]
+
+
 ## 17.0.0
 
 ### Breaking Changes

--- a/Sources/WordPressKit/Models/RemotePostParameters.swift
+++ b/Sources/WordPressKit/Models/RemotePostParameters.swift
@@ -330,22 +330,23 @@ private enum RemotePostXMLRPCCodingKeys: String, CodingKey {
     case ifNotModifiedSince = "if_not_modified_since"
     case type = "post_type"
     case postStatus = "post_status"
-    case date = "date_created_gmt"
-    case authorID = "wp_author_id"
-    case title
-    case content = "description"
-    case password = "wp_password"
-    case excerpt = "mt_excerpt"
-    case slug = "wp_slug"
-    case featuredImageID = "wp_post_thumbnail"
-    case parentPageID = "wp_page_parent_id"
-    case tags = "mt_keywords"
-    case format = "wp_post_format"
+    case date = "post_date"
+    case authorID = "post_author"
+    case title = "post_title"
+    case content = "post_content"
+    case password = "post_password"
+    case excerpt = "post_excerpt"
+    case slug = "post_name"
+    case featuredImageID = "post_thumbnail"
+    case parentPageID = "post_parent"
+    case terms = "terms"
+    case termNames = "terms_names"
+    case format = "post_format"
     case isSticky = "sticky"
-    case categoryIDs = "categories"
     case metadata = "custom_fields"
 
-    static let postTags = "post_tag"
+    static let taxonomyTag = "post_tag"
+    static let taxonomyCategory = "category"
 }
 
 struct RemotePostCreateParametersXMLRPCEncoder: Encodable {
@@ -376,10 +377,10 @@ struct RemotePostCreateParametersXMLRPCEncoder: Encodable {
         // Posts
         try container.encodeIfPresent(parameters.format, forKey: .format)
         if !parameters.tags.isEmpty {
-            try container.encode(parameters.tags, forKey: .tags)
+            try container.encode([RemotePostXMLRPCCodingKeys.taxonomyTag: parameters.tags], forKey: .termNames)
         }
         if !parameters.categoryIDs.isEmpty {
-            try container.encodeIfPresent(parameters.categoryIDs, forKey: .categoryIDs)
+            try container.encode([RemotePostXMLRPCCodingKeys.taxonomyCategory: parameters.categoryIDs], forKey: .terms)
         }
         if parameters.isSticky {
             try container.encode(parameters.isSticky, forKey: .isSticky)
@@ -422,14 +423,16 @@ struct RemotePostUpdateParametersXMLRPCEncoder: Encodable {
         // Posts
         try container.encodeStringIfPresent(parameters.format, forKey: .format)
         if let tags = parameters.tags {
-            try container.encode(tags, forKey: .tags)
+            try container.encode([RemotePostXMLRPCCodingKeys.taxonomyTag: tags], forKey: .termNames)
         }
-        try container.encodeIfPresent(parameters.categoryIDs, forKey: .categoryIDs)
+        if let categoryIDs = parameters.categoryIDs {
+            try container.encode([RemotePostXMLRPCCodingKeys.taxonomyCategory: categoryIDs], forKey: .terms)
+        }
         try container.encodeIfPresent(parameters.isSticky, forKey: .isSticky)
     }
 }
 
-struct RemotePostUpdateParametersXMLRPCMetadata: Encodable {
+private struct RemotePostUpdateParametersXMLRPCMetadata: Encodable {
     let id: String?
     let key: String?
     let value: String?

--- a/Sources/WordPressKit/Models/RemotePostParameters.swift
+++ b/Sources/WordPressKit/Models/RemotePostParameters.swift
@@ -115,7 +115,7 @@ extension RemotePostCreateParameters {
         if previous.tags != tags {
             changes.tags = tags
         }
-        if previous.categoryIDs != categoryIDs {
+        if Set(previous.categoryIDs) != Set(categoryIDs) {
             changes.categoryIDs = categoryIDs
         }
         if previous.metadata != metadata {

--- a/Sources/WordPressKit/Services/PostServiceRemoteXMLRPC+Extended.swift
+++ b/Sources/WordPressKit/Services/PostServiceRemoteXMLRPC+Extended.swift
@@ -19,7 +19,7 @@ extension PostServiceRemoteXMLRPC: PostServiceRemoteExtended {
     public func createPost(with parameters: RemotePostCreateParameters) async throws -> RemotePost {
         let dictionary = try makeParameters(from: RemotePostCreateParametersXMLRPCEncoder(parameters: parameters))
         let parameters = xmlrpcArguments(withExtra: dictionary) as [AnyObject]
-        let response = try await api.call(method: "metaWeblog.newPost", parameters: parameters).get()
+        let response = try await api.call(method: "wp.newPost", parameters: parameters).get()
         guard let postID = (response.body as? NSObject)?.numericValue() else {
             throw URLError(.unknown) // Should never happen
         }
@@ -28,11 +28,8 @@ extension PostServiceRemoteXMLRPC: PostServiceRemoteExtended {
 
     public func patchPost(withID postID: Int, parameters: RemotePostUpdateParameters) async throws -> RemotePost {
         let dictionary = try makeParameters(from: RemotePostUpdateParametersXMLRPCEncoder(parameters: parameters))
-        var parameters = xmlrpcArguments(withExtra: dictionary) as [AnyObject]
-        if parameters.count > 0 {
-            parameters[0] = postID as NSNumber
-        }
-        let result = await api.call(method: "metaWeblog.editPost", parameters: parameters)
+        let parameters = xmlrpcArguments(withExtraDefaults: [postID as NSNumber], andExtra: dictionary) as [AnyObject]
+        let result = await api.call(method: "wp.editPost", parameters: parameters)
         switch result {
         case .success:
             return try await post(withID: postID)


### PR DESCRIPTION
### Description

This PR switched to `wp.editPost` and `wp.newPost`, which are relatively new endpoints (but are still 10+ years old) with multiple bug fixes, and, most important, `if_not_modified_since` support.

Can be tested using https://github.com/wordpress-mobile/WordPress-iOS/pull/23022#issuecomment-2059369598

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
