### PR TITLE
Add search param in `getWPThemesPage` method and migrate endpoint to v2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19318154/WordPressKit.zip",
-            checksum: "769f4ec0c4e3712844af318962af7ffb417c8723c61688c913c381e6ac57e8b6"
+            url: "https://github.com/user-attachments/files/19034191/WordPressKit.zip",
+            checksum: "34f108cba86b5e4334d1c9af79946dbb8b665e270bdd14bc8f7bc0ba7a898583"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19325003/WordPressKit.zip",
-            checksum: "7bab7fb007c1c2bb8b83d0495c32849594451e2d961d289dcee39b84d9c90ebc"
+            url: "https://github.com/user-attachments/files/19329510/WordPressKit.zip",
+            checksum: "79d86c26fb143779b25634a042f740343a046ebf615d7b7117b4756c98a1f91f"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19034191/WordPressKit.zip",
-            checksum: "34f108cba86b5e4334d1c9af79946dbb8b665e270bdd14bc8f7bc0ba7a898583"
+            url: "https://github.com/user-attachments/files/19318154/WordPressKit.zip",
+            checksum: "769f4ec0c4e3712844af318962af7ffb417c8723c61688c913c381e6ac57e8b6"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19338252/WordPressKit.zip",
-            checksum: "e91be125b5d4e3ba98a0c06b32c71f428cbf3ab1aaa8da08598177ebd24d9a1a"
+            url: "https://github.com/user-attachments/files/19338447/WordPressKit.zip",
+            checksum: "309f0960e8881e174bec2f9c0f2d833c6c5926e952394bfa87eb532d92709eac"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19337867/WordPressKit.zip",
-            checksum: "03c45998c7dbb58c2a5a6799c066037b33762b93545d9de764397b7e8ad4173d"
+            url: "https://github.com/user-attachments/files/19338050/WordPressKit.zip",
+            checksum: "b54214abf4a67e3349ce191463cffe908ec3b5dc2c0989fe5a616c660e1edaa8"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19329609/WordPressKit.zip",
-            checksum: "0b29beaa2001b00f38b8d3ecae411ea100bd9867e17c86d0128fa995a7597b55"
+            url: "https://github.com/user-attachments/files/19337867/WordPressKit.zip",
+            checksum: "03c45998c7dbb58c2a5a6799c066037b33762b93545d9de764397b7e8ad4173d"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19034191/WordPressKit.zip",
-            checksum: "34f108cba86b5e4334d1c9af79946dbb8b665e270bdd14bc8f7bc0ba7a898583"
+            url: "https://github.com/user-attachments/files/19325003/WordPressKit.zip",
+            checksum: "7bab7fb007c1c2bb8b83d0495c32849594451e2d961d289dcee39b84d9c90ebc"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19338050/WordPressKit.zip",
-            checksum: "b54214abf4a67e3349ce191463cffe908ec3b5dc2c0989fe5a616c660e1edaa8"
+            url: "https://github.com/user-attachments/files/19338252/WordPressKit.zip",
+            checksum: "e91be125b5d4e3ba98a0c06b32c71f428cbf3ab1aaa8da08598177ebd24d9a1a"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19338447/WordPressKit.zip",
-            checksum: "309f0960e8881e174bec2f9c0f2d833c6c5926e952394bfa87eb532d92709eac"
+            url: "https://github.com/user-attachments/files/19339848/WordPressKit.zip",
+            checksum: "5bf1ff361992dccf44dfe41b0a442ee4c3c13dc0a1ce9b647a8ed1b976b5c3fc"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19329510/WordPressKit.zip",
-            checksum: "79d86c26fb143779b25634a042f740343a046ebf615d7b7117b4756c98a1f91f"
+            url: "https://github.com/user-attachments/files/19329609/WordPressKit.zip",
+            checksum: "0b29beaa2001b00f38b8d3ecae411ea100bd9867e17c86d0128fa995a7597b55"
         ),
     ]
 )

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.h
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.h
@@ -60,6 +60,7 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  *
  *  @param      freeOnly    Only fetch free themes, if false all WP themes will be returned
  *  @param      page        Results page to return.
+ *  @param      search      Search term to filter themes. Can be nil or empty string.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
  *
@@ -67,6 +68,7 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  */
 - (NSProgress *)getWPThemesPage:(NSInteger)page
                        freeOnly:(BOOL)freeOnly
+                        search:(NSString *)search
                         success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                         failure:(ThemeServiceRemoteFailureBlock)failure;
 

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.h
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.h
@@ -60,7 +60,6 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  *
  *  @param      freeOnly    Only fetch free themes, if false all WP themes will be returned
  *  @param      page        Results page to return.
- *  @param      search      Search term to filter themes. Can be nil or empty string.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
  *
