### PR TITLE
Adds os_version parameter to feature flags and dashboard cards APIs

### DIFF
--- a/Sources/WordPressKit/Models/SessionDetails.swift
+++ b/Sources/WordPressKit/Models/SessionDetails.swift
@@ -4,6 +4,7 @@ public struct SessionDetails {
     let buildNumber: String
     let marketingVersion: String
     let identifier: String
+    let osVersion: String
 }
 
 extension SessionDetails: Encodable {
@@ -14,6 +15,7 @@ extension SessionDetails: Encodable {
         case buildNumber = "build_number"
         case marketingVersion = "marketing_version"
         case identifier = "identifier"
+        case osVersion = "os_version"
     }
 
     init(deviceId: String, bundle: Bundle = .main) {
@@ -22,6 +24,7 @@ extension SessionDetails: Encodable {
         self.buildNumber = bundle.infoDictionary?["CFBundleVersion"] as? String ?? "Unknown"
         self.marketingVersion = bundle.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
         self.identifier = bundle.bundleIdentifier ?? "Unknown"
+        self.osVersion = UIDevice.current.systemVersion
     }
 
     func dictionaryRepresentation() throws -> [String: AnyObject]? {

--- a/Tests/WordPressKitTests/Tests/DashboardServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/Tests/DashboardServiceRemoteTests.swift
@@ -23,7 +23,8 @@ class DashboardServiceRemoteTests: RemoteTestCase, RESTTestable {
             "marketing_version",
             "device_id",
             "cards",
-            "locale"
+            "locale",
+            "os_version",
         ]
 
         stubRemoteResponse({ req in

--- a/Tests/WordPressKitTests/Tests/Utilities/FeatureFlagRemoteTests.swift
+++ b/Tests/WordPressKitTests/Tests/Utilities/FeatureFlagRemoteTests.swift
@@ -15,7 +15,8 @@ class FeatureFlagRemoteTests: RemoteTestCase, RESTTestable {
             "platform",
             "build_number",
             "marketing_version",
-            "device_id"
+            "device_id",
+            "os_version",
         ]
 
         stub { req -> Bool in


### PR DESCRIPTION
### Description
Adds `os_version` parameter to feature flags and dashboard cards APIs

See pcdRpT-6Xn-p2

### Testing Details

See `WordPress-iOS` PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/23319

**⚠️ Please remove the `[Status] DO NOT MERGE` label and merge after:**
* D150987-code is deployed (the app should keep working even without it)
* the `WordPress-iOS` PR is approved (this should not be a breaking change)

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.