### PR TITLE
[Tooling] SwiftLint: Use `linter` agent instead of `default` agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -44,7 +44,7 @@ steps:
       - github_commit_status:
           context: "SwiftLint"
     agents:
-      queue: "default"
+      queue: "linter"
 
   - label: "🧹 Lint"
     key: "lint"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,8 +38,9 @@ steps:
   # Linters
   #################
   - label: ":swift: SwiftLint"
-    command: run_swiftlint --strict
-    plugins: *common_plugins
+    command: swiftlint
+    env:
+      SWIFTLINT_OPTION_STRICT: "true"
     notify:
       - github_commit_status:
           context: "SwiftLint"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -40,12 +40,12 @@ steps:
   - label: ":swift: SwiftLint"
     command: swiftlint
     env:
-      SWIFTLINT_OPTION_STRICT: "true"
+      SWIFTLINT_OPTION_STRICT: true
     notify:
       - github_commit_status:
-          context: "SwiftLint"
+          context: SwiftLint
     agents:
-      queue: "linter"
+      queue: linter
 
   - label: "🧹 Lint"
     key: "lint"


### PR DESCRIPTION
### Description

This PR updates the SwiftLint CI task to use the `linter` agent for running SwiftLint instead of the `default` agent. 

### Testing Details

This is good to go as long as CI (and especially SwiftLint) is green

---

- [X] Please check here if your pull request includes additional test coverage.
- [X] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