@@ -68,7 +67,6 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  */
 - (NSProgress *)getWPThemesPage:(NSInteger)page
                        freeOnly:(BOOL)freeOnly
-                        search:(NSString *)search
                         success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                         failure:(ThemeServiceRemoteFailureBlock)failure;
 

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.h
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.h
@@ -81,7 +81,6 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  *              this method and not getThemes.
  *
  *  @param      blogId      The ID of the blog to get the themes for.  Cannot be nil.
- *  @param      search      Search term for filtering themes. Cannot be nil.
  *  @param      page        Results page to return.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
@@ -89,7 +88,6 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  *  @returns    A progress object that can be used to track progress and/or cancel the task
  */
 - (NSProgress *)getThemesForBlogId:(NSNumber *)blogId
-                            search:(NSString *)search
                               page:(NSInteger)page
                            success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                            failure:(ThemeServiceRemoteFailureBlock)failure;

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.h
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.h
@@ -58,6 +58,7 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  *  @details    Includes premium themes even if not purchased.  Don't call this method if the list
  *              you want to retrieve is for a specific blog.  Use getThemesForBlogId instead.
  *
+ *  @param      search      Search term for filtering themes. Cannot be nil.
  *  @param      freeOnly    Only fetch free themes, if false all WP themes will be returned
  *  @param      page        Results page to return.
  *  @param      success     The success handler.  Can be nil.
@@ -66,6 +67,7 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  *  @returns    A progress object that can be used to track progress and/or cancel the task
  */
 - (NSProgress *)getWPThemesPage:(NSInteger)page
+                         search:(NSString *)search
                        freeOnly:(BOOL)freeOnly
                         success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                         failure:(ThemeServiceRemoteFailureBlock)failure;
@@ -79,6 +81,7 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  *              this method and not getThemes.
  *
  *  @param      blogId      The ID of the blog to get the themes for.  Cannot be nil.
+ *  @param      search      Search term for filtering themes. Cannot be nil.
  *  @param      page        Results page to return.
  *  @param      success     The success handler.  Can be nil.
  *  @param      failure     The failure handler.  Can be nil.
@@ -86,6 +89,7 @@ typedef void(^ThemeServiceRemoteFailureBlock)(NSError *error);
  *  @returns    A progress object that can be used to track progress and/or cancel the task
  */
 - (NSProgress *)getThemesForBlogId:(NSNumber *)blogId
+                            search:(NSString *)search
                               page:(NSInteger)page
                            success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                            failure:(ThemeServiceRemoteFailureBlock)failure;

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.m
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.m
@@ -13,6 +13,8 @@ static NSString* const ThemeRequestTierFreeValue = @"free";
 static NSString* const ThemeRequestNumberKey = @"number";
 static NSInteger const ThemeRequestNumberValue = 50;
 static NSString* const ThemeRequestPageKey = @"page";
+static NSString* const ThemeRequestSearchKey = @"search";
+static NSString* const ThemeRequestFilterKey = @"filter";
 
 @implementation ThemeServiceRemote
 
@@ -98,11 +100,13 @@ static NSString* const ThemeRequestPageKey = @"page";
 }
 
 - (NSProgress *)getWPThemesPage:(NSInteger)page
+                         search:(NSString *)search
                        freeOnly:(BOOL)freeOnly
                         success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                         failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert(page > 0);
+    NSParameterAssert([search isKindOfClass:[NSString class]]);
 
     NSString *requestUrl = [self pathForEndpoint:@"themes"
                                      withVersion:WordPressComRESTAPIVersion_1_2];
@@ -110,7 +114,8 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSDictionary *parameters = @{ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
                                  ThemeRequestNumberKey: @(ThemeRequestNumberValue),
                                  ThemeRequestPageKey: @(page),
-                                 };
+                                 ThemeRequestSearchKey: search
+                                };
 
     return [self getThemesWithRequestUrl:requestUrl
                                     page:page
@@ -143,17 +148,20 @@ static NSString* const ThemeRequestPageKey = @"page";
 }
 
 - (NSProgress *)getThemesForBlogId:(NSNumber *)blogId
-                               page:(NSInteger)page
-                            success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
-                            failure:(ThemeServiceRemoteFailureBlock)failure
+                            search:(NSString *)search
+                              page:(NSInteger)page
+                           success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
+                           failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
+    NSParameterAssert([search isKindOfClass:[NSString class]]);
     NSParameterAssert(page > 0);
 
     NSProgress *progress = [self getThemesForBlogId:blogId
                                                page:page
                                          apiVersion:WordPressComRESTAPIVersion_1_2
-                                             params:@{ThemeRequestTierKey: ThemeRequestTierAllValue}
+                                             params:@{ThemeRequestTierKey: ThemeRequestTierAllValue,
+                                                      ThemeRequestFilterKey: [NSString stringWithFormat:@"subject:%@", search]}
                                             success:success
                                             failure:failure];
 

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.m
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.m
@@ -14,7 +14,6 @@ static NSString* const ThemeRequestNumberKey = @"number";
 static NSInteger const ThemeRequestNumberValue = 50;
 static NSString* const ThemeRequestPageKey = @"page";
 static NSString* const ThemeRequestSearchKey = @"search";
