### PR TITLE
Make StatsFollower Equatable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ _None._
 ### Internal Changes
 
 - Update new APIs to create and update posts introduced `PostServiceRemoteExtended` to use `wp.newPost` and `wp.editPost` instead of the older versions of these APIs [#792]
+- Update `StatsFollower` to be `Equatable` [#797]
 
 
 ## 17.0.0

--- a/Sources/WordPressKit/Models/Stats/Insights/StatsDotComFollowersInsight.swift
+++ b/Sources/WordPressKit/Models/Stats/Insights/StatsDotComFollowersInsight.swift
@@ -29,7 +29,7 @@ extension StatsDotComFollowersInsight: StatsInsightData {
     fileprivate static let dateFormatter = ISO8601DateFormatter()
 }
 
-public struct StatsFollower: Codable {
+public struct StatsFollower: Codable, Equatable {
     public let id: String?
     public let name: String
     public let subscribedDate: Date


### PR DESCRIPTION
### Description

Related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/23067. These changes are helpful when comparing values changes when they come from the backend.

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
