### PR TITLE
Support editing media metadata via XMLRPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ _None._
 
 ### New Features
 
-_None._
+- Support updating media metadata via XMLRPC API [#809]
 
 ### Bug Fixes
 

--- a/Sources/WordPressKit/Services/MediaServiceRemoteXMLRPC.m
+++ b/Sources/WordPressKit/Services/MediaServiceRemoteXMLRPC.m
@@ -202,18 +202,16 @@
     NSParameterAssert([media.mediaID longLongValue] > 0);
 
     NSMutableDictionary *content = [NSMutableDictionary dictionary];
-    if (media.title != nil) 
-    {
+
+    if (media.title != nil) {
         content[@"post_title"] = media.title;
     }
 
-    if (media.caption != nil)
-    {
+    if (media.caption != nil) {
         content[@"post_excerpt"] = media.caption;
     }
 
-    if (media.descriptionText != nil) 
-    {
+    if (media.descriptionText != nil) {
         content[@"post_content"] = media.descriptionText;
     }
 


### PR DESCRIPTION
### Description

Related ticket: https://github.com/wordpress-mobile/WordPress-iOS/issues/20726

Media is a type of post therefore "wp.editPost" can be used to edit media metadata via XML-RPC. 

Note that alternative text cannot be edited due to lack of XML-RPC support https://core.trac.wordpress.org/ticket/58582. Explanation: https://github.com/wordpress-mobile/WordPress-Android/issues/18514#issuecomment-15897522

Android solution: https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/98d43f5f4ed25dbacac85fc42889a6ac529c03e4/fluxc/src/main/java/org/wordpress/android/fluxc/network/xmlrpc/media/MediaXMLRPCClient.java#L99 

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
