### PR TITLE
Add support for sending magic links to inexistent accounts

### DIFF
--- a/Sources/WordPressKit/Services/AccountServiceRemoteREST.h
+++ b/Sources/WordPressKit/Services/AccountServiceRemoteREST.h
@@ -28,6 +28,21 @@ extern MagicLinkFlow const MagicLinkFlowSignup;
                         clientSecret:(NSString *)clientSecret
                               source:(MagicLinkSource)source
                          wpcomScheme:(NSString *)scheme
+             createAccountIfNotFound:(BOOL)createAccountIfNotFound
+                             success:(void (^)(void))success
+                             failure:(void (^)(NSError *error))failure;
+
+/**
+*  @brief      Request an authentication link be sent to the email address provided.
+*
+ *  @param      success     The block that will be executed on success.  Can be nil.
+ *  @param      failure     The block that will be executed on failure.  Can be nil.
+ */
+- (void)requestWPComAuthLinkForEmail:(NSString *)email
+                            clientID:(NSString *)clientID
+                        clientSecret:(NSString *)clientSecret
+                              source:(MagicLinkSource)source
+                         wpcomScheme:(NSString *)scheme
                              success:(void (^)(void))success
                              failure:(void (^)(NSError *error))failure;
 

--- a/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
@@ -245,17 +245,19 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
                         clientSecret:(NSString *)clientSecret
                               source:(MagicLinkSource)source
                          wpcomScheme:(NSString *)scheme
+             createAccountIfNotFound:(BOOL)createAccountIfNotFound
                              success:(void (^)(void))success
                              failure:(void (^)(NSError *error))failure
 {
     NSString *path = [self pathForEndpoint:@"auth/send-login-email"
                                withVersion:WordPressComRESTAPIVersion_1_3];
-    
+
     NSDictionary *extraParams = @{
         MagicLinkParameterFlow: MagicLinkFlowLogin,
-        MagicLinkParameterSource: source
+        MagicLinkParameterSource: source,
+        @"create_account": createAccountIfNotFound ? @"true" : @"false"
     };
-    
+
     [self requestWPComMagicLinkForEmail:email
                                    path:path
                                clientID:clientID
@@ -264,6 +266,24 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
                             wpcomScheme:scheme
                                 success:success
                                 failure:failure];
+}
+
+- (void)requestWPComAuthLinkForEmail:(NSString *)email
+                            clientID:(NSString *)clientID
+                        clientSecret:(NSString *)clientSecret
+                              source:(MagicLinkSource)source
+                         wpcomScheme:(NSString *)scheme
+                             success:(void (^)(void))success
+                             failure:(void (^)(NSError *error))failure
+{
+    [self requestWPComAuthLinkForEmail:email
+                              clientID:clientID
+                          clientSecret:clientSecret
+                                source:source
+                           wpcomScheme:scheme
+               createAccountIfNotFound:NO
+                               success:success
+                               failure:failure];
 }
 
 - (void)requestWPComSignupLinkForEmail:(NSString *)email


### PR DESCRIPTION
### Description

Part of https://github.com/woocommerce/woocommerce-ios/issues/14419

This PR updates the magic link request with an option to pass the option `create_account`, this option allows to use the same request for signup flow needed for the above task.

### Testing Details
Use https://github.com/woocommerce/woocommerce-ios/pull/14431

---

- [ ] Please check here if your pull request includes additional test coverage.
- [x] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
