### PR TITLE
Stats: Add `stats/emails/summary` endpoint support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ _None._
 
 - Add `getPost(withID)` to `PostServiceRemoteExtended` [#785]
 - Add support for metadata to `PostServiceRemoteExtended` [#783]
+- Add fetching of `StatsEmailsSummaryData` to `StatsService` [#794]
 
 ### Bug Fixes
 

--- a/Sources/WordPressKit/Models/Stats/Emails/StatsEmailsSummaryData.swift
+++ b/Sources/WordPressKit/Models/Stats/Emails/StatsEmailsSummaryData.swift
@@ -1,0 +1,84 @@
+import Foundation
+import WordPressShared
+
+public struct StatsEmailsSummaryData: Decodable {
+    public let posts: [Post]
+
+    public init(posts: [Post]) {
+        self.posts = posts
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case posts = "posts"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        posts = try container.decode([Post].self, forKey: .posts)
+    }
+
+    public struct Post: Codable {
+        let id: Int
+        let link: URL
+        let date: Date
+        let title: String
+        let type: PostType
+        let opens: Int
+        let clicks: Int
+
+        public enum PostType: String, Codable {
+            case post = "post"
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case id = "id"
+            case link = "href"
+            case date = "date"
+            case title = "title"
+            case type = "type"
+            case opens = "opens"
+            case clicks = "clicks"
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(Int.self, forKey: .id)
+            link = try container.decode(URL.self, forKey: .link)
+            title = (try? container.decodeIfPresent(String.self, forKey: .title)) ?? ""
+            type = (try? container.decodeIfPresent(PostType.self, forKey: .type)) ?? .post
+            opens = (try? container.decodeIfPresent(Int.self, forKey: .opens)) ?? 0
+            clicks = (try? container.decodeIfPresent(Int.self, forKey: .clicks)) ?? 0
+            self.date = try container.decode(Date.self, forKey: .date)
+        }
+    }
+}
+
+extension StatsEmailsSummaryData {
+    public static var pathComponent: String {
+        return "stats/emails/summary"
+    }
+
+    public init?(jsonDictionary: [String: AnyObject]) {
+        do {
+            let jsonData = try JSONSerialization.data(withJSONObject: jsonDictionary, options: [])
+            let decoder = JSONDecoder.apiDecoder
+            self = try decoder.decode(Self.self, from: jsonData)
+        } catch {
+            return nil
+        }
+    }
+
+    public static func queryProperties(quantity: Int, sortField: SortField, sortOrder: SortOrder) -> [String: String] {
+        return ["quantity": String(quantity), "sort_field": sortField.rawValue, "sort_order": sortOrder.rawValue]
+    }
+
+    public enum SortField: String {
+        case opens = "opens"
+        case postId = "post_id"
+    }
+
+    public enum SortOrder: String {
+        case descending = "desc"
+        case ascending = "ASC"
+    }
+}

--- a/Sources/WordPressKit/Models/Stats/Emails/StatsEmailsSummaryData.swift
+++ b/Sources/WordPressKit/Models/Stats/Emails/StatsEmailsSummaryData.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressShared
 
-public struct StatsEmailsSummaryData: Decodable {
+public struct StatsEmailsSummaryData: Decodable, Equatable {
     public let posts: [Post]
 
     public init(posts: [Post]) {
@@ -17,14 +17,24 @@ public struct StatsEmailsSummaryData: Decodable {
         posts = try container.decode([Post].self, forKey: .posts)
     }
 
-    public struct Post: Codable {
-        let id: Int
-        let link: URL
-        let date: Date
-        let title: String
-        let type: PostType
-        let opens: Int
-        let clicks: Int
+    public struct Post: Codable, Equatable {
+        public let id: Int
+        public let link: URL
+        public let date: Date
+        public let title: String
+        public let type: PostType
+        public let opens: Int
+        public let clicks: Int
+
+        public init(id: Int, link: URL, date: Date, title: String, type: PostType, opens: Int, clicks: Int) {
+            self.id = id
+            self.link = link
+            self.date = date
+            self.title = title
+            self.type = type
+            self.opens = opens
+            self.clicks = clicks
+        }
 
         public enum PostType: String, Codable {
             case post = "post"

--- a/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
+++ b/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
@@ -327,9 +327,8 @@ public extension StatsServiceRemoteV2 {
         let path = self.path(forEndpoint: "sites/\(siteID)/\(pathComponent)/", withVersion: ._1_1)
         let properties = StatsEmailsSummaryData.queryProperties(quantity: quantity, sortField: sortField, sortOrder: sortOrder) as [String: AnyObject]
 
-        wordPressComRESTAPI.get(path, parameters: properties, success: { [weak self] (response, _) in
-            guard let self,
-                  let jsonResponse = response as? [String: AnyObject],
+        wordPressComRESTAPI.get(path, parameters: properties, success: { (response, _) in
+            guard let jsonResponse = response as? [String: AnyObject],
                   let emailsSummaryData = StatsEmailsSummaryData(jsonDictionary: jsonResponse)
             else {
                 completion(.failure(ResponseError.decodingFailure))

--- a/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
+++ b/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
@@ -316,6 +316,33 @@ private extension StatsServiceRemoteV2 {
     }
 }
 
+// MARK: - Emails Summary
+
+public extension StatsServiceRemoteV2 {
+    public func getData(quantity: Int, 
+                        sortField: StatsEmailsSummaryData.SortField = .opens,
+                        sortOrder: StatsEmailsSummaryData.SortOrder = .descending,
+                        completion: @escaping ((Result<StatsEmailsSummaryData, Error>) -> Void)) {
+        let pathComponent = StatsEmailsSummaryData.pathComponent
+        let path = self.path(forEndpoint: "sites/\(siteID)/\(pathComponent)/", withVersion: ._1_1)
+        let properties = StatsEmailsSummaryData.queryProperties(quantity: quantity, sortField: sortField, sortOrder: sortOrder) as [String: AnyObject]
+
+        wordPressComRESTAPI.get(path, parameters: properties, success: { [weak self] (response, _) in
+            guard let self,
+                  let jsonResponse = response as? [String: AnyObject],
+                  let emailsSummaryData = StatsEmailsSummaryData(jsonDictionary: jsonResponse)
+            else {
+                completion(.failure(ResponseError.decodingFailure))
+                return
+            }
+
+            completion(.success(emailsSummaryData))
+        }, failure: { (error, _) in
+            completion(.failure(error))
+        })
+    }
+}
+
 // This serves both as a way to get the query properties in a "nice" way,
 // but also as a way to narrow down the generic type in `getInsight(completion:)` method.
 public protocol StatsInsightData {

--- a/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
+++ b/Sources/WordPressKit/Services/StatsServiceRemoteV2.swift
@@ -319,10 +319,10 @@ private extension StatsServiceRemoteV2 {
 // MARK: - Emails Summary
 
 public extension StatsServiceRemoteV2 {
-    public func getData(quantity: Int, 
-                        sortField: StatsEmailsSummaryData.SortField = .opens,
-                        sortOrder: StatsEmailsSummaryData.SortOrder = .descending,
-                        completion: @escaping ((Result<StatsEmailsSummaryData, Error>) -> Void)) {
+    func getData(quantity: Int,
+                 sortField: StatsEmailsSummaryData.SortField = .opens,
+                 sortOrder: StatsEmailsSummaryData.SortOrder = .descending,
+                 completion: @escaping ((Result<StatsEmailsSummaryData, Error>) -> Void)) {
         let pathComponent = StatsEmailsSummaryData.pathComponent
         let path = self.path(forEndpoint: "sites/\(siteID)/\(pathComponent)/", withVersion: ._1_1)
         let properties = StatsEmailsSummaryData.queryProperties(quantity: quantity, sortField: sortField, sortOrder: sortOrder) as [String: AnyObject]

--- a/Tests/WordPressKitTests/Mock Data/stats-emails-summary.json
+++ b/Tests/WordPressKitTests/Mock Data/stats-emails-summary.json
@@ -1,0 +1,38 @@
+{
+    "posts": [
+        {
+            "id": 53978,
+            "href": "https://www.test1.com",
+            "date": "2023-12-29 16:02:54",
+            "title": "A great testing post",
+            "type": "post",
+            "opens": 453192,
+            "clicks": 2202
+        },
+        {
+            "id": 52362,
+            "href": "http://www.test2.com",
+            "date": "2023-06-27 19:15:12",
+            "title": "Hot Off the Press: A new testing post",
+            "type": "post",
+            "opens": 450055,
+            "clicks": 5385
+        },
+        {
+            "id": 54733,
+            "href": "http://www.test3.com",
+            "date": "2024-03-06 21:06:28",
+            "title": "Case Study: A new testing post",
+            "type": "post",
+            "opens": 382335,
+            "clicks": 4063
+        },
+        {
+            "id": 53668,
+            "href": "http://www.test4.com",
+            "date": "2023-11-07 20:18:07",
+            "title": "Test without opens and clicks",
+            "type": "post"
+        }
+    ]
+}

--- a/Tests/WordPressKitTests/Tests/Models/Stats/V2/Emails/StatsEmailsSummaryDataTests.swift
+++ b/Tests/WordPressKitTests/Tests/Models/Stats/V2/Emails/StatsEmailsSummaryDataTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import WordPressKit
+
+final class StatsEmailsSummaryDataTests: XCTestCase {
+    func testEmailsSummaryDecoding() throws {
+        let json = getJSON("stats-emails-summary")
+
+        let emailsSummary = StatsEmailsSummaryData(jsonDictionary: json)
+        XCTAssertNotNil(emailsSummary, "StatsEmailsSummaryTimeIntervalData not decoded as expected")
+        let post = emailsSummary!.posts[0]
+
+        XCTAssertEqual(emailsSummary?.posts.count, 4)
+        XCTAssertEqual(post.link, URL(string: "https://www.test1.com"))
+        XCTAssertEqual(post.title, "A great testing post")
+        XCTAssertEqual(post.type, .post)
+        XCTAssertEqual(post.clicks, 2202)
+        XCTAssertEqual(post.opens, 453192)
+    }
+}
+
+private extension StatsEmailsSummaryDataTests {
+    func getJSON(_ fileName: String) -> [String: AnyObject] {
+        let path = Bundle(for: type(of: self)).path(forResource: fileName, ofType: "json")!
+        let data = try! Data(contentsOf: URL(fileURLWithPath: path))
+        return try! JSONSerialization.jsonObject(with: data, options: .allowFragments) as! [String: AnyObject]
+    }
+}

--- a/WordPressKit.xcodeproj/project.pbxproj
+++ b/WordPressKit.xcodeproj/project.pbxproj
@@ -7,10 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		01383F7F2BD5545B00496B76 /* StatsEmailsSummaryDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01383F7E2BD5545B00496B76 /* StatsEmailsSummaryDataTests.swift */; };
+		01383F822BD556B100496B76 /* stats-emails-summary.json in Resources */ = {isa = PBXBuildFile; fileRef = 01383F802BD5549E00496B76 /* stats-emails-summary.json */; };
 		01438D362B6A31540097D60A /* stats-visits-month-unit-week.json in Resources */ = {isa = PBXBuildFile; fileRef = 01438D342B6A2B2C0097D60A /* stats-visits-month-unit-week.json */; };
 		01438D392B6A361B0097D60A /* stats-summary.json in Resources */ = {isa = PBXBuildFile; fileRef = 01438D372B6A35FB0097D60A /* stats-summary.json */; };
 		01438D3B2B6A36BF0097D60A /* StatsTotalsSummaryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01438D3A2B6A36BF0097D60A /* StatsTotalsSummaryData.swift */; };
 		0152100C28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */; };
+		019C5B8B2BD59CE000A69DB0 /* StatsEmailsSummaryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019C5B892BD59CE000A69DB0 /* StatsEmailsSummaryData.swift */; };
 		0847B92C2A4442730044D32F /* IPLocationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0847B92B2A4442730044D32F /* IPLocationRemote.swift */; };
 		08C7493E2A45EA11000DA0E2 /* IPLocationRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C7493D2A45EA11000DA0E2 /* IPLocationRemoteTests.swift */; };
 		0C1C08412B9CD79900E52F8C /* PostServiceRemoteExtended.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C1C08402B9CD79900E52F8C /* PostServiceRemoteExtended.swift */; };
@@ -754,10 +757,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		01383F7E2BD5545B00496B76 /* StatsEmailsSummaryDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsEmailsSummaryDataTests.swift; sourceTree = "<group>"; };
+		01383F802BD5549E00496B76 /* stats-emails-summary.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "stats-emails-summary.json"; sourceTree = "<group>"; };
 		01438D342B6A2B2C0097D60A /* stats-visits-month-unit-week.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "stats-visits-month-unit-week.json"; sourceTree = "<group>"; };
 		01438D372B6A35FB0097D60A /* stats-summary.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "stats-summary.json"; sourceTree = "<group>"; };
 		01438D3A2B6A36BF0097D60A /* StatsTotalsSummaryData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTotalsSummaryData.swift; sourceTree = "<group>"; };
 		0152100B28EDA9E400DD6783 /* StatsAnnualAndMostPopularTimeInsightDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsAnnualAndMostPopularTimeInsightDecodingTests.swift; sourceTree = "<group>"; };
+		019C5B892BD59CE000A69DB0 /* StatsEmailsSummaryData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsEmailsSummaryData.swift; sourceTree = "<group>"; };
 		0847B92B2A4442730044D32F /* IPLocationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPLocationRemote.swift; sourceTree = "<group>"; };
 		08C7493D2A45EA11000DA0E2 /* IPLocationRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPLocationRemoteTests.swift; sourceTree = "<group>"; };
 		0C1C08402B9CD79900E52F8C /* PostServiceRemoteExtended.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostServiceRemoteExtended.swift; sourceTree = "<group>"; };
@@ -1523,6 +1529,29 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01383F7D2BD5542300496B76 /* TimeInterval */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = TimeInterval;
+			sourceTree = "<group>";
+		};
+		019C5B882BD59C7800A69DB0 /* Emails */ = {
+			isa = PBXGroup;
+			children = (
+				01383F7E2BD5545B00496B76 /* StatsEmailsSummaryDataTests.swift */,
+			);
+			path = Emails;
+			sourceTree = "<group>";
+		};
+		019C5B8A2BD59CE000A69DB0 /* Emails */ = {
+			isa = PBXGroup;
+			children = (
+				019C5B892BD59CE000A69DB0 /* StatsEmailsSummaryData.swift */,
+			);
+			path = Emails;
+			sourceTree = "<group>";
+		};
 		3297E1DC2564649D00287D21 /* Scan */ = {
 			isa = PBXGroup;
 			children = (
@@ -1654,6 +1683,7 @@
 		3FE2E9362BB10EC7002CA2E1 /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				019C5B8A2BD59CE000A69DB0 /* Emails */,
 				404057C3221B30140060250C /* Time Interval */,
 				40414061220F9F2800CF7C5B /* Insights */,
 				40819782221F5C8200A298E4 /* StatsPostDetails.swift */,
@@ -2480,6 +2510,7 @@
 				4081977D221F269A00A298E4 /* stats-visits-month.json */,
 				01438D342B6A2B2C0097D60A /* stats-visits-month-unit-week.json */,
 				40819779221F153A00A298E4 /* stats-visits-week.json */,
+				01383F802BD5549E00496B76 /* stats-emails-summary.json */,
 				436D56392118DE3B00CEAA33 /* supported-countries-success.json */,
 				436D56522121F60400CEAA33 /* supported-states-empty.json */,
 				436D563D2118E34D00CEAA33 /* supported-states-success.json */,
@@ -2597,6 +2628,8 @@
 		F3FF8A1C279C86F600E5C90F /* V2 */ = {
 			isa = PBXGroup;
 			children = (
+				019C5B882BD59C7800A69DB0 /* Emails */,
+				01383F7D2BD5542300496B76 /* TimeInterval */,
 				F3FF8A1D279C86FE00E5C90F /* Insights */,
 			);
 			path = V2;
@@ -3146,6 +3179,7 @@
 				740B23E41F17FB4200067A2A /* xmlrpc-metaweblog-editpost-success.xml in Resources */,
 				7434E1DE1F17C3C900C40DDB /* site-users-update-role-unknown-user-failure.json in Resources */,
 				4081977B221F153B00A298E4 /* stats-visits-week.json in Resources */,
+				01383F822BD556B100496B76 /* stats-emails-summary.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3296,6 +3330,7 @@
 				8BB66DB02523C181000B29DA /* ReaderPostServiceRemote+V2.swift in Sources */,
 				74E229501F1E741B0085F7F2 /* RemotePublicizeConnection.swift in Sources */,
 				40E7FEB722106A8D0032834E /* StatsCommentsInsight.swift in Sources */,
+				019C5B8B2BD59CE000A69DB0 /* StatsEmailsSummaryData.swift in Sources */,
 				9856BE962630B5C200C12FEB /* RemoteUser+Likes.swift in Sources */,
 				3FD634E52BC3A55F00CEDF5E /* WordPressOrgXMLRPCValidator.swift in Sources */,
 				3FE2E97B2BC3A332002CA2E1 /* WordPressAPIError+NSErrorBridge.swift in Sources */,
@@ -3551,6 +3586,7 @@
 				93188D221F2264E60028ED4D /* TaxonomyServiceRemoteRESTTests.m in Sources */,
 				F194E1232417ED9F00874408 /* AtomicAuthenticationServiceRemoteTests.swift in Sources */,
 				4AB6A3652B83191600769115 /* ReaderPostServiceRemote+FetchEndpointTests.swift in Sources */,
+				01383F7F2BD5545B00496B76 /* StatsEmailsSummaryDataTests.swift in Sources */,
 				9817D9D426BC8AF000ECBD8C /* CommentServiceRemoteXMLRPCTests.swift in Sources */,
 				74FC6F3B1F191BB400112505 /* NotificationSyncServiceRemoteTests.swift in Sources */,
 				731BA83821DECD97000FDFCD /* SiteCreationResponseDecodingTests.swift in Sources */,


### PR DESCRIPTION
### Description

Add support for `stats/emails/summary` endpoint:

1. Add `StatsEmailsSummaryData` entity
2. Add `getData` `StatsServiceRemoteV2` method for specific `StatsEmailsSummaryData` result type since its request and response format doesn't match any other current Stats entities
3. Add tests

### Testing Details

https://github.com/wordpress-mobile/WordPress-iOS/pull/23056

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
