### PR TITLE
Add an argument to use ephemeral URLSession to send WP.com API requests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/18379301/WordPressKit.zip",
-            checksum: "afd882de3a6a672c32c6cc7e6e1c1e68ff4e1366e7613af4eab59415ed7abb59"
+            url: "https://github.com/user-attachments/files/18570063/WordPressKit.zip",
+            checksum: "fc25d3065e80af713dac970db7ed89ff37e4cc98afc98b6a2ecf7b47b2ddd0c1"
         ),
     ]
 )

--- a/Sources/CoreAPI/WordPressComRestApi.swift
+++ b/Sources/CoreAPI/WordPressComRestApi.swift
@@ -103,6 +103,8 @@ open class WordPressComRestApi: NSObject {
 
     private var invalidTokenHandler: (() -> Void)?
 
+    private var useEphemeralSession: Bool
+
     /**
      Configure whether or not the user's preferred language locale should be appended. Defaults to true.
      */
@@ -139,7 +141,8 @@ open class WordPressComRestApi: NSObject {
                 backgroundSessionIdentifier: String = WordPressComRestApi.defaultBackgroundSessionIdentifier,
                 sharedContainerIdentifier: String? = nil,
                 localeKey: String = WordPressComRestApi.LocaleKeyDefault,
-                baseURL: URL = WordPressComRestApi.apiBaseURL) {
+                baseURL: URL = WordPressComRestApi.apiBaseURL,
+                useEphemeralSession: Bool = false) {
         self.oAuthToken = oAuthToken
         self.userAgent = userAgent
         self.backgroundUploads = backgroundUploads
@@ -147,6 +150,7 @@ open class WordPressComRestApi: NSObject {
         self.sharedContainerIdentifier = sharedContainerIdentifier
         self.localeKey = localeKey
         self.baseURL = baseURL
+        self.useEphemeralSession = useEphemeralSession
 
         super.init()
     }
@@ -347,7 +351,14 @@ open class WordPressComRestApi: NSObject {
     }()
 
     private func sessionConfiguration(background: Bool) -> URLSessionConfiguration {
-        let configuration = background ? URLSessionConfiguration.background(withIdentifier: self.backgroundSessionIdentifier) : URLSessionConfiguration.default
+        let configuration: URLSessionConfiguration
+        if background {
+            configuration = .background(withIdentifier: self.backgroundSessionIdentifier)
+        } else if useEphemeralSession {
+            configuration = .ephemeral
+        } else {
+            configuration = .default
+        }
 
         var additionalHeaders: [String: AnyObject] = [:]
         if let oAuthToken = self.oAuthToken {


### PR DESCRIPTION
### Description

What says in the title. Some endpoints do not need to include cookies in the shared cookie jar.

### Testing Details

[WordPressKit.zip](https://github.com/user-attachments/files/18570063/WordPressKit.zip)
 

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
