### PR TITLE
Fix encoding of empty fields for RemotePostUpdateParametersWordPressComEncoder

### DIFF
--- a/Sources/WordPressKit/Models/RemotePostParameters.swift
+++ b/Sources/WordPressKit/Models/RemotePostParameters.swift
@@ -91,7 +91,7 @@ extension RemotePostCreateParameters {
         if (previous.content ?? "") != (content ?? "") {
             changes.content = (content ?? "")
         }
-        if previous.password != password {
+        if (previous.password ?? "") != (password ?? "") {
             changes.password = password
         }
         if (previous.excerpt ?? "") != (excerpt ?? "") {
@@ -289,11 +289,11 @@ struct RemotePostUpdateParametersWordPressComEncoder: Encodable {
         try container.encodeIfPresent(parameters.status, forKey: .status)
         try container.encodeIfPresent(parameters.date, forKey: .date)
         try container.encodeIfPresent(parameters.authorID, forKey: .authorID)
-        try container.encodeIfPresent(parameters.title, forKey: .title)
-        try container.encodeIfPresent(parameters.content, forKey: .content)
-        try container.encodeIfPresent(parameters.password, forKey: .password)
-        try container.encodeIfPresent(parameters.excerpt, forKey: .excerpt)
-        try container.encodeIfPresent(parameters.slug, forKey: .slug)
+        try container.encodeStringIfPresent(parameters.title, forKey: .title)
+        try container.encodeStringIfPresent(parameters.content, forKey: .content)
+        try container.encodeStringIfPresent(parameters.password, forKey: .password)
+        try container.encodeStringIfPresent(parameters.excerpt, forKey: .excerpt)
+        try container.encodeStringIfPresent(parameters.slug, forKey: .slug)
         if let value = parameters.featuredImageID {
             try container.encodeNullableID(value, forKey: .featuredImageID)
         }


### PR DESCRIPTION
### Description

Applies the same treatment as in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/786 but to .com endpoints.


### Testing Details

Test using https://github.com/wordpress-mobile/WordPressKit-iOS/pull/801

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
