### PR TITLE
Add raw GET for WP.org client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "WordPressKit",
-            url: "https://github.com/user-attachments/files/21582269/WordPressKit.zip",
-            checksum: "cbfe79d7a4244302d308027ff329f1ccdfd1c604d990871359764eca567ea86f"
+            url: "https://github.com/user-attachments/files/22280239/WordPressKit.zip",
+            checksum: "a2d46f654d72b367359606fefde01d43e44bee2034bfd079fa6334c378cfdb16"
         ),
     ]
 )

--- a/Sources/CoreAPI/WordPressOrgRestApi.swift
+++ b/Sources/CoreAPI/WordPressOrgRestApi.swift
@@ -103,6 +103,13 @@ public final class WordPressOrgRestApi: NSObject {
         await perform(.get, path: path, parameters: parameters, options: options)
     }
 
+    public func get(
+        path: String,
+        parameters: [String: Any]? = nil
+    ) async -> WordPressAPIResult<Data, WordPressOrgRestApiError> {
+        await perform(.get, path: path, parameters: parameters)
+    }
+
     public func post<Success: Decodable>(
         path: String,
         parameters: [String: Any]? = nil,


### PR DESCRIPTION
### Description

Adds the ability to get the raw data from a WP.org GET request.

We need this to be able to pass the raw JSON to GutenbergKit without parsing it first.

### Testing Details
Will be part of the WP-ios PR.

---

- [ ] Please check here if your pull request includes additional test coverage.
- [ ] I have considered if this change warrants release notes and have added them to the appropriate section in the `CHANGELOG.md` if necessary.
- [ ] 
[WordPressKit.zip](https://github.com/user-attachments/files/22280239/WordPressKit.zip)

