### PR TITLE
Parse the menu_order property in posts list

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19658656/WordPressKit.zip",
-            checksum: "9172f9b9906e64efe1f3d79f074ad317f1d40c6ce1ec394259b0f99fea6fe8ee"
+            url: "https://github.com/user-attachments/files/19732825/WordPressKit.zip",
+            checksum: "0ecd8b19cd00a4ef363ab6e826f92166c1efa4693db8f3218533510a3f951dbb"
         ),
     ]
 )

--- a/Sources/WordPressKit/Models/RemotePost.h
+++ b/Sources/WordPressKit/Models/RemotePost.h
@@ -36,6 +36,7 @@ extern NSString * const PostStatusDeleted;
 @property (nonatomic, strong) NSString *postThumbnailPath;
 @property (nonatomic, strong) NSString *type;
 @property (nonatomic, strong) NSString *format;
+@property (nonatomic, assign) NSInteger order;
 
 /**
 * A snapshot of the post at the last autosave.

--- a/Sources/WordPressKit/Services/PostServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/PostServiceRemoteREST.m
@@ -471,6 +471,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     post.postThumbnailPath = [postThumbnail stringForKeyPath:@"URL"];
     post.type = jsonPost[@"type"];
     post.format = jsonPost[@"format"];
+    post.order = [jsonPost numberForKey:@"menu_order"].integerValue;
 
     post.commentCount = [jsonPost numberForKeyPath:@"discussion.comment_count"] ?: @0;
     post.likeCount = [jsonPost numberForKeyPath:@"like_count"] ?: @0;

--- a/Sources/WordPressKit/Services/PostServiceRemoteXMLRPC.m
+++ b/Sources/WordPressKit/Services/PostServiceRemoteXMLRPC.m
@@ -322,6 +322,7 @@ static NSString * const RemoteOptionValueOrderByPostID = @"ID";
     post.postThumbnailPath = [thumbnailDict stringForKey:@"link"];
     post.type = xmlrpcDictionary[@"post_type"];
     post.format = xmlrpcDictionary[@"post_format"];
+    post.order = [xmlrpcDictionary numberForKey:@"menu_order"].integerValue;
 
     post.metadata = xmlrpcDictionary[@"custom_fields"];
 


### PR DESCRIPTION
### Description

[WordPressKit.zip](https://github.com/user-attachments/files/19732825/WordPressKit.zip)



Fixes #

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