-static NSString* const ThemeRequestFilterKey = @"filter";
 
 @implementation ThemeServiceRemote
 
@@ -148,20 +147,17 @@ static NSString* const ThemeRequestFilterKey = @"filter";
 }
 
 - (NSProgress *)getThemesForBlogId:(NSNumber *)blogId
-                            search:(NSString *)search
                               page:(NSInteger)page
                            success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                            failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert([blogId isKindOfClass:[NSNumber class]]);
-    NSParameterAssert([search isKindOfClass:[NSString class]]);
     NSParameterAssert(page > 0);
 
     NSProgress *progress = [self getThemesForBlogId:blogId
                                                page:page
                                          apiVersion:WordPressComRESTAPIVersion_1_2
-                                             params:@{ThemeRequestTierKey: ThemeRequestTierAllValue,
-                                                      ThemeRequestFilterKey: [NSString stringWithFormat:@"subject:%@", search]}
+                                             params:@{ThemeRequestTierKey: ThemeRequestTierAllValue}
                                             success:success
                                             failure:failure];
 

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.m
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.m
@@ -108,7 +108,7 @@ static NSString* const ThemeRequestSearchKey = @"search";
     NSParameterAssert([search isKindOfClass:[NSString class]]);
 
     NSString *requestUrl = [self pathForEndpoint:@"themes"
-                                     withVersion:WordPressComRESTAPIVersion_1_2];
+                                     withVersion:WordPressComRESTAPIVersion_2_0];
 
     NSDictionary *parameters = @{ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
                                  ThemeRequestNumberKey: @(ThemeRequestNumberValue),

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.m
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.m
@@ -99,6 +99,7 @@ static NSString* const ThemeRequestPageKey = @"page";
 
 - (NSProgress *)getWPThemesPage:(NSInteger)page
                        freeOnly:(BOOL)freeOnly
+                        search:(NSString *)search
                         success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                         failure:(ThemeServiceRemoteFailureBlock)failure
 {
@@ -107,10 +108,15 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSString *requestUrl = [self pathForEndpoint:@"themes"
                                      withVersion:WordPressComRESTAPIVersion_1_2];
 
-    NSDictionary *parameters = @{ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
-                                 ThemeRequestNumberKey: @(ThemeRequestNumberValue),
-                                 ThemeRequestPageKey: @(page),
-                                 };
+    NSMutableDictionary *parameters = [@{
+        ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
+        ThemeRequestNumberKey: @(ThemeRequestNumberValue),
+        ThemeRequestPageKey: @(page)
+    } mutableCopy];
+    
+    if (search && search.length > 0) {
+        parameters[@"search"] = search;
+    }
 
     return [self getThemesWithRequestUrl:requestUrl
                                     page:page

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.m
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.m
@@ -105,17 +105,20 @@ static NSString* const ThemeRequestSearchKey = @"search";
                         failure:(ThemeServiceRemoteFailureBlock)failure
 {
     NSParameterAssert(page > 0);
-    NSParameterAssert([search isKindOfClass:[NSString class]]);
-
+    
     NSString *requestUrl = [self pathForEndpoint:@"themes"
                                      withVersion:WordPressComRESTAPIVersion_2_0];
-
-    NSDictionary *parameters = @{ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
-                                 ThemeRequestNumberKey: @(ThemeRequestNumberValue),
-                                 ThemeRequestPageKey: @(page),
-                                 ThemeRequestSearchKey: search
-                                };
-
+    
+    NSMutableDictionary *parameters = [@{
+        ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
+        ThemeRequestNumberKey: @(ThemeRequestNumberValue),
+        ThemeRequestPageKey: @(page)
+    } mutableCopy];
+    
+    if (search) {
+        parameters[ThemeRequestSearchKey] = search;
+    }
+    
     return [self getThemesWithRequestUrl:requestUrl
                                     page:page
                               parameters:parameters

--- a/Sources/WordPressKit/Services/ThemeServiceRemote.m
+++ b/Sources/WordPressKit/Services/ThemeServiceRemote.m
@@ -99,7 +99,6 @@ static NSString* const ThemeRequestPageKey = @"page";
 
 - (NSProgress *)getWPThemesPage:(NSInteger)page
                        freeOnly:(BOOL)freeOnly
-                        search:(NSString *)search
                         success:(ThemeServiceRemoteThemesRequestSuccessBlock)success
                         failure:(ThemeServiceRemoteFailureBlock)failure
 {
@@ -108,15 +107,10 @@ static NSString* const ThemeRequestPageKey = @"page";
     NSString *requestUrl = [self pathForEndpoint:@"themes"
                                      withVersion:WordPressComRESTAPIVersion_1_2];
 
-    NSMutableDictionary *parameters = [@{
-        ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
-        ThemeRequestNumberKey: @(ThemeRequestNumberValue),
-        ThemeRequestPageKey: @(page)
-    } mutableCopy];
-    
-    if (search && search.length > 0) {
-        parameters[@"search"] = search;
-    }
+    NSDictionary *parameters = @{ThemeRequestTierKey: freeOnly ? ThemeRequestTierFreeValue : ThemeRequestTierAllValue,
+                                 ThemeRequestNumberKey: @(ThemeRequestNumberValue),
+                                 ThemeRequestPageKey: @(page),
+                                 };
 
     return [self getThemesWithRequestUrl:requestUrl
                                     page:page

--- a/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
+++ b/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
@@ -224,10 +224,10 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     }];
 
     XCTAssertNoThrow([service getWPThemesPage:1
-                                       search:@""
-                                     freeOnly:NO
-                                      success:successBlock
-                                      failure:nil]);
+                                      search:nil
+                                    freeOnly:NO
+                                     success:successBlock
+                                     failure:nil]);
 }
 
 - (void)testThatGetThemesForBlogIdWorks

--- a/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
+++ b/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
@@ -269,7 +269,6 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     }];
 
     XCTAssertNoThrow([service getThemesForBlogId:blogId
-                                          search:@""
                                            page:1
                                         success:successBlock
                                         failure:nil]);

