### PR TITLE
Update Reader APIs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/17435861/WordPressKit.zip",
-            checksum: "af7239442da8470a91ef5ab923fd91222bb3c0ea345b18f581bfafd63f0dd6b6"
+            url: "https://github.com/user-attachments/files/17435956/WordPressKit.zip",
+            checksum: "b3babe54d211d862e485ab3a742080dc9f2a5f04e2a6fa1d675545b0d00a795e"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/16531883/WordPressKit.zip",
-            checksum: "ca916824c64a6061814a69a37bc9a6560aafcc35559983e945fdfa5c3bbcc23d"
+            url: "https://github.com/user-attachments/files/17435861/WordPressKit.zip",
+            checksum: "af7239442da8470a91ef5ab923fd91222bb3c0ea345b18f581bfafd63f0dd6b6"
         ),
     ]
 )

--- a/Sources/WordPressKit/Models/RemoteReaderPost.m
+++ b/Sources/WordPressKit/Models/RemoteReaderPost.m
@@ -97,7 +97,10 @@ static const NSUInteger ReaderPostTitleLength = 30;
     self.authorDisplayName = [[self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyName]] wpkit_stringByDecodingXMLCharacters]; // Typically the author's given name
     self.authorEmail = [self authorEmailFromAuthorDictionary:authorDict];
     self.authorURL = [self stringOrEmptyString:[authorDict stringForKey:PostRESTKeyURL]];
-    self.siteIconURL = [self stringOrEmptyString:[dict stringForKeyPath:@"meta.data.site.icon.img"]];
+    self.siteIconURL = [self stringOrEmptyString:[dict stringForKeyPath:@"site_icon.img"]];
+    if (self.siteIconURL.length == 0) {
+        self.siteIconURL = [self stringOrEmptyString:[dict stringForKeyPath:@"meta.data.site.icon.img"]];
+    }
     self.blogName = [self siteNameFromPostDictionary:dict];
     self.blogDescription = [self siteDescriptionFromPostDictionary:dict];
     self.blogURL = [self siteURLFromPostDictionary:dict];

--- a/Sources/WordPressKit/Services/ReaderPostServiceRemote+Cards.swift
+++ b/Sources/WordPressKit/Services/ReaderPostServiceRemote+Cards.swift
@@ -46,20 +46,22 @@ extension ReaderPostServiceRemote {
     /// - Topics you may like
     /// - Blogs you may like and so on
     ///
+    /// - Parameter stream: The name of the stream. By default, `discover`.
     /// - Parameter topics: an array of String representing the topics
     /// - Parameter page: a String that represents a page handle
     /// - Parameter sortingOption: a ReaderSortingOption that represents a sorting option
     /// - Parameter count: the number of cards to fetch. Warning: This also changes the number of objects returned for recommended sites/tags.
     /// - Parameter success: Called when the request succeeds and the data returned is valid
     /// - Parameter failure: Called if the request fails for any reason, or the response data is invalid
-    public func fetchStreamCards(for topics: [String],
+    public func fetchStreamCards(stream: String = "discover",
+                                 for topics: [String],
                                  page: String? = nil,
                                  sortingOption: ReaderSortingOption = .noSorting,
                                  refreshCount: Int? = nil,
                                  count: Int? = nil,
                                  success: @escaping ([RemoteReaderCard], String?) -> Void,
                                  failure: @escaping (Error) -> Void) {
-        let path = "read/streams/discover"
+        let path = "read/streams/\(stream)"
         guard let requestUrl = cardsEndpoint(with: path,
                                              topics: topics,
                                              page: page,

--- a/Sources/WordPressKit/Services/ReaderPostServiceRemote+Cards.swift
+++ b/Sources/WordPressKit/Services/ReaderPostServiceRemote+Cards.swift
@@ -11,6 +11,11 @@ public enum ReaderSortingOption: String, CaseIterable {
     }
 }
 
+public enum ReaderStream: String {
+    case discover = "discover"
+    case firstPosts = "first-posts"
+}
+
 extension ReaderPostServiceRemote {
     /// Returns a collection of RemoteReaderCard using the tags API
     /// a Reader Card can represent an item for the reader feed, such as
@@ -46,14 +51,14 @@ extension ReaderPostServiceRemote {
     /// - Topics you may like
     /// - Blogs you may like and so on
     ///
-    /// - Parameter stream: The name of the stream. By default, `discover`.
+    /// - Parameter stream: The name of the stream. By default, `.discover`.
     /// - Parameter topics: an array of String representing the topics
     /// - Parameter page: a String that represents a page handle
     /// - Parameter sortingOption: a ReaderSortingOption that represents a sorting option
     /// - Parameter count: the number of cards to fetch. Warning: This also changes the number of objects returned for recommended sites/tags.
     /// - Parameter success: Called when the request succeeds and the data returned is valid
     /// - Parameter failure: Called if the request fails for any reason, or the response data is invalid
-    public func fetchStreamCards(stream: String = "discover",
+    public func fetchStreamCards(stream: ReaderStream = .discover,
                                  for topics: [String],
                                  page: String? = nil,
                                  sortingOption: ReaderSortingOption = .noSorting,
@@ -61,7 +66,7 @@ extension ReaderPostServiceRemote {
                                  count: Int? = nil,
                                  success: @escaping ([RemoteReaderCard], String?) -> Void,
                                  failure: @escaping (Error) -> Void) {
-        let path = "read/streams/\(stream)"
+        let path = "read/streams/\(stream.rawValue)"
         guard let requestUrl = cardsEndpoint(with: path,
                                              topics: topics,
                                              page: page,


### PR DESCRIPTION
### Description

- Add support for changing the Discover streams (required for `first-posts`)
- Add support for site icons in Discover

### Testing Details

PR:  https://github.com/wordpress-mobile/WordPress-iOS/pull/23676

- Check that site icons are loading in Discover
- Check that "First Posts" stream works and show the same posts as on the web

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
