### PR TITLE
Remove explicit macOS platform requirement from `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,12 @@ let package = Package(
             name: "CoreAPI",
             dependencies: [
                 .target(name: "APIInterface"),
-                .product(name: "WordPressShared", package: "WordPress-iOS-Shared"),
+                .product(
+                    name: "WordPressShared",
+                    package: "WordPress-iOS-Shared",
+                    // Constrain to iOS only to avoid having to explicitly set a macOS version because of this library's requirements.
+                    condition: .when(platforms: [.iOS])
+                ),
                 "wpxmlrpc"
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -4,11 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "WordPressKit",
-    platforms: [
-        .iOS(.v13),
-        // The package(s) are meant for iOS only, but the use of the SwiftLint plugin down the dependency chain requires specifying a compatible macOS version.
-        .macOS(.v12),
-    ],
+    platforms: [.iOS(.v13)],
     products: [
         .library(name: "APIInterface", targets: ["APIInterface"]),
         .library(name: "CoreAPI", targets: ["CoreAPI"]),


### PR DESCRIPTION
It was there because of an error related to the WordPressShared dependency using the SwiftLint build plugin. I discovered what I think is a better approach to set up the dependency, which does not require explicitly declaring macOS support.

### Before

<img width="2109" alt="image" src="https://github.com/wordpress-mobile/WordPressKit-iOS/assets/1218433/c92834f5-aa9d-4717-b3f1-5a4972f7d499">

### After

<img width="2116" alt="image" src="https://github.com/wordpress-mobile/WordPressKit-iOS/assets/1218433/1625622b-0cfc-44c7-bfa9-c2285cd89010">

### Testing Details

See green CI. 

However, notice CI doesn't build the package, so the test might give a false positive for this change.

One way to verify it is to run the following script:

```sh
#!/bin/bash

# Quit Xcode in case there is a version of WordPressKit open that could give us trouble
osascript -e 'tell application "Xcode" to quit'

mkdir -p xcode_staging
mv ./WordPressKit.xcodeproj xcode_staging
mv ./WordPressKit.xcworkspace xcode_staging

bundle install

# The device parameter is required (when running standalone?) or the underlying xcodebuild call will fail with:
# Building a Swift package requires that a destination is provided using the "-destination" option. [...]
bundle exec fastlane run run_tests \
  package_path:. \
  scheme:WordPressKit-Package \
  device:'iPhone 15 Pro'

mv xcode_staging/* .

rm -rf xcode_staging
```

---

- [ ] Please check here if your pull request includes additional test coverage. — N.A.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary. — N.A.