### PR TITLE
Bump version to 17.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,24 @@ _None._
 
 ### New Features
 
+_None._
+
+### Bug Fixes
+
+_None._
+
+### Internal Changes
+
+_None._
+
+## 17.1.2
+
+### Breaking Changes
+
+_None._
+
+### New Features
+
 - Add `JetpackAIServiceRemote`
 
 ### Bug Fixes

--- a/WordPressKit.podspec
+++ b/WordPressKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name          = 'WordPressKit'
-  s.version       = '17.1.1'
+  s.version       = '17.1.2'
 
   s.summary       = 'WordPressKit offers a clean and simple WordPress.com and WordPress.org API.'
   s.description   = <<-DESC


### PR DESCRIPTION
### Description

This version bump is part of the beta release workflow for the 25.0 release.

### Testing Details

Not applicable.

---

- [ ] Please check here if your pull request includes additional test coverage. **Not applicable** 
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
