### PR TITLE
Do not show disconnected Jetpack sites

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19339848/WordPressKit.zip",
-            checksum: "5bf1ff361992dccf44dfe41b0a442ee4c3c13dc0a1ce9b647a8ed1b976b5c3fc"
+            url: "https://github.com/user-attachments/files/19533607/WordPressKit.zip",
+            checksum: "d0c8d8994a64ff7ac0cf0fb1cc23c4fa419df011406c327f716b40af7dd8faa0"
         ),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/19533607/WordPressKit.zip",
-            checksum: "d0c8d8994a64ff7ac0cf0fb1cc23c4fa419df011406c327f716b40af7dd8faa0"
+            url: "https://github.com/user-attachments/files/19658656/WordPressKit.zip",
+            checksum: "9172f9b9906e64efe1f3d79f074ad317f1d40c6ce1ec394259b0f99fea6fe8ee"
         ),
     ]
 )

--- a/Sources/WordPressKit/Models/RemoteBlog.swift
+++ b/Sources/WordPressKit/Models/RemoteBlog.swift
@@ -37,10 +37,10 @@ import Foundation
     /// Features available for the current blog's plan.
     public var planActiveFeatures = [String]()
 
-    /// Indicates whether the jetpack connection is active.
+    /// Indicates whether the site is a Jetpack site or not.
     public var jetpack: Bool = false
 
-    /// Indicates whether it's a Jetpack connected site.
+    /// Indicates whether the site is connected to WP.com via `jetpack-connection`.
     public var jetpackConnection: Bool = false
 
     /// Boolean indicating whether the current user has Admin privileges, or not.

--- a/Sources/WordPressKit/Models/RemoteBlog.swift
+++ b/Sources/WordPressKit/Models/RemoteBlog.swift
@@ -37,8 +37,11 @@ import Foundation
     /// Features available for the current blog's plan.
     public var planActiveFeatures = [String]()
 
-    /// Indicates whether it's a jetpack site, or not.
+    /// Indicates whether the jetpack connection is active.
     public var jetpack: Bool = false
+
+    /// Indicates whether it's a Jetpack connected site.
+    public var jetpackConnection: Bool = false
 
     /// Boolean indicating whether the current user has Admin privileges, or not.
     public var isAdmin: Bool = false
@@ -70,6 +73,7 @@ import Foundation
         self.url = json.string(forKey: "URL") ?? ""
         self.xmlrpc = json.string(forKeyPath: "meta.links.xmlrpc")
         self.jetpack = json.number(forKey: "jetpack")?.boolValue ?? false
+        self.jetpackConnection = json.number(forKey: "jetpack_connection")?.boolValue ?? false
         self.icon = json.string(forKeyPath: "icon.img")
         self.capabilities = json.object(forKey: "capabilities") as? [String: Bool] ?? [:]
         self.isAdmin = json.number(forKeyPath: "capabilities.manage_options")?.boolValue ?? false

--- a/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
+++ b/Sources/WordPressKit/Services/AccountServiceRemoteREST.m
@@ -391,7 +391,16 @@ MagicLinkFlow const MagicLinkFlowSignup = @"signup";
         // Exclude deleted sites from query result, since the app does not handle deleted sites properly.
         // I tried to use query arguments `site_visibility=visible` and `site_activity=active`, but neither excludes
         // deleted sites.
-        return !blog.isDeleted;
+        if (blog.isDeleted) {
+            return false;
+        }
+
+        // Exclude sites that are connected via Jetpack, but without an active Jetpack connection.
+        if (blog.jetpackConnection && !blog.jetpack) {
+            return false;
+        }
+
+        return true;
     }];
 }
 


### PR DESCRIPTION
### Description

The app displays sites inaccessible Jetpack self-hosted sites(for example, deleted Jurassic Ninja sites). Similar to deleted WP.com sites, when switching to those sites, the app displays almost empty content. This PR removes those sites from API responses.

[WordPressKit.zip](https://github.com/user-attachments/files/19658656/WordPressKit.zip)



ℹ Please replace the above with a link to the issue this pull request addresses, as well as a summary of the implementation details.

### Testing Details

ℹ Please replace this with a clear and concise description of the steps required to validate this pull request.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