--- a/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
+++ b/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
@@ -196,7 +196,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     XCTAssertNoThrow(service = [[ThemeServiceRemote alloc] initWithWordPressComRestApi:api]);
 
     NSString *url = [service pathForEndpoint:@"themes"
-                                 withVersion:WordPressComRESTAPIVersion_1_2];
+                                 withVersion:WordPressComRESTAPIVersion_2_0];
 
     ThemeServiceRemoteThemesRequestSuccessBlock successBlock = ^void (NSArray<RemoteTheme *> *themes, BOOL hasMore, NSInteger totalThemeCount) {
         NSCAssert([themes count] == expectedThemes, @"Expected %ld themes to be returned", expectedThemes);

--- a/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
+++ b/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
@@ -224,6 +224,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     }];
 
     XCTAssertNoThrow([service getWPThemesPage:1
+                                       search:@""
                                      freeOnly:NO
                                       success:successBlock
                                       failure:nil]);
@@ -268,9 +269,10 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
     }];
 
     XCTAssertNoThrow([service getThemesForBlogId:blogId
-                                            page:1
-                                         success:successBlock
-                                         failure:nil]);
+                                          search:@""
+                                           page:1
+                                        success:successBlock
+                                        failure:nil]);
 }
 
 - (void)testThatGetThemesForBlogIdThrowsExceptionWithoutBlogId

--- a/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
+++ b/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
@@ -225,6 +225,7 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
 
     XCTAssertNoThrow([service getWPThemesPage:1
                                      freeOnly:NO
+                                      search:nil
                                       success:successBlock
                                       failure:nil]);
 }

--- a/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
+++ b/Tests/WordPressKitTests/Tests/ThemeServiceRemoteTests.m
@@ -225,7 +225,6 @@ static NSString* const ThemeServiceRemoteTestGetSingleThemeJson = @"get-single-t
 
     XCTAssertNoThrow([service getWPThemesPage:1
                                      freeOnly:NO
-                                      search:nil
                                       success:successBlock
                                       failure:nil]);
 }


### PR DESCRIPTION
### Description

This PR can be tested through https://github.com/wordpress-mobile/WordPress-iOS/pull/24262

[WordPressKit.zip](https://github.com/user-attachments/files/19339848/WordPressKit.zip)

This is part of the work needed to fix this issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/23153

In WPiOS, the theme search was not functioning correctly because the search was conducted locally. As a result, since it also supports pagination, the search only considered the elements that had been fetched. If some elements were beyond the already downloaded data, they were not displayed.

In this PR, I migrated the endpoint `rest/v1.2/themes` to v2.0, as v1.2 has been deprecated. I also introduced the `search` parameter, which allows users to search for themes by keyword. Please refer to the linear issue for more details `CMM-55/cannot-find-seedlet-theme`.


---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
