### PR TITLE
Expanded `StatsFileDownload` entity to contain `relativeURL` and `downloadURL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ _None._
 
 ### Breaking Changes
 
-_None._
+- Expanded `StatsFileDownload` entity to contain `relativeURL` and `downloadURL` [#808]
 
 ### New Features
 

--- a/Sources/WordPressKit/Models/Stats/Time Interval/StatsFileDownloadsTimeIntervalData.swift
+++ b/Sources/WordPressKit/Models/Stats/Time Interval/StatsFileDownloadsTimeIntervalData.swift
@@ -67,7 +67,7 @@ extension StatsFileDownloadsTimeIntervalData: StatsTimeIntervalData {
             return StatsFileDownload(
                 file: file,
                 downloadCount: downloads,
-                relativeURL: relativeURLString, 
+                relativeURL: relativeURLString,
                 downloadURL: downloadURL
             )
         }

--- a/Sources/WordPressKit/Models/Stats/Time Interval/StatsFileDownloadsTimeIntervalData.swift
+++ b/Sources/WordPressKit/Models/Stats/Time Interval/StatsFileDownloadsTimeIntervalData.swift
@@ -22,11 +22,17 @@ public struct StatsFileDownloadsTimeIntervalData {
 public struct StatsFileDownload {
     public let file: String
     public let downloadCount: Int
+    public let relativeURL: String
+    public let downloadURL: URL
 
     public init(file: String,
-                downloadCount: Int) {
+                downloadCount: Int,
+                relativeURL: String,
+                downloadURL: URL) {
         self.file = file
         self.downloadCount = downloadCount
+        self.relativeURL = relativeURL
+        self.downloadURL = downloadURL
     }
 }
 
@@ -49,11 +55,21 @@ extension StatsFileDownloadsTimeIntervalData: StatsTimeIntervalData {
         }
 
         let fileDownloads: [StatsFileDownload] = fileDownloadsDict.compactMap {
-            guard let file = $0["filename"] as? String, let downloads = $0["downloads"] as? Int else {
+            guard let file = $0["filename"] as? String,
+                  let downloads = $0["downloads"] as? Int,
+                  let relativeURLString = $0["relative_url"] as? String,
+                  let downloadURLString = $0["download_url"] as? String,
+                  let downloadURL = URL(string: downloadURLString)
+            else {
                 return nil
             }
 
-            return StatsFileDownload(file: file, downloadCount: downloads)
+            return StatsFileDownload(
+                file: file,
+                downloadCount: downloads,
+                relativeURL: relativeURLString, 
+                downloadURL: downloadURL
+            )
         }
 
         self.periodEndDate = date

--- a/Tests/WordPressKitTests/Mock Data/stats-file-downloads.json
+++ b/Tests/WordPressKitTests/Mock Data/stats-file-downloads.json
@@ -5,12 +5,16 @@
         "2019-07-01": {
             "files": [
                 {
-                    "filename": "/2019/07/test.pdf",
-                    "downloads": 11
+                    "filename": "test.pdf",
+                    "downloads": 11,
+                    "relative_url": "/2019/07/test.pdf",
+                    "download_url": "https://testsite.com/2019/07/test.pdf"
                 },
                 {
-                    "filename": "/2019/07/sampleaudio.mp3",
-                    "downloads": 4
+                    "filename": "sampleaudio.mp3",
+                    "downloads": 4,
+                    "relative_url": "/2019/07/sampleaudio.mp3",
+                    "download_url": "https://testsite.com/2019/07/sampleaudio.mp3"
                 }
             ],
             "other_downloads": 0,

--- a/Tests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
+++ b/Tests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
@@ -393,7 +393,8 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
             XCTAssertEqual(fileDownloads?.fileDownloads.count, 2)
 
-            XCTAssertEqual(fileDownloads?.fileDownloads.first!.file, "/2019/07/test.pdf")
+            XCTAssertEqual(fileDownloads?.fileDownloads.first!.file, "test.pdf")
+            XCTAssertEqual(fileDownloads?.fileDownloads.first!.downloadURL, URL(string: "https://testsite.com/2019/07/test.pdf"))
             XCTAssertEqual(fileDownloads?.fileDownloads.first!.downloadCount, 11)
 
             expect.fulfill()


### PR DESCRIPTION
### Description

Expanded `StatsFileDownload` entity to contain `relativeURL` and `downloadURL`

Related to https://github.com/wordpress-mobile/WordPress-iOS/issues/23270

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [x] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
