### PR TITLE
Exclude deleted sites from getBlogs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19034191/WordPressKit.zip",
-            checksum: "34f108cba86b5e4334d1c9af79946dbb8b665e270bdd14bc8f7bc0ba7a898583"
+            url: "https://github.com/user-attachments/files/19315257/WordPressKit.zip",
+            checksum: "1b4ba5cef01a64e98ffdc02a5c8ac92f550f234222bfb6abf11b4b4df94435bc"
         ),
     ]
 )

--- a/Sources/WordPressKit/Models/RemoteBlog.swift
+++ b/Sources/WordPressKit/Models/RemoteBlog.swift
@@ -58,6 +58,8 @@ import Foundation
     /// Blog's total disk quota space used.
     public var quotaSpaceUsed: NSNumber?
 
+    public var isDeleted: Bool
+
     /// Parses details from a JSON dictionary, as returned by the WordPress.com REST API.
     @objc(initWithJSONDictionary:)
     public init(jsonDictionary json: NSDictionary) {
@@ -79,6 +81,7 @@ import Foundation
         self.planActiveFeatures = (json.array(forKeyPath: "plan.features.active") as? [String]) ?? []
         self.quotaSpaceAllowed = json.number(forKeyPath: "quota.space_allowed")
         self.quotaSpaceUsed = json.number(forKeyPath: "quota.space_used")
+        self.isDeleted = json.number(forKey: "is_deleted")?.boolValue == true
     }
 
 }

--- a/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
@@ -354,6 +354,11 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
 {
     NSString *requestUrl = [self pathForEndpoint:@"me/sites"
                                      withVersion:WordPressComRESTAPIVersion_1_2];
+    if (parameters[@"site_visibility"] == nil) {
+        NSMutableDictionary *another = [parameters mutableCopy];
+        another[@"site_visibility"] = @"visible";
+        parameters = another;
+    }
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {

--- a/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
@@ -354,11 +354,6 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
 {
     NSString *requestUrl = [self pathForEndpoint:@"me/sites"
                                      withVersion:WordPressComRESTAPIVersion_1_2];
-    if (parameters[@"site_visibility"] == nil) {
-        NSMutableDictionary *another = [parameters mutableCopy];
-        another[@"site_visibility"] = @"visible";
-        parameters = another;
-    }
     [self.wordPressComRESTAPI get:requestUrl
                        parameters:parameters
                           success:^(id responseObject, NSHTTPURLResponse *httpResponse) {
@@ -390,10 +385,14 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
 - (NSArray *)remoteBlogsFromJSONArray:(NSArray *)jsonBlogs
 {
     NSArray *blogs = jsonBlogs;
-    return [blogs wpkit_map:^id(NSDictionary *jsonBlog) {
+    return [[blogs wpkit_map:^id(NSDictionary *jsonBlog) {
         return [[RemoteBlog alloc] initWithJSONDictionary:jsonBlog];
+    }] wpkit_filter:^BOOL(RemoteBlog *blog) {
+        // Exclude deleted sites from query result, since the app does not handle deleted sites properly.
+        // I tried to use query arguments `site_visibility=visible` and `site_activity=active`, but neither excludes
+        // deleted sites.
+        return !blog.isDeleted;
     }];
-    return blogs;
 }
 
 @end


### PR DESCRIPTION
### Description
[WordPressKit.zip](https://github.com/user-attachments/files/19315257/WordPressKit.zip)

Relates to https://github.com/wordpress-mobile/WordPress-iOS/issues/23344.

We'll exclude deleted sites for now, and can add them back once the app supports them properly.

ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
