### PR TITLE
Bump version to 17.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ _None._
 
 _None._
 
+## 17.1.1
+
+### Bug Fixes
+
+- Fix encoding of empty fields for `RemotePostUpdateParametersWordPressComEncoder` [#801]
+
 ## 17.1.0
 
 ### New Features
@@ -66,7 +72,6 @@ _None._
 
 - Update new APIs to create and update posts introduced `PostServiceRemoteExtended` to use `wp.newPost` and `wp.editPost` instead of the older versions of these APIs [#792]
 - Update `StatsFollower` to be `Equatable` [#797]
-
 
 ## 17.0.0
 

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '17.1.0'
+  s.version       = '17.1.1'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
This version bump PR is part of the beta release workflow for WordPress iOS 24.8 and is here only to leave a breadcrumb in the release process. Once CI is green, I will push the tag for this version and, once that is successfully deployed, admin-merge this.