### PR TITLE
AINFRA-283 - Set `queue: mac` explicitly in pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 ---
 
+agents:
+  queue: mac
+
 env:
   IMAGE_ID: xcode-15.3-v3
 
@@ -54,5 +57,3 @@ steps:
       - "validate"
       - "lint"
     if: build.tag != null
-    agents:
-      queue: "mac"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,13 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+env:
+  IMAGE_ID: xcode-15.3-v3
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
     - automattic/a8c-ci-toolkit#3.1.0
-  # Common environment values to use with the `env` key.
-  env: &common_env
-    # -v3 contains a workaround for a Simulator boot issue
-    # See paaHJt-6gL-p2#comment-8712
-    IMAGE_ID: xcode-15.3-v3
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -21,7 +22,6 @@ steps:
       - fastlane/test_output/report.html
       - fastlane/test_output/report.junit
       - .build/derived-data/Logs/**/*.xcactivitylog
-    env: *common_env
     plugins: *common_plugins
 
   #################
@@ -40,7 +40,6 @@ steps:
     key: "lint"
     command: |
       lint_pod
-    env: *common_env
     plugins: *common_plugins
 
   #################
@@ -49,7 +48,6 @@ steps:
   - label: "⬆️ Publish Podspec"
     key: "publish"
     command: .buildkite/publish-pod.sh
-    env: *common_env
     plugins: *common_plugins
     depends_on:
       - "test"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -7,7 +7,7 @@ env:
 # Nodes with values to reuse in the pipeline.
 common_params:
   plugins: &common_plugins
-    - automattic/a8c-ci-toolkit#3.1.0
+    - automattic/a8c-ci-toolkit#3.5.1
 
 # This is the default pipeline – it will build and test the app
 steps:


### PR DESCRIPTION
This will allow adopting an improved default pipeline upload step on the CI infrastructure side of the setup. It also makes it clear what queue is in use just by looking at the pipeline file.

Notice it does not introduce the standard `shared-pipeline-vars` file because to use that we first need the default pipeline upload step in the IaC configuration.

See https://linear.app/a8c/issue/AINFRA-283

<!-- blue -->
> [!NOTE]  
> Tests are failing but that's unrelated with the changes in this PR, they fail on #816, too. Given how WordPressKit has changed to ship as an XCFramework _and_ that currently WordPress-Jetpack-Reader is the only consumer, I decided not to investigate. I'm happy to if required, but my current understanding is that this repo is on life support and will see minimal changes, meaning investing in does not give the best RoI.

<!-- blue -->
> [!NOTE]  
> I targeted #816 instead of `trunk` because WordPress-Jetpack-Reader is the only consumer of this library. As such, I propose merging #816 and making it the main branch, adding a note on the state of the project. See also pbArwn-7sp-p2